### PR TITLE
Iss122 - fix rotating through mastered spells

### DIFF
--- a/Ollivanders/src/net/pottercraft/Ollivanders2/O2Player.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/O2Player.java
@@ -726,9 +726,13 @@ public class O2Player
             int nextSpellIndex;
 
             if (reverse)
+            {
                nextSpellIndex = curSpellIndex + 1;
+            }
             else
+            {
                nextSpellIndex = curSpellIndex - 1;
+            }
 
             // handle roll overs
             if (nextSpellIndex >= masteredSpells.size())

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/O2Player.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/O2Player.java
@@ -703,6 +703,16 @@ public class O2Player
     */
    public void shiftMasterSpell ()
    {
+      shiftMasterSpell(false);
+   }
+
+   /**
+    * Shift the wand's master spell to the next spell.
+    *
+    * @param reverse if set to true, iterates backwards through spell list
+    */
+   public void shiftMasterSpell (boolean reverse)
+   {
       // shift to the next spell if there is more than one mastered spell
       if (masteredSpells.size() >= 1)
       {
@@ -712,17 +722,25 @@ public class O2Player
          }
          else
          {
-            int i = masteredSpells.indexOf(masterSpell);
+            int curSpellIndex = masteredSpells.indexOf(masterSpell);
+            int nextSpellIndex;
 
-            if (i == (masteredSpells.size() - 1))
-            {
-               // spell is the last in the array, roll over
-               masterSpell = masteredSpells.get(0);
-            }
+            if (reverse)
+               nextSpellIndex = curSpellIndex + 1;
             else
+               nextSpellIndex = curSpellIndex - 1;
+
+            // handle roll overs
+            if (nextSpellIndex >= masteredSpells.size())
             {
-               masterSpell = masteredSpells.get(i + 1);
+               nextSpellIndex = 0;
             }
+            else if (nextSpellIndex < 0)
+            {
+               nextSpellIndex = masteredSpells.size() - 1;
+            }
+
+            masterSpell = masteredSpells.get(nextSpellIndex);
          }
       }
       else

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Ollivanders2.java
@@ -35,11 +35,13 @@ import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.NPC;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.FurnaceRecipe;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapedRecipe;
@@ -1421,7 +1423,7 @@ public class Ollivanders2 extends JavaPlugin
    }
 
    /**
-    * Does the player hold a wand item?
+    * Does the player hold a wand item in their primary hand?
     *
     * @param player - Player to check.
     * @return True if the player holds a wand. False if not or if player is null.
@@ -1437,6 +1439,37 @@ public class Ollivanders2 extends JavaPlugin
       {
          return false;
       }
+   }
+
+   /**
+    * Does the player hold a wand item in their hand?
+    *
+    * @since 2.2.7
+    * @param player - Player to check.
+    * @param hand - the equipment slot to check for this player
+    * @return True if the player holds a wand. False if not or if player is null.
+    */
+   public boolean holdsWand (Player player, EquipmentSlot hand)
+   {
+      if (player == null || hand == null)
+         return false;
+
+      ItemStack held;
+      if (hand == EquipmentSlot.HAND)
+      {
+         held = player.getInventory().getItemInMainHand();
+      }
+      else if (hand == EquipmentSlot.OFF_HAND)
+      {
+         held = player.getInventory().getItemInOffHand();
+      }
+      else
+         return false;
+
+      if (held == null)
+         return false;
+
+      return isWand(held);
    }
 
    /**
@@ -1482,7 +1515,7 @@ public class Ollivanders2 extends JavaPlugin
    }
 
    /**
-    * Is this itemstack the player's destined wand?
+    * Is this ItemStack the player's destined wand?
     *
     * @param player - Player to check the stack against.
     * @param stack  - Itemstack to be checked
@@ -1535,7 +1568,7 @@ public class Ollivanders2 extends JavaPlugin
    }
 
    /**
-    * Checks what kind of wand a player holds. Returns a value based on the
+    * Checks what kind of wand a player holds in their primary hand. Returns a value based on the
     * wand and it's relation to the player.
     *
     * @assumes player not null, player holding a wand
@@ -1548,6 +1581,48 @@ public class Ollivanders2 extends JavaPlugin
    {
       ItemStack item = player.getInventory().getItemInMainHand();
 
+      return doWandCheck(player, item);
+   }
+
+   /**
+    * Checks what kind of wand a player holds. Returns a value based on the wand and it's relation to the player.
+    *
+    * @since 2.2.7
+    * @assumes player not null, player is holding a wand in the equipment slot passed in
+    * @param player - Player being checked. The player must be holding a wand.
+    * @param hand - the hand that is holding the wand to check.
+    * @return 2 - The wand is not player's type AND/OR is not allied to player.<p>
+    * 1 - The wand is player's type and is allied to player OR the wand is the elder wand and is not allied to player.<p>
+    * 0.5 - The wand is the elder wand and it is allied to player.
+    */
+   public double wandCheck (Player player, EquipmentSlot hand)
+   {
+      ItemStack item;
+
+      if (hand == EquipmentSlot.HAND)
+      {
+         item = player.getInventory().getItemInMainHand();
+      }
+      else
+      {
+         item = player.getInventory().getItemInOffHand();
+      }
+
+      return doWandCheck(player, item);
+   }
+
+   /**
+    * Checks what kind of wand a player holds. Returns a value based on the wand and it's relation to the player.
+    *
+    * @since 2.2.7
+    * @param player - the player to check
+    * @param item - the
+    * @return 2 - The wand is not player's type AND/OR is not allied to player.<p>
+    * 1 - The wand is player's type and is allied to player OR the wand is the elder wand and is not allied to player.<p>
+    * 0.5 - The wand is the elder wand and it is allied to player.
+    */
+   double doWandCheck (Player player, ItemStack item)
+   {
       List<String> lore = item.getItemMeta().getLore();
       if (lore.get(0).equals("Blaze and Ender Pearl")) // elder wand
       {

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/OllivandersListener.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/OllivandersListener.java
@@ -733,7 +733,6 @@ public class OllivandersListener implements Listener
          /**
           * A right click of the primary hand is used:
           *  - to determine if the wand is the player's destined wand
-          *  - to set the mastered spell in the wand for non-verbal casting if they are sneaking while clicking
           *  - to brew a potion if they are holding a glass bottle in their off hand and facing a cauldron
           */
          else if (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK)

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/OllivandersListener.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/OllivandersListener.java
@@ -32,7 +32,6 @@ import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.util.Vector;
-import org.bukkit.material.MaterialData;
 
 import java.lang.reflect.Constructor;
 import java.util.*;
@@ -649,6 +648,54 @@ public class OllivandersListener implements Listener
    }
 
    /**
+    * Action by player to cast a spell
+    *
+    * @since 2.2.7
+    * @param player
+    */
+   void castSpell (Player player)
+   {
+      O2Player o2p = p.getO2Player(player);
+      Spells spell = o2p.getWandSpell();
+
+      if (spell != null)
+      {
+         double wandCheck;
+         boolean playerHoldsWand = p.holdsWand(player, EquipmentSlot.HAND);
+         if (playerHoldsWand)
+         {
+            if (Ollivanders2.debug)
+               p.getLogger().info("OllivandersListener:castSpell: player holds a wand in their primary hand");
+
+            wandCheck = p.wandCheck(player, EquipmentSlot.HAND);
+            allyWand(player);
+         }
+         else
+         {
+            if (Ollivanders2.debug)
+            {
+               p.getLogger().info("OllivandersListener:castSpell: player does not hold a wand in their primary hand");
+            }
+            return;
+         }
+
+         createSpellProjectile(player, spell, wandCheck);
+         o2p.setSpellRecentCastTime(spell);
+         int spellCastCount = p.getSpellNum(player, spell);
+         if (spellCastCount < 100 || spell == Spells.AVADA_KEDAVRA || !playerHoldsWand)
+         {
+            if (Ollivanders2.debug)
+            {
+               p.getLogger().info("OllivandersListener:castSpell: allow cast spell");
+            }
+
+            o2p.setWandSpell(null);
+            p.setO2Player(player, o2p);
+         }
+      }
+   }
+
+   /**
     * Handle events when player interacts with an item in their hand.
     *
     * @param event
@@ -662,128 +709,102 @@ public class OllivandersListener implements Listener
       if (Ollivanders2.debug)
          p.getLogger().info("onPlayerInteract: enter");
 
-      if (action == null || player == null || event.getHand() != EquipmentSlot.HAND)
+      if (action == null || player == null)
       {
          return;
       }
 
       /**
-       * A left click is used to cast a spell
+       * A right or left click of the primary hand when holding a wand is used to make a magical action.
        */
-      if (action == Action.LEFT_CLICK_AIR || action == Action.LEFT_CLICK_BLOCK)
+      if ((event.getHand() == EquipmentSlot.HAND) && (p.holdsWand(player, EquipmentSlot.HAND)))
       {
-         if (Ollivanders2.debug)
-            p.getLogger().info("OllivandersListener:onPlayerInteract: left click action");
-
-         O2Player o2p = p.getO2Player(player);
-         Spells spell = o2p.getWandSpell();
-         if (spell != null)
+         /**
+          * A left click of the primary hand is used to cast a spell
+          */
+         if (action == Action.LEFT_CLICK_AIR || action == Action.LEFT_CLICK_BLOCK)
          {
-            double wandC;
-            boolean playerHoldsWand = p.holdsWand(player);
-            if (playerHoldsWand)
-            {
-               if (Ollivanders2.debug)
-                  p.getLogger().info("OllivandersListener:onPlayerInteract: player holds a wand");
+            if (Ollivanders2.debug)
+               p.getLogger().info("OllivandersListener:onPlayerInteract: left click action");
 
-               wandC = p.wandCheck(player);
-               allyWand(player);
-            }
-            else
-            {
-               if (Ollivanders2.debug)
-               {
-                  p.getLogger().info("OllivandersListener:onPlayerInteract: player does not hold a wand");
-               }
-
-               wandC = 10;
-            }
-
-            createSpellProjectile(player, spell, wandC);
-            o2p.setSpellRecentCastTime(spell);
-            int spellc = p.getSpellNum(player, spell);
-            if (spellc < 100 || spell == Spells.AVADA_KEDAVRA || !playerHoldsWand)
-            {
-               if (Ollivanders2.debug)
-               {
-                  p.getLogger().info("OllivandersListener:onPlayerInteract: allow cast spell");
-               }
-
-               o2p.setWandSpell(null);
-               p.setO2Player(player, o2p);
-            }
-
-            /*
-            if (spellc >= 100 && wandC != 1)
-            {
-               if (Ollivanders2.debug)
-               {
-                  p.getLogger().info("OllivandersListener:onPlayerInteract: allow cast spell");
-               }
-
-               o2p.setMasterSpell(null);
-               p.setO2Player(player, o2p);
-            }
-            */
-         }
-      }
-
-      /**
-       * A right click is used:
-       *  - to determine if the wand is the player's destined wand
-       *  - to set the mastered spell in the wand for non-verbal casting if they are sneaking while clicking
-       *  - to brew a potion if they are holding a glass bottle in their off hand and facing a cauldron
-       */
-      else if (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK)
-      {
-         if (!p.holdsWand(player))
+            castSpell(player);
             return;
-
-         if (Ollivanders2.debug)
-            p.getLogger().info("OllivandersListener:onPlayerInteract: right click action");
-
-         O2Player o2p = p.getO2Player(player);
-         Location location = player.getLocation();
-         location.setY(location.getY() + 1.6);
-
-         if (p.wandCheck(player) == 1)
+         }
+         /**
+          * A right click of the primary hand is used:
+          *  - to determine if the wand is the player's destined wand
+          *  - to set the mastered spell in the wand for non-verbal casting if they are sneaking while clicking
+          *  - to brew a potion if they are holding a glass bottle in their off hand and facing a cauldron
+          */
+         else if (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK)
          {
-            if (player.isSneaking() && Ollivanders2.nonVerbalCasting)
-            {
-               if (Ollivanders2.debug)
-                  p.getLogger().info("OllivandersListener:onPlayerInteract: shift mastered spell");
+            if (Ollivanders2.debug)
+               p.getLogger().info("OllivandersListener:onPlayerInteract: right click action");
 
-               o2p.shiftMasterSpell();
-               Spells spell = o2p.getMasterSpell();
-               if (spell != null)
-               {
-                  String spellName = Spells.firstLetterCapitalize(Spells.recode(spell));
-                  player.sendMessage("Wand master spell set to " + spellName);
-               }
-               else
-               {
-                  if (Ollivanders2.debug)
-                  {
-                     player.sendMessage("You have not mastered any spells.");
-                  }
-               }
-            }
-            else if ((playerFacingCauldron(player) != null) && (player.getInventory().getItemInOffHand().getType() == Material.GLASS_BOTTLE))
+            Block cauldron = (playerFacingCauldron(player));
+            if ((cauldron != null) && (player.getInventory().getItemInOffHand().getType() == Material.GLASS_BOTTLE))
             {
                if (Ollivanders2.debug)
                   p.getLogger().info("OllivandersListener:onPlayerInteract: brewing potion");
 
-               Block cauldron = (playerFacingCauldron(player));
                brewPotion(player, cauldron);
+               return;
             }
-            else
-            {
-               if (Ollivanders2.debug)
-                  p.getLogger().info("OllivandersListener:onPlayerInteract: waving destined wand");
-               // play a sound and visual effect when they right-click their destined wand with no spell
-               player.getWorld().playEffect(location, Effect.ENDER_SIGNAL, 0);
-               player.getWorld().playSound(location, Sound.ENTITY_PLAYER_LEVELUP, 1, 1);
-            }
+
+            if (Ollivanders2.debug)
+               p.getLogger().info("OllivandersListener:onPlayerInteract: waving destined wand");
+            // play a sound and visual effect when they right-click their destined wand with no spell
+            Location location = player.getLocation();
+            location.setY(location.getY() + 1.6);
+            player.getWorld().playEffect(location, Effect.ENDER_SIGNAL, 0);
+            player.getWorld().playSound(location, Sound.ENTITY_PLAYER_LEVELUP, 1, 1);
+         }
+      }
+      /**
+       * A right or left click of the off hand is used to rotate through mastered spells for non-verbal spell casting.
+       */
+      else // event.getHand() == EquipmentSlot.OFF_HAND
+      {
+         rotateNonVerbalSpell(player, action);
+      }
+   }
+
+   /**
+    * If non-verbal spell casting is enabled, selects a new spell from mastered spells.
+    *
+    * @assumes non-verbal spell casting is enabled
+    * @param player
+    * @param action
+    */
+   void rotateNonVerbalSpell (Player player, Action action)
+   {
+      if (!Ollivanders2.nonVerbalCasting)
+         return;
+
+      if (Ollivanders2.debug)
+         p.getLogger().info("Rotating mastered spells for non-verbal casting.");
+
+      if (!p.holdsWand(player, EquipmentSlot.OFF_HAND))
+         return;
+
+      O2Player o2p = p.getO2Player(player);
+      boolean reverse = false;
+      // right click rotates through spells backwards
+      if (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK)
+         reverse = true;
+
+      o2p.shiftMasterSpell(reverse);
+      Spells spell = o2p.getMasterSpell();
+      if (spell != null)
+      {
+         String spellName = Spells.firstLetterCapitalize(Spells.recode(spell));
+         player.sendMessage("Wand master spell set to " + spellName);
+      }
+      else
+      {
+         if (Ollivanders2.debug)
+         {
+            player.sendMessage("You have not mastered any spells.");
          }
       }
    }
@@ -1672,6 +1693,9 @@ public class OllivandersListener implements Listener
     */
    void brewPotion (Player player, Block cauldron)
    {
+      if (Ollivanders2.debug)
+         p.getLogger().info("OllivandersListener:brewPotion: brewing potion");
+
       Block under = cauldron.getRelative(BlockFace.DOWN);
       if (under.getType() == Material.FIRE || under.getType() == Material.LAVA || under.getType() == Material.STATIONARY_LAVA)
       {


### PR DESCRIPTION
Changed how we rotate through spells so that, rather than sneak-click, holding the wand in the off hand and right or left clicking rotates through. This keeps wand in primary hand actions consistent as always resulting in a magical action/effect happening.  

Refactored onPlayerInteract() in to helper functions since it was getting unruly.