### PR TITLE
Potions part 2 - saving experience between restarts

### DIFF
--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Book/MAGICAL_DRAFTS_AND_POTIONS.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Book/MAGICAL_DRAFTS_AND_POTIONS.java
@@ -20,7 +20,7 @@ public class MAGICAL_DRAFTS_AND_POTIONS extends O2Book
       author = "Arsenius Jigger";
       branch = O2MagicBranch.POTIONS;
 
-      potions.add(O2PotionType.ANTIDOTE_POTION);
+      potions.add(O2PotionType.COMMON_ANTIDOTE_POTION);
       potions.add(O2PotionType.WIT_SHARPENING_POTION);
       potions.add(O2PotionType.FORGETFULLNESS_POTION);
       potions.add(O2PotionType.HERBICIDE_POTION);

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Book/O2Books.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Book/O2Books.java
@@ -187,7 +187,7 @@ public final class O2Books
     *
     * @param bookLore the lore from a book
     * @param player the player reading the book
-    * @param p
+    * @param p the callback to the MC plugin
     */
    public static void readLore (List<String> bookLore, Player player, Ollivanders2 p)
    {
@@ -197,6 +197,8 @@ public final class O2Books
       }
 
       O2Player o2p = p.players.getPlayer(player.getUniqueId());
+      if (o2p == null)
+         return;
 
       for (String spell : bookLore)
       {

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Book/THE_HEALERS_HELPMATE.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Book/THE_HEALERS_HELPMATE.java
@@ -25,7 +25,7 @@ public class THE_HEALERS_HELPMATE extends O2Book
       spells.add(O2SpellType.AGUAMENTI);
       spells.add(O2SpellType.BRACKIUM_EMENDO);
       spells.add(O2SpellType.EPISKEY);
-      potions.add(O2PotionType.ANTIDOTE_POTION);
+      potions.add(O2PotionType.COMMON_ANTIDOTE_POTION);
       // wound cleaning potion
       // pepperup potion
       // wideye potion

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Effect/LYCANTHROPY.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Effect/LYCANTHROPY.java
@@ -110,8 +110,6 @@ public class LYCANTHROPY extends ShapeShiftSuper
     */
    private void addAdditionalEffects ()
    {
-      O2Player o2p = p.players.getPlayer(targetID);
-
       AGGRESSION aggression = new AGGRESSION(p, 5, targetID);
       aggression.setAggressionLevel(10);
       p.players.playerEffects.addEffect(aggression);

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Effect/O2Effects.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Effect/O2Effects.java
@@ -23,7 +23,7 @@ public class O2Effects
 
    static Semaphore semaphore = new Semaphore(1);
 
-   public final String effectLabel = "Effect_";
+   public final String effectLabelPrefix = "Effect_";
 
    /**
     * Thread-safe storage class for the effect data on players.
@@ -334,7 +334,7 @@ public class O2Effects
          return;
 
       if (Ollivanders2.debug)
-         p.getLogger().info("Applying effects for " + p.players.getPlayer(pid).getPlayerName());
+         p.getLogger().info("Applying effects for " + p.getServer().getPlayer(pid).getDisplayName());
 
       for (Entry<O2EffectType, Integer> entry : savedEffects.entrySet())
       {
@@ -419,7 +419,7 @@ public class O2Effects
          Map<O2EffectType, Integer> savedEffects = effectsData.getPlayerSavedEffects(pid);
          for (Entry<O2EffectType, Integer> entry : savedEffects.entrySet())
          {
-            serialized.put(effectLabel + entry.getKey().toString(), entry.getValue().toString());
+            serialized.put(effectLabelPrefix + entry.getKey().toString(), entry.getValue().toString());
          }
       }
 
@@ -440,7 +440,7 @@ public class O2Effects
 
       Map<O2EffectType, Integer> savedEffects = effectsData.getPlayerSavedEffects(pid);
 
-      String effectName = effectsString.replaceFirst(effectLabel, "");
+      String effectName = effectsString.replaceFirst(effectLabelPrefix, "");
       Integer duration = p.common.integerFromString(durationString);
 
       if (duration != null)
@@ -513,7 +513,7 @@ public class O2Effects
       effectsData.updatePlayerActiveEffects(pid, playerEffects);
 
       if (Ollivanders2.debug)
-         p.getLogger().info("Added effect " + e.effectType.toString() + " to " + p.players.getPlayer(pid).getPlayerName());
+         p.getLogger().info("Added effect " + e.effectType.toString() + " to " + p.getServer().getPlayer(pid).getDisplayName());
    }
 
    /**
@@ -543,7 +543,7 @@ public class O2Effects
       effectsData.updatePlayerActiveEffects(pid, playerEffects);
 
       if (Ollivanders2.debug)
-         p.getLogger().info("Removed effect " + effectType.toString() + " to " + p.players.getPlayer(pid).getPlayerName());
+         p.getLogger().info("Removed effect " + effectType.toString() + " to " + p.getServer().getPlayer(pid).getDisplayName());
    }
 
    /**

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Effect/ShapeShiftSuper.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Effect/ShapeShiftSuper.java
@@ -80,7 +80,7 @@ public abstract class ShapeShiftSuper extends O2Effect
 
       if (form != null)
       {
-         p.getLogger().info("transforming " + p.players.getPlayer(targetID).getPlayerName());
+         p.getLogger().info("transforming " + p.getServer().getPlayer(targetID).getDisplayName());
 
          // disguisePlayer the player
          DisguiseType disguiseType = DisguiseType.getType(form);

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/GsonDataPersistenceLayer.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/GsonDataPersistenceLayer.java
@@ -16,6 +16,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
+import java.util.Date;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 
 public class GsonDataPersistenceLayer implements DataPersistenceLayer
 {
@@ -23,6 +26,7 @@ public class GsonDataPersistenceLayer implements DataPersistenceLayer
    private Ollivanders2 p;
 
    private String saveDirectory = "plugins/Ollivanders2";
+   private String archiveDirectory = "plugins/Ollivanders2/archive";
    private String housesJSONFile = "O2Houses.txt";
    private String housePointsJSONFile = "O2HousePoints.txt";
    private String o2PlayerJSONFile = "O2Players.txt";
@@ -246,8 +250,13 @@ public class GsonDataPersistenceLayer implements DataPersistenceLayer
       {
          if(file.exists())
          {
-            // if the file exists, we want to rewrite it
-            file.delete();
+            // if the file exists, we want to move it
+            File archiveDir = new File(archiveDirectory);
+            archiveDir.mkdirs();
+            String archiveFile = archiveDirectory + "/" + path + "-" + getCurrentTimestamp();
+
+            File prev = new File(archiveFile);
+            file.renameTo(prev);
          }
 
          // create the directory and file
@@ -353,5 +362,13 @@ public class GsonDataPersistenceLayer implements DataPersistenceLayer
       }
 
       return json;
+   }
+
+   private String getCurrentTimestamp ()
+   {
+      DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss");
+      Date date = new Date();
+
+      return dateFormat.format(date);
    }
 }

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/GsonDataPersistenceLayer.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/GsonDataPersistenceLayer.java
@@ -150,9 +150,6 @@ public class GsonDataPersistenceLayer implements DataPersistenceLayer
          }
 
          map.put(pid, hType);
-
-         if (Ollivanders2.debug)
-            p.getLogger().info("Read " + playerID + " : " + house);
       }
 
       return map;
@@ -205,9 +202,6 @@ public class GsonDataPersistenceLayer implements DataPersistenceLayer
          }
 
          map.put(hType, pts);
-
-         if (Ollivanders2.debug)
-            p.getLogger().info("Read " + house + " : " + points);
       }
 
       return map;

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/House/O2HouseType.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/House/O2HouseType.java
@@ -132,7 +132,7 @@ public enum O2HouseType
 
    /**
     * Set the score for this house. Should only be done from within the House package.
-    * @param s
+    * @param s the score to set
     */
    void setScore (Integer s)
    {

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/House/O2Houses.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/House/O2Houses.java
@@ -164,6 +164,7 @@ public class O2Houses
          O2HouseType houseType = e.getKey();
 
          houseType.setScore(e.getValue());
+         p.getLogger().info(e.getKey().getName() + " : " + e.getValue());
       }
    }
 
@@ -293,9 +294,6 @@ public class O2Houses
    public synchronized boolean setHousePoints (O2HouseType houseType, int points)
    {
       houseType.setScore(points);
-
-      if (Ollivanders2.debug)
-         p.getLogger().info("Set house points for " + houseType.getName() + " to " + points);
 
       return updateScoreboard();
    }
@@ -455,8 +453,6 @@ public class O2Houses
          {
             updateScoreboardScore(houseType);
          }
-
-         p.getLogger().info("Updated scoreboard with current house points...");
 
          return true;
       }

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Ollivanders2.java
@@ -1960,6 +1960,10 @@ public class Ollivanders2 extends JavaPlugin
                }
             }
          }
+         else if (subCommand.equalsIgnoreCase("list"))
+         {
+            return listAllPotions((Player)sender);
+         }
          else if (subCommand.equalsIgnoreCase("all"))
          {
             return giveAllPotions((Player)sender);
@@ -1994,6 +1998,37 @@ public class Ollivanders2 extends JavaPlugin
     */
    public boolean givePotion (CommandSender sender, Player player, String potionName)
    {
+      O2PotionType potionType = null;
+
+      // need to iterate rather than call potions.getPotionTypeByName so we can do startsWith
+      for (O2PotionType p : O2PotionType.values())
+      {
+         if (p.getPotionName().toLowerCase().startsWith(potionName.toLowerCase()))
+         {
+            potionType = p;
+            break;
+         }
+      }
+
+      if (potionType == null)
+      {
+         sender.sendMessage(chatColor + "Unable to find potion " + potionName);
+         
+         return true;
+      }
+
+      O2Potion potion = potions.getPotionFromType(potionType);
+
+      if (potion == null)
+         return true;
+
+      ItemStack brewedPotion = potion.brew((Player)sender, false);
+      List<ItemStack> kit = new ArrayList<>();
+      kit.add(brewedPotion);
+
+      givePlayerKit(player, kit);
+
+      /*
       O2Potion potion = null;
 
       for (O2Potion p : potions.getAllPotions())
@@ -2018,6 +2053,7 @@ public class Ollivanders2 extends JavaPlugin
       {
          sender.sendMessage(chatColor + "Unable to find potion " + potionName);
       }
+      */
 
       return true;
    }
@@ -2047,6 +2083,28 @@ public class Ollivanders2 extends JavaPlugin
       String displayString = "Ingredients:";
 
       for (String name : ingredientList)
+      {
+         displayString = displayString + "\n" + name;
+      }
+      displayString = displayString + "\n";
+
+      player.sendMessage(chatColor + displayString);
+
+      return true;
+   }
+
+   /**
+    * Lists all the potions active in the game.
+    *
+    * @param player the player to display the list to
+    * @return true
+    */
+   private boolean listAllPotions (Player player)
+   {
+      String displayString = "Potions:";
+
+      List<String> potionNames = potions.getAllPotionNames();
+      for (String name : potionNames)
       {
          displayString = displayString + "\n" + name;
       }

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Ollivanders2.java
@@ -491,7 +491,12 @@ public class Ollivanders2 extends JavaPlugin
       if (debug)
          getLogger().info("Running playerSummary");
 
-      O2Player o2p = players.getPlayer(player.getUniqueId());
+      O2Player o2p = getO2Player(player);
+      if (o2p == null)
+      {
+         sender.sendMessage(chatColor + "Unable to find player.");
+         return true;
+      }
 
       String summary = "Ollivanders2 player summary:\n\n";
 
@@ -1008,8 +1013,13 @@ public class Ollivanders2 extends JavaPlugin
                sender.sendMessage(chatColor + "Unable to find a player named " + p + ".\n");
                return true;
             }
-            O2Player o2p = players.getPlayer(player.getUniqueId());
-            sender.sendMessage(chatColor + "Player " + p + " is in year " + o2p.getYear().getIntValue());
+
+            O2Player o2p = getO2Player(player);
+            if (o2p != null)
+              sender.sendMessage(chatColor + "Player " + p + " is in year " + o2p.getYear().getIntValue());
+            else
+               sender.sendMessage(chatColor + "Unable to find player.");
+
             return true;
          }
       }
@@ -1092,7 +1102,7 @@ public class Ollivanders2 extends JavaPlugin
          sender.sendMessage(chatColor + "Unable to find a player named " + targetPlayer + ".\n");
          return true;
       }
-      O2Player o2p = players.getPlayer(player.getUniqueId());
+      O2Player o2p = getO2Player(player);
       int year;
       try
       {
@@ -1129,7 +1139,13 @@ public class Ollivanders2 extends JavaPlugin
          sender.sendMessage(chatColor + "Unable to find a player named " + targetPlayer + ".\n");
          return true;
       }
-      O2Player o2p = players.getPlayer(player.getUniqueId());
+      O2Player o2p = getO2Player(player);
+      if (o2p == null)
+      {
+         sender.sendMessage(chatColor + "Unable to find player.");
+         return true;
+      }
+
       int year = o2p.getYear().getIntValue() + yearChange;
       if (year > 0 && year < 8)
       {
@@ -1423,7 +1439,7 @@ public class Ollivanders2 extends JavaPlugin
     */
    public int getSpellNum (Player player, O2SpellType spell)
    {
-      O2Player o2p = players.getPlayer(player.getUniqueId());
+      O2Player o2p = getO2Player(player);
 
       return o2p.getSpellCount(spell);
    }
@@ -1438,7 +1454,7 @@ public class Ollivanders2 extends JavaPlugin
    public void setSpellNum (Player player, O2SpellType spell, int count)
    {
       UUID pid = player.getUniqueId();
-      O2Player o2p = players.getPlayer(pid);
+      O2Player o2p = getO2Player(player);
 
       o2p.setSpellCount(spell, count);
 
@@ -1456,7 +1472,7 @@ public class Ollivanders2 extends JavaPlugin
    {
       //returns the incremented spell count
       UUID pid = player.getUniqueId();
-      O2Player o2p = players.getPlayer(pid);
+      O2Player o2p = getO2Player(player);
 
       o2p.incrementSpellCount(spell);
       players.updatePlayer(pid, o2p);
@@ -1474,10 +1490,31 @@ public class Ollivanders2 extends JavaPlugin
    {
       //returns the incremented potion count
       UUID pid = player.getUniqueId();
-      O2Player o2p = players.getPlayer(pid);
+      O2Player o2p = getO2Player(player);
 
       o2p.incrementPotionCount(potionType);
       players.updatePlayer(pid, o2p);
+   }
+
+   /**
+    * Gets the O2Player associated with the Player
+    *
+    * @param player the player to get
+    * @return O2Player object for this player
+    */
+   public O2Player getO2Player (Player player)
+   {
+      UUID pid = player.getUniqueId();
+      O2Player o2p = players.getPlayer(pid);
+
+      if (o2p == null)
+      {
+         players.addPlayer(pid, player.getDisplayName());
+
+         o2p = players.getPlayer(pid);
+      }
+
+      return o2p;
    }
 
    /**
@@ -1551,6 +1588,9 @@ public class Ollivanders2 extends JavaPlugin
       }
 
       O2Player p = players.getPlayer(player.getUniqueId());
+      if (p == null)
+         return false;
+
       boolean coolDown = System.currentTimeMillis() < p.getSpellLastCastTime(spell);
 
       if (coolDown)

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Potion/ANIMAGUS_POTION.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Potion/ANIMAGUS_POTION.java
@@ -24,7 +24,7 @@ public final class ANIMAGUS_POTION extends O2Potion
    {
       super(plugin);
 
-      potionType = O2PotionType.ANTIDOTE_POTION;
+      potionType = O2PotionType.COMMON_ANTIDOTE_POTION;
       potionLevel = PotionLevel.NEWT;
 
       ingredients.put(IngredientType.MANDRAKE_LEAF, 1);

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Potion/COMMON_ANTIDOTE_POTION.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Potion/COMMON_ANTIDOTE_POTION.java
@@ -4,7 +4,6 @@ import net.pottercraft.Ollivanders2.Player.O2Player;
 import net.pottercraft.Ollivanders2.Ollivanders2;
 import org.bukkit.Color;
 import org.bukkit.entity.Player;
-import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
 /**
@@ -15,18 +14,18 @@ import org.bukkit.potion.PotionEffectType;
  * @since 2.2.7
  * @author Azami7
  */
-public final class ANTIDOTE_POTION extends O2Potion
+public final class COMMON_ANTIDOTE_POTION extends O2Potion
 {
    /**
     * Constructor
     *
     * @param plugin a callback to the plugin
     */
-   public ANTIDOTE_POTION (Ollivanders2 plugin)
+   public COMMON_ANTIDOTE_POTION (Ollivanders2 plugin)
    {
       super(plugin);
 
-      potionType = O2PotionType.ANTIDOTE_POTION;
+      potionType = O2PotionType.COMMON_ANTIDOTE_POTION;
       potionLevel = PotionLevel.BEGINNER;
 
       ingredients.put(IngredientType.MISTLETOE_BERRIES, 2);

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Potion/O2PotionType.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Potion/O2PotionType.java
@@ -11,9 +11,9 @@ import net.pottercraft.Ollivanders2.Ollivanders2Common;
 public enum O2PotionType
 {
    ANIMAGUS_POTION (net.pottercraft.Ollivanders2.Potion.ANIMAGUS_POTION.class),
-   ANTIDOTE_POTION (net.pottercraft.Ollivanders2.Potion.ANTIDOTE_POTION.class),
    BABBLING_BEVERAGE (net.pottercraft.Ollivanders2.Potion.BABBLING_BEVERAGE.class),
    BARUFFIOS_BRAIN_ELIXIR (net.pottercraft.Ollivanders2.Potion.BARUFFIOS_BRAIN_ELIXIR.class),
+   COMMON_ANTIDOTE_POTION(net.pottercraft.Ollivanders2.Potion.COMMON_ANTIDOTE_POTION.class),
    CURE_FOR_BOILS (net.pottercraft.Ollivanders2.Potion.CURE_FOR_BOILS.class),
    DRAUGHT_OF_LIVING_DEATH (net.pottercraft.Ollivanders2.Potion.DRAUGHT_OF_LIVING_DEATH.class),
    FORGETFULLNESS_POTION (net.pottercraft.Ollivanders2.Potion.FORGETFULLNESS_POTION.class),

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Potion/O2Potions.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Potion/O2Potions.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
+import java.util.List;
 
 import net.pottercraft.Ollivanders2.Ollivanders2;
 import net.pottercraft.Ollivanders2.Ollivanders2Common;
@@ -70,6 +70,23 @@ public class O2Potions
       }
 
       return potions;
+   }
+
+   /**
+    * Get the names of all potions loaded in the game.
+    *
+    * @return the list of active potion names
+    */
+   public List<String> getAllPotionNames ()
+   {
+      ArrayList<String> potionNames = new ArrayList<>();
+
+      for (O2PotionType potionType : O2PotionType.values())
+      {
+         potionNames.add(potionType.getPotionName());
+      }
+
+      return potionNames;
    }
 
    /**
@@ -190,7 +207,7 @@ public class O2Potions
     * @param potionType the type of potion to get
     * @return the O2Potion object, if it could be created, or null otherwise
     */
-   private O2Potion getPotionFromType (O2PotionType potionType)
+   public O2Potion getPotionFromType (O2PotionType potionType)
    {
       O2Potion potion;
 

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Spell/AMATO_ANIMO_ANIMATO_ANIMAGUS.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Spell/AMATO_ANIMO_ANIMATO_ANIMAGUS.java
@@ -72,6 +72,12 @@ public class AMATO_ANIMO_ANIMATO_ANIMAGUS extends Transfiguration
    {
       O2Player o2p = p.players.getPlayer(player.getUniqueId());
 
+      if (o2p == null)
+      {
+         kill();
+         return;
+      }
+
       if (o2p.isAnimagus())
       {
          // If the player is already an animagus, the incantation changes them to and from their animal form.

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Spell/ET_INTERFICIAM_ANIMAM_LIGAVERIS.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Spell/ET_INTERFICIAM_ANIMAM_LIGAVERIS.java
@@ -8,11 +8,10 @@ import net.pottercraft.Ollivanders2.StationarySpell.StationarySpells;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.attribute.Attributable;
 import org.bukkit.attribute.Attribute;
-import org.bukkit.entity.Damageable;
 import org.bukkit.entity.Player;
 
+import net.pottercraft.Ollivanders2.Player.O2Player;
 import net.pottercraft.Ollivanders2.StationarySpell.HORCRUX;
 import net.pottercraft.Ollivanders2.Ollivanders2;
 
@@ -60,6 +59,13 @@ public final class ET_INTERFICIAM_ANIMAM_LIGAVERIS extends DarkArts
 
    public void checkEffect ()
    {
+      O2Player o2p = p.players.getPlayer(player.getUniqueId());
+      if (o2p == null)
+      {
+         kill();
+         return;
+      }
+
       move();
       if (getBlock().getType() != Material.AIR && getBlock().getType() != Material.FIRE && getBlock().getType()
             != Material.WATER && getBlock().getType() != Material.STATIONARY_WATER)
@@ -69,7 +75,7 @@ public final class ET_INTERFICIAM_ANIMAM_LIGAVERIS extends DarkArts
          {
             futureHealth = player.getAttribute(org.bukkit.attribute.Attribute.GENERIC_MAX_HEALTH).getBaseValue() / 2.0;
          }
-         int souls = p.players.getPlayer(player.getUniqueId()).getSouls();
+         int souls = o2p.getSouls();
          //If the player's soul is split enough and they can survive making another horcrux, then make a new one and damage them
          if (futureHealth - 1 > 0 && souls > 0)
          {
@@ -78,7 +84,7 @@ public final class ET_INTERFICIAM_ANIMAM_LIGAVERIS extends DarkArts
             p.stationarySpells.addStationarySpell(horcrux);
             player.getAttribute(Attribute.GENERIC_MAX_HEALTH).setBaseValue(
                   player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue() / 2.0);
-            p.players.getPlayer(player.getUniqueId()).subtractSoul();
+            o2p.subtractSoul();
             player.damage(1.0);
             kill();
          }

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Spell/LEGILIMENS.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Spell/LEGILIMENS.java
@@ -57,7 +57,7 @@ public final class LEGILIMENS extends DarkArts
          if (live instanceof Player)
          {
             Player target = (Player) live;
-            double experience = p.players.getPlayer(target.getUniqueId()).getSpellCount(O2SpellType.LEGILIMENS);
+            double experience = p.getO2Player(target).getSpellCount(O2SpellType.LEGILIMENS);
             if (usesModifier > experience)
             {
                player.openInventory(target.getInventory());


### PR DESCRIPTION
Added saving potions and reading potion experience to player file
Fixed race condition in re-adding effects on Join
Added protections for NPEs in a few places
Added logic to protect clobbering save files with bad saves and archive previous versions rather than overwrite
Fixed unnecessary double loops in OllivandersSchedule
Fixed name of antidote potion class and enum