### PR TITLE
2.2.9.1

### DIFF
--- a/Ollivanders/src/config.yml
+++ b/Ollivanders/src/config.yml
@@ -27,11 +27,24 @@ nonVerbalSpellCasting: false
 spellJournal: true
 hostileMobAnimagi: false
 deathExpLoss: false
+divinationMaxDays: 4
 
 # Houses
 #
 # https://github.com/Azami7/Ollivanders2/wiki/Configuration#houses-and-years
 houses: false
+gryffindorName: "Gryffindor"
+hufflepuffName: "Hufflepuff"
+ravenclawName: "Ravenclaw"
+slytherinName: "Slytherin"
+gryffindorColor: DARK_RED
+hufflepuffColor: GOLD
+ravenclawColor: BLUE
+slytherinColor: DARK_GREEN
+
+# Years
+#
+# https://github.com/Azami7/Ollivanders2/wiki/Configuration#years
 years: false
 
 # Magical Items

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Book/O2Books.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Book/O2Books.java
@@ -193,7 +193,7 @@ public final class O2Books
     */
    public static void readLore (List<String> bookLore, Player player, Ollivanders2 p)
    {
-      if (bookLore == null || player == null || !Ollivanders2.useBookLearning)
+      if (bookLore == null || player == null || !Ollivanders2.bookLearning)
       {
          return;
       }

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Effect/ANIMAGUS_EFFECT.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Effect/ANIMAGUS_EFFECT.java
@@ -168,7 +168,7 @@ public class ANIMAGUS_EFFECT extends ShapeShiftSuper
 
          horseWatcher.setColor(color);
       }
-      else if (Ollivanders2.mcVersionCheck() && form == EntityType.LLAMA)
+      else if (Ollivanders2.mcVersion > 11 && form == EntityType.LLAMA)
       {
          LlamaWatcher llamaWatcher = (LlamaWatcher)watcher;
          Llama.Color color = Llama.Color.WHITE;

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/House/O2Houses.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/House/O2Houses.java
@@ -59,7 +59,9 @@ public class O2Houses
     */
    private void readHouseConfig ()
    {
-      // read house name config
+      //
+      // house names
+      //
       if (p.getConfig().isSet("gryffindorName"))
          O2HouseType.GRYFFINDOR.setName(p.getConfig().getString("gryffindorName"));
 
@@ -72,7 +74,9 @@ public class O2Houses
       if (p.getConfig().isSet("slytherinName"))
          O2HouseType.SLYTHERIN.setName(p.getConfig().getString("slytherinName"));
 
-      // read house color config
+      //
+      // house colors
+      //
       if (p.getConfig().isSet("gryffindorColor"))
          O2HouseType.GRYFFINDOR.setColor(p.getConfig().getString("gryffindorColor"));
 

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Ollivanders2.java
@@ -3,8 +3,6 @@ package net.pottercraft.Ollivanders2;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.ObjectInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -56,7 +54,7 @@ import org.bukkit.plugin.java.JavaPlugin;
  * @author cakenggt
  * @author lownes
  * @author Azami7
- * @author autumnwoz
+ * @author lil_miss_giggles
  */
 
 public class Ollivanders2 extends JavaPlugin
@@ -1720,24 +1718,6 @@ public class Ollivanders2 extends JavaPlugin
    }
 
    /**
-    * SLAPI = Saving/Loading API
-    * API for Saving and Loading Objects.
-    *
-    * @author Tomsik68
-    */
-   @Deprecated
-   public static class SLAPI
-   {
-      public static Object load (String path) throws Exception
-      {
-         ObjectInputStream ois = new ObjectInputStream(new FileInputStream(path));
-         Object result = ois.readObject();
-         ois.close();
-         return result;
-      }
-   }
-
-   /**
     * Check to see if we're running MC version 1.12 or higher, which many Ollivanders2 features depend on.
     *
     * @return true of version string is 1.12, false otherwise.
@@ -1759,7 +1739,7 @@ public class Ollivanders2 extends JavaPlugin
     */
    private boolean giveFlooPowder (Player player)
    {
-      ItemStack flooPowder = new ItemStack(Material.REDSTONE);
+      ItemStack flooPowder = new ItemStack(Ollivanders2.flooPowderMaterial);
       List<String> lore = new ArrayList<>();
       lore.add("Glittery, silver powder");
       flooPowder.getItemMeta().setLore(lore);

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Ollivanders2.java
@@ -11,7 +11,6 @@ import java.util.UUID;
 
 import Quidditch.Arena;
 
-import net.pottercraft.Ollivanders2.Book.O2Books;
 import net.pottercraft.Ollivanders2.Effect.O2Effect;
 import net.pottercraft.Ollivanders2.Effect.O2EffectType;
 import net.pottercraft.Ollivanders2.House.O2HouseType;
@@ -43,7 +42,6 @@ import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.command.Command;
 import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -60,26 +58,32 @@ import org.bukkit.plugin.java.JavaPlugin;
 public class Ollivanders2 extends JavaPlugin
 {
    private List<O2Spell> projectiles = new ArrayList<>();
-
    private List<Block> tempBlocks = new ArrayList<>();
-   private FileConfiguration fileConfig;
-   public O2Books books;
 
-   private static String mcVersion;
-   public static boolean debug = false;
-   public static boolean useNonVerbalCasting = false;
-   public static boolean useHostileMobAnimagi = false;
-   public static boolean useBookLearning = false;
-   public static boolean useHouses = false;
-   public static boolean useYears = false;
+   // file config
+   public static int chatDropoff = 15;
+   public static ChatColor chatColor;
+   public static boolean showLogInMessage;
+   public static boolean bookLearning;
+   public static boolean enableNonVerbalSpellCasting;
+   public static boolean useSpellJournal;
+   public static boolean useHostileMobAnimagi;
+   public static boolean enableDeathExpLoss;
    public static int divinationMaxDays = 4;
-   public static Ollivanders2WorldGuard worldGuardO2;
+   public static boolean useHouses;
+   public static boolean useYears;
+   public static boolean debug;
+   public static Material flooPowderMaterial;
+   public static Material broomstickMaterial;
+   public static boolean enableWitchDrop;
+   private ConfigurationSection zoneConfig;
+
+   // other config
+   private static String mcVersion;
+   public static Material wandMaterial = Material.STICK;
    public static boolean worldGuardEnabled = false;
    public static boolean libsDisguisesEnabled = false;
-   public static ChatColor chatColor = ChatColor.AQUA;
-   public static Material wandMaterial = Material.STICK;
-   public static Material flooPowderMaterial = Material.REDSTONE;
-   public static int chatDropoff = 15;
+   public static Ollivanders2WorldGuard worldGuardO2;
 
    /**
     * onDisable runs when the Minecraft server is shutting down.
@@ -122,16 +126,15 @@ public class Ollivanders2 extends JavaPlugin
    {
       Ollivanders2API.init(this);
 
+      // set up event listeners
       Listener playerListener = new OllivandersListener(this);
       getServer().getPluginManager().registerEvents(playerListener, this);
 
-      //loads data
+      // check for plugin data directory
       if (new File("plugins/Ollivanders2/").mkdirs())
       {
-         getLogger().info("File directory for Ollivanders2");
+         getLogger().info("Creating directory for Ollivanders2");
       }
-      projectiles = new ArrayList<>();
-      fileConfig = getConfig();
 
       //check version of server
       mcVersion = Bukkit.getBukkitVersion();
@@ -140,91 +143,15 @@ public class Ollivanders2 extends JavaPlugin
          getLogger().warning("MC version " + mcVersion + ". Some features of Ollivanders2 require MC 1.12 and higher.");
       }
 
-      // write the config.yml to the Ollivanders2 folder if there wasn't one already
-      if (!new File(this.getDataFolder(), "config.yml").exists())
-      {
-         this.saveDefaultConfig();
-      }
-
-      //
       // read configuration
-      //
+      initConfig();
 
-      debug = getConfig().getBoolean("debug");
-      if (debug)
-         getLogger().info("Enabling debug mode.");
-
-      if (getConfig().isSet("chatColor"))
-      {
-         chatColor = ChatColor.getByChar(getConfig().getString("chatColor"));
-         getLogger().info("Setting plugin message color to " + chatColor.toString());
-      }
-
-      if (getConfig().isSet("chatDropoff"))
-      {
-         int drop = getConfig().getInt("chatDropoff");
-         if (drop > 0)
-            chatDropoff = drop;
-      }
-
-      if (getConfig().isSet("flooPowder"))
-      {
-         flooPowderMaterial = Material.getMaterial(fileConfig.getString("flooPowder"));
-         O2ItemType.FLOO_POWDER.setMaterial(flooPowderMaterial);
-      }
-
-      useNonVerbalCasting = getConfig().getBoolean("nonVerbalSpellCasting");
-      if (useNonVerbalCasting)
-         getLogger().info("Enabling non-verbal spell casting.");
-
-      useHostileMobAnimagi = getConfig().getBoolean("hostileMobAnimagi");
-      if (useHostileMobAnimagi)
-         getLogger().info("Enabling hostile mob types for animagi.");
-
-      useBookLearning = getConfig().getBoolean("bookLearning");
-      if (useBookLearning)
-         getLogger().info("Enabling book learning.");
-
-      useHouses = getConfig().getBoolean("houses");
-      if (useHouses)
-         getLogger().info("Enabling school houses.");
-
-      useYears = getConfig().getBoolean("years");
-      if (useYears)
-         getLogger().info("Enabling school years.");
-
-      if (getConfig().isSet("divinationMaxDays"))
-      {
-         divinationMaxDays = getConfig().getInt("divinationMaxDays");
-         if (divinationMaxDays < 0)
-         {
-            divinationMaxDays = 4;
-         }
-      }
-
+      // set up scheduler
       OllivandersSchedule schedule = new OllivandersSchedule(this);
       Bukkit.getScheduler().scheduleSyncRepeatingTask(this, schedule, 20L, 1L);
 
-      // set up libDisguises
-      Plugin libsDisguises = Bukkit.getServer().getPluginManager().getPlugin("LibsDisguises");
-      if (libsDisguises != null)
-      {
-         libsDisguisesEnabled = true;
-         getLogger().info("LibsDisguises found, enabled entity transfiguration spells.");
-      }
-      else
-      {
-         getLogger().info("LibsDisguises not found, disabling entity transfiguration spells.");
-      }
-
-      if (worldGuardEnabled)
-      {
-         getLogger().info("WorldGuard found, enabled WorldGuard features.");
-      }
-      else
-      {
-         getLogger().info("WorldGuard not found, disabled WorldGuard features.");
-      }
+      // set up dependencies
+      loadDependenciesPlugins();
 
       // set up players
       try
@@ -306,9 +233,198 @@ public class Ollivanders2 extends JavaPlugin
          e.printStackTrace();
       }
 
+      // set up all plugin crafting recipes
+      initRecipes();
+
+      getLogger().info(this + " is now enabled!");
+   }
+
+   /**
+    * Load plugin config. If there is a config.yml file, load any config
+    * set there and set everything else to default values.
+    */
+   private void initConfig ()
+   {
+      //
+      // chatDropoff
+      //
+      if (getConfig().isSet("chatDropoff"))
+      {
+         chatDropoff = getConfig().getInt("chatDropoff");
+      }
+      if (chatDropoff <= 0)
+      {
+         chatDropoff = 15;
+      }
+
+      //
+      // chatColor
+      //
+      if (getConfig().isSet("chatColor"))
+      {
+         chatColor = ChatColor.getByChar(getConfig().getString("chatColor"));
+      }
+      if (chatColor == null)
+      {
+         chatColor = ChatColor.AQUA;
+      }
+      getLogger().info("Setting plugin message color to " + chatColor.toString());
+
+      //
+      // showLogInMessage
+      //
+      showLogInMessage = getConfig().getBoolean("showLogInMessage");
+      if (showLogInMessage)
+      {
+         getLogger().info("Enabling player log in message.");
+      }
+
+      //
+      // bookLearning
+      //
+      bookLearning = getConfig().getBoolean("bookLearning");
+      if (bookLearning)
+      {
+         getLogger().info("Enabling book learning.");
+      }
+
+      //
+      // nonVerbalSpellCasting
+      //
+      enableNonVerbalSpellCasting = getConfig().getBoolean("nonVerbalSpellCasting");
+      if (enableNonVerbalSpellCasting)
+      {
+         getLogger().info("Enabling non-verbal spell casting.");
+      }
+
+      //
+      // spellJournal
+      //
+      useSpellJournal = getConfig().getBoolean("spellJournal");
+      if (useSpellJournal)
+      {
+         getLogger().info("Enabling spell journal.");
+      }
+
+      //
+      // hostileMobAnimagi
+      //
+      useHostileMobAnimagi = getConfig().getBoolean("hostileMobAnimagi");
+      if (useHostileMobAnimagi)
+      {
+         getLogger().info("Enabling hostile mob types for animagi.");
+      }
+
+      //
+      // deathExpLoss
+      //
+      enableDeathExpLoss = getConfig().getBoolean("deathExpLoss");
+      if (enableDeathExpLoss)
+      {
+         getLogger().info("Enabling death experience loss.");
+      }
+
+      //
+      // divinationMaxDays
+      //
+      if (getConfig().isSet("divinationMaxDays"))
+      {
+         divinationMaxDays = getConfig().getInt("divinationMaxDays");
+      }
+      if (divinationMaxDays <= 0)
+      {
+         divinationMaxDays = 4;
+      }
+
+      //
+      // houses
+      //
+      useHouses = getConfig().getBoolean("houses");
+      if (useHouses)
+      {
+         getLogger().info("Enabling school houses.");
+      }
+
+      //
+      // years
+      //
+      useYears = getConfig().getBoolean("years");
+      if (useYears)
+      {
+         getLogger().info("Enabling school years.");
+      }
+
+      //
+      // flooPowder
+      //
+      if (getConfig().isSet("flooPowder"))
+      {
+         flooPowderMaterial = Material.getMaterial(getConfig().getString("flooPowder"));
+      }
+      if (flooPowderMaterial == null)
+      {
+         flooPowderMaterial = Material.REDSTONE;
+      }
+      O2ItemType.FLOO_POWDER.setMaterial(flooPowderMaterial);
+
+      //
+      // broomstick
+      //
+      if (getConfig().isSet("broomstick"))
+      {
+         broomstickMaterial = Material.getMaterial(getConfig().getString("broomstick"));
+      }
+      if (broomstickMaterial == null)
+      {
+         broomstickMaterial = Material.STICK;
+      }
+      O2ItemType.BROOMSTICK.setMaterial(broomstickMaterial);
+
+      //
+      // witchDrop
+      //
+      enableWitchDrop = getConfig().getBoolean("witchDrop");
+      if (enableWitchDrop)
+      {
+         getLogger().info("Enabling witch wand drop");
+      }
+
+      //
+      // debug
+      //
+      debug = getConfig().getBoolean("debug");
+      if (debug)
+      {
+         getLogger().info("Enabling debug mode.");
+      }
+
+      //
+      // Zones
+      //
+      zoneConfig = getConfig().getConfigurationSection("zones");
+   }
+
+   /**
+    * Load dependency plugins or turn of the features that require them if
+    * they are not present.
+    */
+   private void loadDependenciesPlugins ()
+   {
+      // set up libDisguises
+      Plugin libsDisguises = Bukkit.getServer().getPluginManager().getPlugin("LibsDisguises");
+      if (libsDisguises != null)
+      {
+         libsDisguisesEnabled = true;
+         getLogger().info("LibsDisguises found, enabled entity transfiguration spells.");
+      }
+      else
+      {
+         getLogger().info("LibsDisguises not found, disabling entity transfiguration spells.");
+      }
+
       // set up WorldGuard manager
-      Plugin wg = Bukkit.getServer().getPluginManager().getPlugin("WorldGuard");
-      if (wg == null)
+      Plugin worldGuard = Bukkit.getServer().getPluginManager().getPlugin("WorldGuard");
+      if (worldGuard == null)
       {
          worldGuardEnabled = false;
       }
@@ -316,7 +432,7 @@ public class Ollivanders2 extends JavaPlugin
       {
          try
          {
-            if (wg instanceof WorldGuardPlugin)
+            if (worldGuard instanceof WorldGuardPlugin)
             {
                worldGuardO2 = new Ollivanders2WorldGuard(this);
                worldGuardEnabled = true;
@@ -328,6 +444,21 @@ public class Ollivanders2 extends JavaPlugin
          }
       }
 
+      if (worldGuard != null)
+      {
+         getLogger().info("WorldGuard found, enabled WorldGuard features.");
+      }
+      else
+      {
+         getLogger().info("WorldGuard not found, disabled WorldGuard features.");
+      }
+   }
+
+   /**
+    * Set up all the Ollivanders2 crafting recipes
+    */
+   private void initRecipes ()
+   {
       //broomstick recipe
       ItemStack broomstick = Ollivanders2API.getItems().getItemByType(O2ItemType.BROOMSTICK, 1);
       NamespacedKey recipeKey = new NamespacedKey(this, "broomstick");
@@ -340,8 +471,6 @@ public class Ollivanders2 extends JavaPlugin
       ItemStack flooPowder = Ollivanders2API.getItems().getItemByType(O2ItemType.FLOO_POWDER, 8);
       getServer().addRecipe(new FurnaceRecipe(flooPowder, Material.ENDER_PEARL));
       getServer().addRecipe(bRecipe);
-
-      getLogger().info(this + " is now enabled!");
    }
 
    /**
@@ -663,7 +792,7 @@ public class Ollivanders2 extends JavaPlugin
     */
    private boolean runHouse (CommandSender sender, String[] args)
    {
-      if (!getConfig().getBoolean("houses"))
+      if (!useHouses)
       {
          sender.sendMessage(chatColor
                + "House are not currently enabled for your server."
@@ -986,7 +1115,7 @@ public class Ollivanders2 extends JavaPlugin
 
    private boolean runYear (CommandSender sender, String[] args)
    {
-      if (!getConfig().getBoolean("years"))
+      if (!useYears)
       {
          sender.sendMessage(chatColor
                + "Years are not currently enabled for your server."
@@ -1307,9 +1436,9 @@ public class Ollivanders2 extends JavaPlugin
    private boolean runReloadConfigs(CommandSender sender)
    {
       reloadConfig();
-      fileConfig = getConfig();
-      sender.sendMessage(chatColor + "Config reloaded");
+      initConfig();
 
+      sender.sendMessage(chatColor + "Config reloaded");
       return true;
    }
 
@@ -1616,19 +1745,18 @@ public class Ollivanders2 extends JavaPlugin
       double x = loc.getX();
       double y = loc.getY();
       double z = loc.getZ();
-      if (fileConfig.contains("zones"))
+      if (zoneConfig != null)
       {
-         ConfigurationSection config = fileConfig.getConfigurationSection("zones");
-         for (String zone : config.getKeys(false))
+         for (String zone : zoneConfig.getKeys(false))
          {
             String prefix = zone + ".";
-            String type = config.getString(prefix + "type");
-            String world = config.getString(prefix + "world");
-            String areaString = config.getString(prefix + "area");
+            String type = zoneConfig.getString(prefix + "type");
+            String world = zoneConfig.getString(prefix + "world");
+            String areaString = zoneConfig.getString(prefix + "area");
             boolean allAllowed = false;
             boolean allDisallowed = false;
             List<O2SpellType> allowedSpells = new ArrayList<>();
-            for (String spellString : config.getStringList(prefix + "allowed-spells"))
+            for (String spellString : zoneConfig.getStringList(prefix + "allowed-spells"))
             {
                if (spellString.equalsIgnoreCase("ALL"))
                {
@@ -1640,7 +1768,7 @@ public class Ollivanders2 extends JavaPlugin
                }
             }
             List<O2SpellType> disallowedSpells = new ArrayList<>();
-            for (String spellString : config.getStringList(prefix + "disallowed-spells"))
+            for (String spellString : zoneConfig.getStringList(prefix + "disallowed-spells"))
             {
                if (spellString.equalsIgnoreCase("ALL"))
                {
@@ -1704,17 +1832,6 @@ public class Ollivanders2 extends JavaPlugin
          }
       }
       return cast;
-   }
-
-   /**
-    * Get the file configuration
-    *
-    * @return FileConfiguration
-    */
-   @Deprecated
-   public FileConfiguration getFileConfig ()
-   {
-      return fileConfig;
    }
 
    /**

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Ollivanders2.java
@@ -484,7 +484,7 @@ public class Ollivanders2 extends JavaPlugin
          {
             return runEffect(sender, args);
          }
-         else if (subCommand.equalsIgnoreCase("prophecy"))
+         else if (subCommand.equalsIgnoreCase("prophecy") || subCommand.equalsIgnoreCase("prophecies"))
          {
             return runProphecies(sender, args);
          }

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Ollivanders2.java
@@ -79,11 +79,11 @@ public class Ollivanders2 extends JavaPlugin
    private ConfigurationSection zoneConfig;
 
    // other config
-   private static String mcVersion;
    public static Material wandMaterial = Material.STICK;
    public static boolean worldGuardEnabled = false;
    public static boolean libsDisguisesEnabled = false;
    public static Ollivanders2WorldGuard worldGuardO2;
+   public static int mcVersion = 11;
 
    /**
     * onDisable runs when the Minecraft server is shutting down.
@@ -134,14 +134,11 @@ public class Ollivanders2 extends JavaPlugin
       if (new File("plugins/Ollivanders2/").mkdirs())
       {
          getLogger().info("Creating directory for Ollivanders2");
+         this.saveDefaultConfig();
       }
 
       //check version of server
-      mcVersion = Bukkit.getBukkitVersion();
-      if (!mcVersionCheck())
-      {
-         getLogger().warning("MC version " + mcVersion + ". Some features of Ollivanders2 require MC 1.12 and higher.");
-      }
+      mcVersionCheck();
 
       // read configuration
       initConfig();
@@ -1835,16 +1832,25 @@ public class Ollivanders2 extends JavaPlugin
    }
 
    /**
-    * Check to see if we're running MC version 1.12 or higher, which many Ollivanders2 features depend on.
-    *
-    * @return true of version string is 1.12, false otherwise.
+    * Check to see what MC version is being run to determine what Ollivanders2 features are supported.
     */
-   public static boolean mcVersionCheck ()
+   private void mcVersionCheck ()
    {
-      if (mcVersion.startsWith("1.12"))
-         return true;
+      String versionString = Bukkit.getBukkitVersion();
 
-      return false;
+      if (versionString.startsWith("1.12"))
+      {
+         mcVersion = 12;
+      }
+      else if (versionString.startsWith("1.13"))
+      {
+         mcVersion = 13;
+      }
+
+      if (mcVersion < 12)
+      {
+         getLogger().warning("MC version " + versionString + ". Some features of Ollivanders2 require MC 1.12 and higher.");
+      }
    }
 
    /**

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Ollivanders2Common.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Ollivanders2Common.java
@@ -732,7 +732,7 @@ public class Ollivanders2Common
     */
    public boolean isBroom (ItemStack item)
    {
-      if (item.getType() == Material.getMaterial(p.getConfig().getString("broomstick")))
+      if (item.getType() == Ollivanders2.broomstickMaterial)
       {
          if (item.containsEnchantment(Enchantment.PROTECTION_FALL))
          {

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/OllivandersListener.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/OllivandersListener.java
@@ -417,7 +417,7 @@ public class OllivandersListener implements Listener
       {
          if (p.canCast(sender, spellType, true))
          {
-            if (Ollivanders2.useBookLearning && p.getO2Player(sender).getSpellCount(spellType) < 1)
+            if (Ollivanders2.bookLearning && p.getO2Player(sender).getSpellCount(spellType) < 1)
             {
                // if bookLearning is set to true then spell count must be > 0 to cast this spell
                if (Ollivanders2.debug)
@@ -801,7 +801,7 @@ public class OllivandersListener implements Listener
 
       // if no spell set, check to see if they have a master spell
       boolean nonverbal = false;
-      if (spellType == null && Ollivanders2.useNonVerbalCasting)
+      if (spellType == null && Ollivanders2.enableNonVerbalSpellCasting)
       {
          spellType = o2p.getMasterSpell();
          nonverbal = true;
@@ -981,7 +981,7 @@ public class OllivandersListener implements Listener
     */
    private void rotateNonVerbalSpell (Player player, Action action)
    {
-      if (!Ollivanders2.useNonVerbalCasting)
+      if (!Ollivanders2.enableNonVerbalSpellCasting)
          return;
 
       if (Ollivanders2.debug)
@@ -1051,7 +1051,7 @@ public class OllivandersListener implements Listener
       p.setO2Player(player, o2p);
 
       // show log in message
-      if (p.getConfig().getBoolean("showLogInMessage"))
+      if (Ollivanders2.showLogInMessage)
       {
          StringBuilder message = new StringBuilder();
 
@@ -1117,7 +1117,7 @@ public class OllivandersListener implements Listener
    @EventHandler(priority = EventPriority.HIGHEST)
    public void onPlayerDeath (PlayerDeathEvent event)
    {
-      if (p.getConfig().getBoolean("deathExpLoss"))
+      if (Ollivanders2.enableDeathExpLoss)
       {
          O2Player o2p = Ollivanders2API.getPlayers().getPlayer(event.getEntity().getUniqueId());
 
@@ -1601,7 +1601,7 @@ public class OllivandersListener implements Listener
    @EventHandler(priority = EventPriority.NORMAL)
    public void witchWandDrop (EntityDeathEvent event)
    {
-      if (event.getEntityType() == EntityType.WITCH && p.getConfig().getBoolean("witchDrop"))
+      if (event.getEntityType() == EntityType.WITCH && Ollivanders2.enableWitchDrop)
       {
          int wandType = Math.abs(Ollivanders2Common.random.nextInt() % 4);
          int coreType = Math.abs(Ollivanders2Common.random.nextInt() % 4);
@@ -1692,7 +1692,7 @@ public class OllivandersListener implements Listener
    public void onBookRead (PlayerInteractEvent event)
    {
       // only run this if bookLearning is enabled
-      if (!Ollivanders2.useBookLearning)
+      if (!Ollivanders2.bookLearning)
          return;
 
       Action action = event.getAction();
@@ -1723,7 +1723,7 @@ public class OllivandersListener implements Listener
    public void onSpellJournalHold (PlayerItemHeldEvent event)
    {
       // only run this if spellJournal is enabled
-      if (event == null || !p.getConfig().getBoolean("spellJournal"))
+      if (event == null || !Ollivanders2.useSpellJournal)
          return;
 
       Player player = event.getPlayer();

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/OllivandersListener.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/OllivandersListener.java
@@ -301,6 +301,9 @@ public class OllivandersListener implements Listener
          spellType = Ollivanders2API.getSpells().getSpellTypeByName(spellName.toString());
 
          if (spellType != null)
+            break;
+
+         if (i == O2Spell.max_spell_words)
          {
             break;
          }
@@ -642,7 +645,7 @@ public class OllivandersListener implements Listener
                if (entity.getLocation().distance(sender.getLocation()) <= 10)
                {
                   Creature owl;
-                  if (Ollivanders2.mcVersionCheck() && entity instanceof Parrot)
+                  if (Ollivanders2.mcVersion > 11 && entity instanceof Parrot)
                   {
                      owl = (Parrot) entity;
                   }
@@ -671,7 +674,7 @@ public class OllivandersListener implements Listener
                            {
                               if (recipient.getWorld().getUID().equals(world.getUID()))
                               {
-                                 if (Ollivanders2.mcVersionCheck())
+                                 if (Ollivanders2.mcVersion > 11)
                                  {
                                     world.playSound(owl.getLocation(), Sound.ENTITY_PARROT_AMBIENT, 1, 0);
                                  }
@@ -681,7 +684,7 @@ public class OllivandersListener implements Listener
                                  }
                                  owl.teleport(recipient.getLocation());
                                  item.teleport(recipient.getLocation());
-                                 if (Ollivanders2.mcVersionCheck())
+                                 if (Ollivanders2.mcVersion > 11)
                                  {
                                     world.playSound(owl.getLocation(), Sound.ENTITY_PARROT_AMBIENT, 1, 0);
                                  }
@@ -692,7 +695,7 @@ public class OllivandersListener implements Listener
                               }
                               else
                               {
-                                 if (Ollivanders2.mcVersionCheck())
+                                 if (Ollivanders2.mcVersion > 11)
                                  {
                                     world.playSound(owl.getLocation(), Sound.ENTITY_PARROT_HURT, 1, 0);
                                  }
@@ -705,7 +708,7 @@ public class OllivandersListener implements Listener
                            }
                            else
                            {
-                              if (Ollivanders2.mcVersionCheck())
+                              if (Ollivanders2.mcVersion > 11)
                               {
                                  world.playSound(owl.getLocation(), Sound.ENTITY_PARROT_HURT, 1, 0);
                               }
@@ -718,7 +721,7 @@ public class OllivandersListener implements Listener
                         }
                         else
                         {
-                           if (Ollivanders2.mcVersionCheck())
+                           if (Ollivanders2.mcVersion > 11)
                            {
                               world.playSound(owl.getLocation(), Sound.ENTITY_PARROT_HURT, 1, 0);
                            }

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/OllivandersListener.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/OllivandersListener.java
@@ -295,7 +295,7 @@ public class OllivandersListener implements Listener
       StringBuilder spellName = new StringBuilder();
       O2SpellType spellType = null;
 
-      for (int i = 0; i < O2Spell.max_spell_words; i++)
+      for (int i = 0; i < words.length; i++)
       {
          spellName.append(words[i]);
          spellType = Ollivanders2API.getSpells().getSpellTypeByName(spellName.toString());
@@ -304,6 +304,9 @@ public class OllivandersListener implements Listener
          {
             break;
          }
+
+         if (i == O2Spell.max_spell_words)
+            break;
 
          spellName.append(" ");
       }

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Player/O2Player.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Player/O2Player.java
@@ -12,7 +12,6 @@ import java.util.UUID;
 import net.pottercraft.Ollivanders2.House.O2HouseType;
 import net.pottercraft.Ollivanders2.Ollivanders2;
 import net.pottercraft.Ollivanders2.Ollivanders2API;
-import net.pottercraft.Ollivanders2.Ollivanders2Common;
 import net.pottercraft.Ollivanders2.Spell.O2SpellType;
 import net.pottercraft.Ollivanders2.Spell.O2Spell;
 import net.pottercraft.Ollivanders2.Potion.O2PotionType;
@@ -566,7 +565,7 @@ public class O2Player
     */
    public O2SpellType getWandSpell ()
    {
-      if (wandSpell == null && masterSpell != null && Ollivanders2.useNonVerbalCasting)
+      if (wandSpell == null && masterSpell != null && Ollivanders2.enableNonVerbalSpellCasting)
          return masterSpell;
 
       return wandSpell;
@@ -1057,11 +1056,11 @@ public class O2Player
          message.append("\nFind your destined wand to begin using magic.");
       else if (Ollivanders2.useHouses && !Ollivanders2API.getHouses().isSorted(pid))
          message.append("\nGet sorted in to your school house to start earning house points.");
-      else if (knownSpells.size() < 1 && Ollivanders2.useBookLearning)
+      else if (knownSpells.size() < 1 && Ollivanders2.bookLearning)
          message.append("\nFind a spell book to get started learning magic.");
       else if (knownSpells.size() < 1)
          message.append("\nTry casting a spell by saying the incantation and waving your wand.");
-      else if (knownPotions.size() < 1 && Ollivanders2.useBookLearning)
+      else if (knownPotions.size() < 1 && Ollivanders2.bookLearning)
          message.append("\nFind a potions book and a water-filled cauldron to get started brewing potions.");
       else if (knownPotions.size() < 1)
          message.append("\nTry brewing a potion by using a water-filled cauldron and the potion ingredients.");
@@ -1083,7 +1082,7 @@ public class O2Player
     */
    public void onDeath ()
    {
-      if (p.getConfig().getBoolean("deathExpLoss"))
+      if (Ollivanders2.enableDeathExpLoss)
       {
          resetSpellCount();
          resetPotionCount();

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Player/O2Player.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Player/O2Player.java
@@ -906,16 +906,7 @@ public class O2Player
          int form = 0;
 
          ArrayList<EntityType> animagusShapes = O2PlayerCommon.getAnimagusShapes();
-
-         if (Ollivanders2.mcVersionCheck())
-         {
-            form = Math.abs(pid.hashCode() % animagusShapes.size());
-         }
-         else
-         {
-            // last 2 types are MC 1.12 and higher
-            form = Math.abs(pid.hashCode() % (animagusShapes.size() - 2));
-         }
+         form = Math.abs(pid.hashCode() % animagusShapes.size());
 
          animagusForm = animagusShapes.get(form);
          if (Ollivanders2.debug)
@@ -938,7 +929,7 @@ public class O2Player
          {
             animagusColor = Ollivanders2API.common.randomHorseColor().toString();
          }
-         else if (Ollivanders2.mcVersionCheck() && animagusForm == EntityType.LLAMA)
+         else if (Ollivanders2.mcVersion > 11 && animagusForm == EntityType.LLAMA)
          {
             animagusColor = Ollivanders2API.common.randomLlamaColor().toString();
          }

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Player/O2PlayerCommon.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Player/O2PlayerCommon.java
@@ -76,7 +76,7 @@ public final class O2PlayerCommon
          animagusShapes.add(EntityType.SHULKER);
       }
 
-      if (Ollivanders2.mcVersionCheck())
+      if (Ollivanders2.mcVersion > 11)
       {
          animagusShapes.add(EntityType.POLAR_BEAR);
          animagusShapes.add(EntityType.LLAMA);

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Potion/ANIMAGUS_POTION.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Potion/ANIMAGUS_POTION.java
@@ -48,8 +48,7 @@ public final class ANIMAGUS_POTION extends O2Potion
    {
       if (!Ollivanders2.libsDisguisesEnabled)
       {
-         player.sendMessage(ChatColor.getByChar(p.getConfig().getString("chatColor"))
-               + "Nothing seems to happen.");
+         player.sendMessage(Ollivanders2.chatColor + "Nothing seems to happen.");
 
          return;
       }
@@ -61,8 +60,7 @@ public final class ANIMAGUS_POTION extends O2Potion
             Ollivanders2API.getPlayers().playerEffects.removeEffect(o2p.getID(), O2EffectType.ANIMAGUS_INCANTATION);
          }
 
-         player.sendMessage(ChatColor.getByChar(p.getConfig().getString("chatColor"))
-               + "You taste something vaguely familiar.");
+         player.sendMessage(Ollivanders2.chatColor + "You taste something vaguely familiar.");
 
          return;
       }
@@ -70,8 +68,7 @@ public final class ANIMAGUS_POTION extends O2Potion
       if (!player.getWorld().isThundering())
       {
          // potion only works in a thunderstorm
-         player.sendMessage(ChatColor.getByChar(p.getConfig().getString("chatColor"))
-               + "Nothing seems to happen.");
+         player.sendMessage(Ollivanders2.chatColor + "Nothing seems to happen.");
          return;
       }
 

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Potion/FORGETFULLNESS_POTION.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Potion/FORGETFULLNESS_POTION.java
@@ -84,6 +84,6 @@ public final class FORGETFULLNESS_POTION extends O2Potion
       if (Ollivanders2.debug)
          p.getLogger().info("Forgetfullness Potion: " + player.getDisplayName() + " lost " + memLoss + " experience  with " + lostSpell);
 
-      player.sendMessage(ChatColor.getByChar(p.getConfig().getString("chatColor")) + "It feels like you've forgotten something.");
+      player.sendMessage(Ollivanders2.chatColor + "It feels like you've forgotten something.");
    }
 }

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Potion/O2Potion.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Potion/O2Potion.java
@@ -275,7 +275,7 @@ public abstract class O2Potion implements Teachable
       Integer potionCount = o2p.getPotionCount(potionType);
 
       // do not allow them to brew if book learning is on and they do not know this potion
-      if (Ollivanders2.useBookLearning && (potionCount < 1))
+      if (Ollivanders2.bookLearning && (potionCount < 1))
       {
          brewer.sendMessage(Ollivanders2.chatColor + "You feel uncertain about how to make this potion.");
          canBrew = false;

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Spell/AVIFORS.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Spell/AVIFORS.java
@@ -34,7 +34,7 @@ public final class AVIFORS extends FriendlyMobDisguiseSuper
          add("However, mastering a Transfiguration spell such as \"Avifors\" can be both rewarding and useful.");
       }};
 
-      if (Ollivanders2.mcVersionCheck())
+      if (Ollivanders2.mcVersion > 11)
          text = "Turns target entity in to a bird.";
       else
          text = "Turns target entity in to a bat.";
@@ -54,7 +54,7 @@ public final class AVIFORS extends FriendlyMobDisguiseSuper
       spellType = O2SpellType.AVIFORS;
       setUsesModifier();
 
-      if (Ollivanders2.mcVersionCheck())
+      if (Ollivanders2.mcVersion > 11)
       {
          targetType = EntityType.PARROT;
       }
@@ -66,7 +66,7 @@ public final class AVIFORS extends FriendlyMobDisguiseSuper
       disguiseType = DisguiseType.getType(targetType);
       disguise = new MobDisguise(disguiseType);
 
-      if (Ollivanders2.mcVersionCheck())
+      if (Ollivanders2.mcVersion > 11)
       {
          ParrotWatcher watcher = (ParrotWatcher)disguise.getWatcher();
          int rand = Math.abs(Ollivanders2Common.random.nextInt() % 20);

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Spell/AVIS.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Spell/AVIS.java
@@ -35,7 +35,7 @@ public final class AVIS extends Charms
          add("\"Oh, hello, Harry ... I was just practicing.\" -Hermione Granger conjuring small golden birds just before sending them to attack Ron");
       }};
 
-      if (Ollivanders2.mcVersionCheck())
+      if (Ollivanders2.mcVersion > 11)
          text = "Causes one or more birds to fly out of the tip of your wand.";
       else
          text = "Causes one or more bats to fly out of the tip of your wand.";
@@ -67,7 +67,7 @@ public final class AVIS extends Charms
       {
          move();
 
-         if (Ollivanders2.mcVersionCheck())
+         if (Ollivanders2.mcVersion > 11)
          {
             Parrot bird = (Parrot) location.getWorld().spawnEntity(location, EntityType.PARROT);
 

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Spell/ET_INTERFICIAM_ANIMAM_LIGAVERIS.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Spell/ET_INTERFICIAM_ANIMAM_LIGAVERIS.java
@@ -93,15 +93,14 @@ public final class ET_INTERFICIAM_ANIMAM_LIGAVERIS extends DarkArts
          {
             if (souls == 0)
             {
-               player.sendMessage(ChatColor.getByChar(p.getConfig().getString("chatColor"))
-                     + "Your soul is not yet so damaged to allow this.");
+               player.sendMessage(Ollivanders2.chatColor + "Your soul is not yet so damaged to allow this.");
                return;
             }
             //If they player couldn't survive making another horcrux then they are sent back to a previous horcrux
             else if ((futureHealth - 1) <= 0)
             {
-               List<StationarySpellObj> stationarys = Ollivanders2API.getStationarySpells().getActiveStationarySpells();
-               for (StationarySpellObj stationary : stationarys)
+               List<StationarySpellObj> stationaries = Ollivanders2API.getStationarySpells().getActiveStationarySpells();
+               for (StationarySpellObj stationary : stationaries)
                {
                   if (stationary.getSpellType() == O2StationarySpellType.HORCRUX && stationary.getCasterID().equals(player.getUniqueId()))
                   {

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Spell/LEGILIMENS.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Spell/LEGILIMENS.java
@@ -197,7 +197,7 @@ public final class LEGILIMENS extends DarkArts
             // 33% chance detect mastered spell
             if (rand >= 66)
             {
-               if (Ollivanders2.useNonVerbalCasting)
+               if (Ollivanders2.enableNonVerbalSpellCasting)
                {
                   O2SpellType masteredSpell = o2p.getMasterSpell();
                   if (masteredSpell != null)

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/Spell/VOLATUS.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/Spell/VOLATUS.java
@@ -74,7 +74,7 @@ public final class VOLATUS extends Charms
     */
    public boolean isBroom (ItemStack item)
    {
-      if (item.getType() == Material.getMaterial(p.getConfig().getString("broomstick")))
+      if (item.getType() == Ollivanders2.broomstickMaterial)
       {
          ItemMeta meta = item.getItemMeta();
          if (meta.hasLore())

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/StationarySpell/ALIQUAM_FLOO.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/StationarySpell/ALIQUAM_FLOO.java
@@ -88,7 +88,7 @@ public class ALIQUAM_FLOO extends StationarySpellObj implements StationarySpell
             ItemStack stack = item.getItemStack();
             if (item.getLocation().getBlock().equals(block))
             {
-               if (stack.getType() == Material.getMaterial(p.getConfig().getString("flooPowder")))
+               if (stack.getType() == Ollivanders2.flooPowderMaterial)
                {
                   if (stack.hasItemMeta())
                   {

--- a/Ollivanders/src/net/pottercraft/Ollivanders2/StationarySpell/O2StationarySpells.java
+++ b/Ollivanders/src/net/pottercraft/Ollivanders2/StationarySpell/O2StationarySpells.java
@@ -169,15 +169,7 @@ public class O2StationarySpells
 
       if (serializedSpells == null)
       {
-         try
-         {
-            O2StationarySpells = (List<StationarySpellObj>) Ollivanders2.SLAPI.load("plugins/Ollivanders2/stationary.bin");
-            p.getLogger().info("Loaded save file stationary.bin");
-         }
-         catch (Exception e)
-         {
-            p.getLogger().warning("Did not find stationary.bin");
-         }
+         p.getLogger().warning("Did not find stationary.bin");
       }
       else
       {

--- a/Ollivanders/src/plugin.yml
+++ b/Ollivanders/src/plugin.yml
@@ -1,6 +1,6 @@
 name: Ollivanders2
 main: net.pottercraft.Ollivanders2.Ollivanders2
-version: 2.2.9
+version: 2.3
 authors: [Azami7, autumnwoz]
 website: https://www.spigotmc.org/resources/ollivanders2.38992/
 softdepend: [WorldGuard, LibsDisguises]


### PR DESCRIPTION
Bug fixes:

* added plural spelling on prophecy command
* updated mcVersionCheck to handle 1.12 and 1.13 checks
* added default config for everything that can be set in config.yml
* removed all direct access of the file config
* fixed giveFlooPowder to use correct material
* removed deprecated use of SLAPI in stationary spells (unrelated but I noticed it)