### PR TITLE
Updated to use LibsDisguises 9.9 for 1.14 support

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/O2Color.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/O2Color.java
@@ -185,9 +185,22 @@ public enum O2Color
     *
     * @return the dyeable color
     */
-   public static O2Color getRandomPrimaryDyeableColor ()
+   public static O2Color getRandomPrimaryDyeableColor()
    {
-      int rand = Math.abs(Ollivanders2Common.random.nextInt() % primaryDyeableColors.length);
+      int seed = Math.abs(Ollivanders2Common.random.nextInt());
+
+      return getRandomPrimaryDyeableColor(seed);
+   }
+
+   /**
+    * Get a random primary dyeable color - red, orange, yellow, green, blue, purple
+    *
+    * @param seed the base value that the percentile check will use
+    * @return the dyeable color
+    */
+   public static O2Color getRandomPrimaryDyeableColor(int seed)
+   {
+      int rand = Math.abs(seed) % primaryDyeableColors.length;
 
       return primaryDyeableColors[rand];
    }
@@ -197,9 +210,22 @@ public enum O2Color
     *
     * @return the dyeable color
     */
-   public static O2Color getRandomDyeableColor ()
+   public static O2Color getRandomDyeableColor()
    {
-      int rand = Math.abs(Ollivanders2Common.random.nextInt() % dyeableColors.length);
+      int seed = Math.abs(Ollivanders2Common.random.nextInt());
+
+      return getRandomDyeableColor(seed);
+   }
+
+   /**
+    * Get a random dyeable color
+    *
+    * @param seed the base value that the percentile check will use
+    * @return the dyeable color
+    */
+   public static O2Color getRandomDyeableColor(int seed)
+   {
+      int rand = Math.abs(seed) % dyeableColors.length;
 
       return dyeableColors[rand];
    }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2API.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2API.java
@@ -48,7 +48,7 @@ public class Ollivanders2API
    {
       players = new O2Players(p);
       players.loadO2Players();
-      playerCommon = new O2PlayerCommon(p);
+      playerCommon = new O2PlayerCommon();
    }
 
    static void savePlayers ()

--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2Common.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2Common.java
@@ -12,7 +12,6 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.UUID;
 
-import com.google.gson.internal.$Gson$Preconditions;
 import me.libraryaddict.disguise.disguisetypes.RabbitType;
 import net.pottercraft.ollivanders2.player.O2WandCoreType;
 import net.pottercraft.ollivanders2.player.O2WandWoodType;
@@ -20,19 +19,21 @@ import net.pottercraft.ollivanders2.spell.O2SpellType;
 import net.pottercraft.ollivanders2.potion.O2PotionType;
 
 import org.bukkit.Bukkit;
+import org.bukkit.DyeColor;
 import org.bukkit.Effect;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Cat;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Llama;
-import org.bukkit.entity.Ocelot;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.World;
-import org.bukkit.block.Block;
-import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Parrot;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -363,29 +364,63 @@ public class Ollivanders2Common
    }
 
    /**
-    * Generate a random Ocelot type.
+    * Generate a random Cat type.
     *
-    * @return the Ocelot type
+    * @return the Cat type
     */
-   public Ocelot.Type randomOcelotType ()
+   public Cat.Type getRandomCatType()
    {
-      int rand = Math.abs(random.nextInt() % 4);
+      int seed = Math.abs(random.nextInt());
 
-      Ocelot.Type type;
+      return getRandomCatType(seed);
+   }
+
+   /**
+    * Generate a random Cat type.
+    *
+    * @param seed the base value that the percentile check will use
+    * @return the Cat type
+    */
+   public Cat.Type getRandomCatType(int seed)
+   {
+      int rand = Math.abs(seed) % 11;
+
+      Cat.Type type;
 
       switch (rand)
       {
+         case 0:
+            type = Cat.Type.ALL_BLACK;
+            break;
          case 1:
-            type = Ocelot.Type.BLACK_CAT;
+            type = Cat.Type.BLACK;
             break;
          case 2:
-            type = Ocelot.Type.RED_CAT;
+            type = Cat.Type.BRITISH_SHORTHAIR;
             break;
          case 3:
-            type = Ocelot.Type.SIAMESE_CAT;
+            type = Cat.Type.CALICO;
+            break;
+         case 4:
+            type = Cat.Type.JELLIE;
+            break;
+         case 5:
+            type = Cat.Type.PERSIAN;
+            break;
+         case 6:
+            type = Cat.Type.RAGDOLL;
+            break;
+         case 7:
+            type = Cat.Type.RED;
+            break;
+         case 8:
+            type = Cat.Type.SIAMESE;
+            break;
+         case 9:
+            type = Cat.Type.TABBY;
             break;
          default:
-            type = Ocelot.Type.WILD_OCELOT;
+            type = Cat.Type.WHITE;
             break;
       }
 
@@ -397,11 +432,24 @@ public class Ollivanders2Common
     *
     * @return the type color for the rabbit
     */
-   public RabbitType randomRabbitType ()
+   public RabbitType getRandomRabbitType()
+   {
+      int seed = Math.abs(random.nextInt());
+
+      return getRandomRabbitType(seed);
+   }
+
+   /**
+    * Get a random rabbit type. Odds are 1/60 to get a Killer Bunny.
+    *
+    * @param seed the base value that the percentile check will use
+    * @return the type color for the rabbit
+    */
+   public RabbitType getRandomRabbitType(int seed)
    {
       RabbitType type;
 
-      int rand = Math.abs(random.nextInt() % 61);
+      int rand = Math.abs(seed) % 61;
 
       if (rand < 10)
          type = RabbitType.BROWN;
@@ -426,24 +474,37 @@ public class Ollivanders2Common
     *
     * @return the horse style
     */
-   public Horse.Style randomHorseStyle ()
+   public Horse.Style getRandomHorseStyle()
+   {
+      int seed = Math.abs(random.nextInt());
+
+      return getRandomHorseStyle(seed);
+   }
+
+   /**
+    * Generate a random horse style.
+    *
+    * @param seed the base value that the percentile check will use
+    * @return the horse style
+    */
+   public Horse.Style getRandomHorseStyle(int seed)
    {
       Horse.Style style;
 
-      int rand = Math.abs(random.nextInt() % 20);
+      int rand = Math.abs(seed) % 20;
 
       switch (rand)
       {
-         case 1:
+         case 0:
             style = Horse.Style.WHITE;
             break;
-         case 2:
+         case 1:
             style = Horse.Style.WHITE_DOTS;
             break;
-         case 3:
+         case 2:
             style = Horse.Style.WHITEFIELD;
             break;
-         case 4:
+         case 3:
             style = Horse.Style.BLACK_DOTS;
             break;
          default:
@@ -459,30 +520,43 @@ public class Ollivanders2Common
     *
     * @return the color
     */
-   public Horse.Color randomHorseColor ()
+   public Horse.Color getRandomHorseColor()
+   {
+      int seed = Math.abs(random.nextInt());
+
+      return getRandomHorseColor(seed);
+   }
+
+   /**
+    * Generate a random horse color.
+    *
+    * @param seed the base value that the percentile check will use
+    * @return the color
+    */
+   public Horse.Color getRandomHorseColor(int seed)
    {
       Horse.Color color;
 
-      int rand = Math.abs(random.nextInt() % 7);
+      int rand = Math.abs(seed) % 7;
 
       switch (rand)
       {
-         case 1:
+         case 0:
             color = Horse.Color.BLACK;
             break;
-         case 2:
+         case 1:
             color = Horse.Color.BROWN;
             break;
-         case 3:
+         case 2:
             color = Horse.Color.CHESTNUT;
             break;
-         case 4:
+         case 3:
             color = Horse.Color.CREAMY;
             break;
-         case 5:
+         case 4:
             color = Horse.Color.DARK_BROWN;
             break;
-         case 6:
+         case 5:
             color = Horse.Color.GRAY;
             break;
          default:
@@ -498,21 +572,34 @@ public class Ollivanders2Common
     *
     * @return the color
     */
-   public Llama.Color randomLlamaColor ()
+   public Llama.Color getRandomLlamaColor()
+   {
+      int seed = Math.abs(random.nextInt());
+
+      return getRandomLlamaColor(seed);
+   }
+
+   /**
+    * Generate random llama color.
+    *
+    * @param seed the base value that the percentile check will use
+    * @return the color
+    */
+   public Llama.Color getRandomLlamaColor(int seed)
    {
       Llama.Color color;
 
-      int rand = Math.abs(random.nextInt() % 4);
+      int rand = Math.abs(seed) % 4;
 
       switch (rand)
       {
-         case 1:
+         case 0:
             color = Llama.Color.BROWN;
             break;
-         case 2:
+         case 1:
             color = Llama.Color.CREAMY;
             break;
-         case 3:
+         case 2:
             color = Llama.Color.GRAY;
             break;
          default:
@@ -524,13 +611,96 @@ public class Ollivanders2Common
    }
 
    /**
+    * Genenrate a random parrot color.
+    *
+    * @return the color
+    */
+   public Parrot.Variant getRandomParrotColor()
+   {
+      int seed = Math.abs(random.nextInt());
+
+      return getRandomParrotColor(seed);
+   }
+
+   /**
+    * Genenrate a random parrot color.
+    *
+    * @param seed the base value that the percentile check will use
+    * @return the color
+    */
+   public Parrot.Variant getRandomParrotColor(int seed)
+   {
+      Parrot.Variant variant;
+
+      int rand = Math.abs(seed) % 5;
+
+      switch (rand)
+      {
+         case 0:
+            variant = Parrot.Variant.CYAN;
+            break;
+         case 1:
+            variant = Parrot.Variant.GRAY;
+            break;
+         case 2:
+            variant = Parrot.Variant.BLUE;
+            break;
+         case 3:
+            variant = Parrot.Variant.GREEN;
+            break;
+         default:
+            variant = Parrot.Variant.RED;
+      }
+
+      return variant;
+   }
+
+   /**
+    * Generate a random natural sheep color
+    *
+    * @return the color
+    */
+   public DyeColor getRandomNaturalSheepColor()
+   {
+      int seed = Math.abs(random.nextInt());
+
+      return getRandomNaturalSheepColor(seed);
+   }
+
+   /**
+    * Generate a random natural sheep color
+    *
+    * @param seed the base value that the percentile check will use
+    * @return the color
+    */
+   public DyeColor getRandomNaturalSheepColor(int seed)
+   {
+      int rand = Math.abs(seed) % 100;
+
+      if (rand < 2) // 2% chance
+      {
+         return DyeColor.BLACK;
+      }
+      else if (rand < 22) // 20% chance
+      {
+         return DyeColor.BROWN;
+      }
+      else if (rand < 32) // 10% chance
+      {
+         return DyeColor.LIGHT_GRAY;
+      }
+      else
+         return DyeColor.WHITE;
+   }
+
+   /**
     * Gets all entities within a radius of a specific location
     *
     * @param location the location to search for entities from
-    * @param radius - radius within which to get entities
+    * @param radius   - radius within which to get entities
     * @return List of entities within the radius
     */
-   public Collection<Entity> getEntitiesInRadius (Location location, double radius)
+   public Collection<Entity> getEntitiesInRadius(Location location, double radius)
    {
       return getEntitiesInBounds(location, radius, radius, radius);
    }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/ANIMAGUS_EFFECT.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/ANIMAGUS_EFFECT.java
@@ -209,7 +209,7 @@ public class ANIMAGUS_EFFECT extends ShapeShiftSuper
       }
       else if (watcher instanceof PolarBearWatcher)
       {
-         ((PolarBearWatcher) watcher).setStanding(true);
+         ((PolarBearWatcher) watcher).setStanding(false);
       }
       else if (watcher instanceof CreeperWatcher)
       {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/ANIMAGUS_EFFECT.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/ANIMAGUS_EFFECT.java
@@ -6,20 +6,32 @@ import me.libraryaddict.disguise.disguisetypes.RabbitType;
 import me.libraryaddict.disguise.disguisetypes.watchers.AgeableWatcher;
 import me.libraryaddict.disguise.disguisetypes.watchers.HorseWatcher;
 import me.libraryaddict.disguise.disguisetypes.watchers.LlamaWatcher;
-import me.libraryaddict.disguise.disguisetypes.watchers.OcelotWatcher;
 import me.libraryaddict.disguise.disguisetypes.watchers.RabbitWatcher;
 import me.libraryaddict.disguise.disguisetypes.watchers.WolfWatcher;
+import me.libraryaddict.disguise.disguisetypes.watchers.CatWatcher;
+import me.libraryaddict.disguise.disguisetypes.watchers.PandaWatcher;
+import me.libraryaddict.disguise.disguisetypes.watchers.PolarBearWatcher;
+import me.libraryaddict.disguise.disguisetypes.watchers.CreeperWatcher;
+import me.libraryaddict.disguise.disguisetypes.watchers.FoxWatcher;
+import me.libraryaddict.disguise.disguisetypes.watchers.PigWatcher;
+import me.libraryaddict.disguise.disguisetypes.watchers.SheepWatcher;
+import me.libraryaddict.disguise.disguisetypes.watchers.SlimeWatcher;
+import me.libraryaddict.disguise.disguisetypes.watchers.SpiderWatcher;
+import me.libraryaddict.disguise.disguisetypes.watchers.ShulkerWatcher;
+import me.libraryaddict.disguise.disguisetypes.watchers.TurtleWatcher;
+import me.libraryaddict.disguise.disguisetypes.watchers.TraderLlamaWatcher;
 
+import net.pottercraft.ollivanders2.O2Color;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
 import net.pottercraft.ollivanders2.player.O2Player;
 
 import org.bukkit.DyeColor;
-import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Cat;
+import org.bukkit.entity.Fox;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.Llama;
-import org.bukkit.entity.Ocelot;
-import org.bukkit.entity.Player;
+import org.bukkit.entity.Panda;
 
 /**
  * Transforms an Animagus player in to their animal form.
@@ -85,49 +97,52 @@ public class ANIMAGUS_EFFECT extends ShapeShiftSuper
    @Override
    protected void customizeWatcher ()
    {
-      if (form == EntityType.OCELOT)
+      // in case the variant doesn't work, this can be used to fix the value at the end of this method
+      String correctedVariant = null;
+
+      if (watcher instanceof CatWatcher)
       {
-         OcelotWatcher ocelotWatcher = (OcelotWatcher)watcher;
-         Ocelot.Type type = Ocelot.Type.WILD_OCELOT;
-         ocelotWatcher.isAdult();
+         CatWatcher catWatcher = (CatWatcher) watcher;
+         Cat.Type color = Cat.Type.WHITE;
 
          try
          {
-            type = Ocelot.Type.valueOf(colorVariant);
+            color = Cat.Type.valueOf(colorVariant);
          }
          catch (Exception e)
          {
-            p.getLogger().warning("Failed to parse Ocelot.Type " + colorVariant);
+            p.getLogger().warning("Failed to parse Cat.Type " + colorVariant);
             if (Ollivanders2.debug)
                e.printStackTrace();
+
+            correctedVariant = color.toString();
          }
 
-         ocelotWatcher.setType(type);
+         catWatcher.setType(color);
+         catWatcher.setCollarColor(O2Color.getRandomPrimaryDyeableColor().getDyeColor());
       }
-      else if (form == EntityType.RABBIT)
+      else if (watcher instanceof RabbitWatcher)
       {
-         RabbitWatcher rabbitWatcher = (RabbitWatcher)watcher;
-         RabbitType type = RabbitType.WHITE;
-         rabbitWatcher.isAdult();
+         RabbitType color = RabbitType.WHITE;
 
          try
          {
-            type = RabbitType.valueOf(colorVariant);
+            color = RabbitType.valueOf(colorVariant);
          }
          catch (Exception e)
          {
             p.getLogger().warning("Failed to parse Rabbit.Type " + colorVariant);
             if (Ollivanders2.debug)
                e.printStackTrace();
+
+            correctedVariant = color.toString();
          }
 
-         rabbitWatcher.setType(type);
+         ((RabbitWatcher) watcher).setType(color);
       }
-      else if (form == EntityType.WOLF)
+      else if (watcher instanceof WolfWatcher)
       {
-         WolfWatcher wolfWatcher = (WolfWatcher)watcher;
          DyeColor color = DyeColor.WHITE;
-         wolfWatcher.isAdult();
 
          try
          {
@@ -138,17 +153,16 @@ public class ANIMAGUS_EFFECT extends ShapeShiftSuper
             p.getLogger().warning("Failed to parse DyeColor " + colorVariant);
             if (Ollivanders2.debug)
                e.printStackTrace();
+
+            correctedVariant = color.toString();
          }
 
-         wolfWatcher.isTamed();
-         wolfWatcher.setCollarColor(color);
+         ((WolfWatcher) watcher).isTamed();
+         ((WolfWatcher) watcher).setCollarColor(color);
       }
-      else if (form == EntityType.HORSE)
+      else if (watcher instanceof HorseWatcher)
       {
-         HorseWatcher horseWatcher = (HorseWatcher)watcher;
-         horseWatcher.setStyle(Horse.Style.NONE);
          Horse.Color color = Horse.Color.WHITE;
-         horseWatcher.setBaby();
 
          try
          {
@@ -159,15 +173,16 @@ public class ANIMAGUS_EFFECT extends ShapeShiftSuper
             p.getLogger().warning("Failed to parse Horse.Color " + colorVariant);
             if (Ollivanders2.debug)
                e.printStackTrace();
+
+            correctedVariant = color.toString();
          }
 
-         horseWatcher.setColor(color);
+         ((HorseWatcher) watcher).setColor(color);
+         ((HorseWatcher) watcher).setStyle(Horse.Style.NONE);
       }
-      else if (form == EntityType.LLAMA)
+      else if (watcher instanceof LlamaWatcher || watcher instanceof TraderLlamaWatcher)
       {
-         LlamaWatcher llamaWatcher = (LlamaWatcher) watcher;
          Llama.Color color = Llama.Color.WHITE;
-         llamaWatcher.setBaby();
 
          try
          {
@@ -178,13 +193,113 @@ public class ANIMAGUS_EFFECT extends ShapeShiftSuper
             p.getLogger().warning("Failed to parse Llama.Color " + colorVariant);
             if (Ollivanders2.debug)
                e.printStackTrace();
+
+            correctedVariant = color.toString();
          }
 
-         llamaWatcher.setColor(color);
-      } else if (form == EntityType.COW || form == EntityType.DONKEY || form == EntityType.MULE || form == EntityType.SLIME || form == EntityType.POLAR_BEAR)
+         if (watcher instanceof LlamaWatcher)
+            ((LlamaWatcher) watcher).setColor(color);
+         else
+            ((TraderLlamaWatcher) watcher).setColor(color);
+      }
+      else if (watcher instanceof PandaWatcher)
       {
-         AgeableWatcher ageableWatcher = (AgeableWatcher) watcher;
-         ageableWatcher.setBaby();
+         ((PandaWatcher) watcher).setMainGene(Panda.Gene.NORMAL);
+         ((PandaWatcher) watcher).setSitting(false);
+      }
+      else if (watcher instanceof PolarBearWatcher)
+      {
+         ((PolarBearWatcher) watcher).setStanding(true);
+      }
+      else if (watcher instanceof CreeperWatcher)
+      {
+         ((CreeperWatcher) watcher).setIgnited(false);
+         ((CreeperWatcher) watcher).setPowered(false);
+      }
+      else if (watcher instanceof FoxWatcher)
+      {
+         Fox.Type color = Fox.Type.RED;
+
+         try
+         {
+            color = Fox.Type.valueOf(colorVariant);
+         }
+         catch (Exception e)
+         {
+            p.getLogger().warning("Failed to parse Fox.Type " + colorVariant);
+            if (Ollivanders2.debug)
+               e.printStackTrace();
+
+            correctedVariant = color.toString();
+         }
+
+         ((FoxWatcher) watcher).setType(color);
+         ((FoxWatcher) watcher).setSitting(false);
+      }
+      else if (watcher instanceof PigWatcher)
+      {
+         ((PigWatcher) watcher).setSaddled(false);
+      }
+      else if (watcher instanceof SheepWatcher)
+      {
+         DyeColor color = DyeColor.WHITE;
+
+         try
+         {
+            color = DyeColor.valueOf(colorVariant);
+         }
+         catch (Exception e)
+         {
+            p.getLogger().warning("Failed to parse DyeColor " + colorVariant);
+            if (Ollivanders2.debug)
+               e.printStackTrace();
+
+            correctedVariant = color.toString();
+         }
+
+         ((SheepWatcher) watcher).setColor(color);
+      }
+      else if (watcher instanceof SlimeWatcher)
+      {
+         ((SlimeWatcher) watcher).setSize(1);
+      }
+      else if (watcher instanceof SpiderWatcher)
+      {
+         ((SpiderWatcher) watcher).setClimbing(false);
+      }
+      else if (watcher instanceof ShulkerWatcher)
+      {
+         DyeColor color = DyeColor.WHITE;
+
+         try
+         {
+            color = DyeColor.valueOf(colorVariant);
+         }
+         catch (Exception e)
+         {
+            p.getLogger().warning("Failed to parse DyeColor " + colorVariant);
+            if (Ollivanders2.debug)
+               e.printStackTrace();
+
+            correctedVariant = color.toString();
+         }
+
+         ((ShulkerWatcher) watcher).setColor(color);
+      }
+      else if (watcher instanceof TurtleWatcher)
+      {
+         ((TurtleWatcher) watcher).setEgg(false);
+      }
+
+      if (watcher instanceof AgeableWatcher)
+      {
+         ((AgeableWatcher) watcher).setAdult();
+      }
+
+      // fix player's animagus color variant if needed
+      if (correctedVariant != null)
+      {
+         Ollivanders2API.getPlayers().fixPlayerAnimagusColorVariant(targetID, correctedVariant);
       }
    }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Player.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Player.java
@@ -1132,12 +1132,11 @@ public class O2Player
     */
    private void fixOcelotAnimagus()
    {
-      if (animagusForm != EntityType.OCELOT || animagusColor == null)
+      if (animagusForm != EntityType.OCELOT)
          return;
 
-      if (animagusColor.contains("OCELOT"))
+      if (animagusColor != null && animagusColor.contains("OCELOT"))
       {
-         animagusForm = EntityType.OCELOT;
          animagusColor = null;
          return;
       }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Player.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Player.java
@@ -1123,26 +1123,40 @@ public class O2Player
       // MC split Cat from Ocelot so now players that were actually Cats are not anymore
       if (animagusForm == EntityType.OCELOT)
       {
-         if (animagusColor != null)
+         fixOcelotAnimagus();
+      }
+   }
+
+   /**
+    * Fix where a player's animagus form is actually a Cat but is saved as Ocelot from pre-MC 1.14
+    */
+   private void fixOcelotAnimagus()
+   {
+      if (animagusForm != EntityType.OCELOT || animagusColor == null)
+         return;
+
+      if (animagusColor.contains("OCELOT"))
+      {
+         animagusForm = EntityType.OCELOT;
+         animagusColor = null;
+         return;
+      }
+
+      animagusForm = EntityType.CAT;
+      Cat.Type color = Cat.Type.WHITE;
+
+      try
+      {
+         color = Cat.Type.valueOf(animagusColor);
+      }
+      catch (Exception e)
+      {
+         if (Ollivanders2.debug)
          {
-            // they are actually a cat because we dont set this for wild Ocelots
-            animagusForm = EntityType.CAT;
-            Cat.Type color = Cat.Type.WHITE;
-
-            try
-            {
-               color = Cat.Type.valueOf(animagusColor);
-            }
-            catch (Exception e)
-            {
-               if (Ollivanders2.debug)
-               {
-                  p.getLogger().info("O2Player.fix() - invalid Cat.Type " + animagusColor);
-               }
-            }
-
-            animagusColor = color.toString();
+            p.getLogger().info("O2Player.fix() - invalid Cat.Type " + animagusColor);
          }
       }
+
+      animagusColor = color.toString();
    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Player.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Player.java
@@ -1132,10 +1132,10 @@ public class O2Player
     */
    private void fixOcelotAnimagus()
    {
-      if (animagusForm != EntityType.OCELOT)
+      if (animagusForm != EntityType.OCELOT || animagusForm == null)
          return;
 
-      if (animagusColor != null && animagusColor.contains("OCELOT"))
+      if (animagusColor.contains("OCELOT"))
       {
          animagusColor = null;
          return;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Player.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Player.java
@@ -18,7 +18,9 @@ import net.pottercraft.ollivanders2.spell.O2Spell;
 import net.pottercraft.ollivanders2.potion.O2PotionType;
 
 import org.bukkit.Material;
+import org.bukkit.entity.Cat;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Fox;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
 
@@ -140,18 +142,21 @@ public class O2Player
     */
    private Year year = Year.YEAR_1;
 
+   private O2PlayerCommon o2PlayerCommon;
+
    /**
     * Constructor.
     *
-    * @param id the UUID of the player
-    * @param name the name of the player
+    * @param id     the UUID of the player
+    * @param name   the name of the player
     * @param plugin a reference to the plugin
     */
-   public O2Player (UUID id, String name, Ollivanders2 plugin)
+   public O2Player(UUID id, String name, Ollivanders2 plugin)
    {
       p = plugin;
       playerName = name;
       pid = id;
+      o2PlayerCommon = new O2PlayerCommon();
 
       // set destined wand
       initDestinedWand();
@@ -356,7 +361,10 @@ public class O2Player
     *
     * @return a map of all recent spells and the time they were cast.
     */
-   public Map<O2SpellType, Long> getRecentSpells () { return recentSpells; }
+   public Map<O2SpellType, Long> getRecentSpells()
+   {
+      return recentSpells;
+   }
 
    /**
     * Set the spell count for a spell. This will override the existing values for this spell and should
@@ -635,14 +643,20 @@ public class O2Player
     *
     * @return true if they are a muggle, false otherwise
     */
-   public boolean isMuggle () { return muggle; }
+   public boolean isMuggle()
+   {
+      return muggle;
+   }
 
    /**
     * Set if a player is a muggle.
     *
     * @param isMuggle true if the player is a muggle
     */
-   public void setMuggle (boolean isMuggle) { muggle = isMuggle; }
+   public void setMuggle(boolean isMuggle)
+   {
+      muggle = isMuggle;
+   }
 
    /**
     * Get the number of souls this player has collected.
@@ -693,10 +707,13 @@ public class O2Player
 
    /**
     * Set the year this player is in.
+    *
     * @param y The year to set them to
     */
-   public void setYear(Year y) {
-      if (year != null) {
+   public void setYear(Year y)
+   {
+      if (year != null)
+      {
          year = y;
       }
    }
@@ -904,41 +921,48 @@ public class O2Player
    {
       if (animagusForm == null)
       {
-         int form = 0;
-
-         ArrayList<EntityType> animagusShapes = O2PlayerCommon.getAnimagusShapes();
-         form = Math.abs(pid.hashCode() % animagusShapes.size());
-
-         animagusForm = animagusShapes.get(form);
-         if (Ollivanders2.debug)
-            p.getLogger().info(playerName + " is an animagus type " + animagusForm.toString());
+         animagusForm = o2PlayerCommon.getAnimagusForm(pid);
 
          // determine color variations for certain types
-         if (animagusForm == EntityType.OCELOT)
+         if (animagusForm == EntityType.CAT)
          {
-            animagusColor = Ollivanders2API.common.randomOcelotType().toString();
+            animagusColor = Ollivanders2API.common.getRandomCatType(pid.hashCode()).toString();
          }
-         else if(animagusForm == EntityType.RABBIT)
+         else if (animagusForm == EntityType.RABBIT)
          {
-            animagusColor = Ollivanders2API.common.randomRabbitType().toString();
+            animagusColor = Ollivanders2API.common.getRandomRabbitType(pid.hashCode()).toString();
          }
-         else if (animagusForm == EntityType.WOLF)
+         else if (animagusForm == EntityType.WOLF || animagusForm == EntityType.SHULKER)
          {
-            animagusColor = O2Color.getRandomPrimaryDyeableColor().getDyeColor().toString();
+            animagusColor = O2Color.getRandomPrimaryDyeableColor(pid.hashCode()).getDyeColor().toString();
          }
          else if (animagusForm == EntityType.HORSE)
          {
-            animagusColor = Ollivanders2API.common.randomHorseColor().toString();
+            animagusColor = Ollivanders2API.common.getRandomHorseColor(pid.hashCode()).toString();
          }
          else if (animagusForm == EntityType.LLAMA)
          {
-            animagusColor = Ollivanders2API.common.randomLlamaColor().toString();
+            animagusColor = Ollivanders2API.common.getRandomLlamaColor(pid.hashCode()).toString();
+         }
+         else if (animagusForm == EntityType.FOX)
+         {
+            if ((pid.hashCode() % 10) == 1)
+               animagusColor = Fox.Type.SNOW.toString();
+            else
+               animagusColor = Fox.Type.RED.toString();
+         }
+         else if (animagusForm == EntityType.SHEEP)
+         {
+            animagusColor = Ollivanders2API.common.getRandomNaturalSheepColor(pid.hashCode()).toString();
          }
 
          if (animagusColor != null && Ollivanders2.debug)
          {
             p.getLogger().info("Color variation " + animagusColor);
          }
+
+         if (Ollivanders2.debug)
+            p.getLogger().info(playerName + " is an animagus type " + animagusForm.toString());
       }
    }
 
@@ -949,9 +973,7 @@ public class O2Player
     */
    public void setAnimagusForm (EntityType type)
    {
-      ArrayList<EntityType> animagusShapes = O2PlayerCommon.getAnimagusShapes();
-
-      if (animagusShapes.contains(type))
+      if (o2PlayerCommon.isAllowedAnimagusForm(type))
       {
          animagusForm = type;
       }
@@ -964,7 +986,12 @@ public class O2Player
       }
    }
 
-   void setAnimagusColor (String color)
+   /**
+    * Set the player's animagus color
+    *
+    * @param color the color/type as a string
+    */
+   void setAnimagusColor(String color)
    {
       animagusColor = color;
    }
@@ -1072,7 +1099,7 @@ public class O2Player
    /**
     * Do player onDeath actions
     */
-   public void onDeath ()
+   public void onDeath()
    {
       if (Ollivanders2.enableDeathExpLoss)
       {
@@ -1083,5 +1110,39 @@ public class O2Player
       }
 
       setWandSpell(null);
+   }
+
+   /**
+    * Called after a player's data has been read from save to fix changes made to the plugin between versions.
+    */
+   protected void fix()
+   {
+      //
+      // animagus form was an ocelot
+      //
+      // MC split Cat from Ocelot so now players that were actually Cats are not anymore
+      if (animagusForm == EntityType.OCELOT)
+      {
+         if (animagusColor != null)
+         {
+            // they are actually a cat because we dont set this for wild Ocelots
+            animagusForm = EntityType.CAT;
+            Cat.Type color = Cat.Type.WHITE;
+
+            try
+            {
+               color = Cat.Type.valueOf(animagusColor);
+            }
+            catch (Exception e)
+            {
+               if (Ollivanders2.debug)
+               {
+                  p.getLogger().info("O2Player.fix() - invalid Cat.Type " + animagusColor);
+               }
+            }
+
+            animagusColor = color.toString();
+         }
+      }
    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/player/O2PlayerCommon.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/player/O2PlayerCommon.java
@@ -2,6 +2,7 @@ package net.pottercraft.ollivanders2.player;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
@@ -12,61 +13,57 @@ import org.bukkit.inventory.ItemStack;
 
 public final class O2PlayerCommon
 {
-   private Ollivanders2 p;
-
-   public O2PlayerCommon (Ollivanders2 plugin)
+   public O2PlayerCommon()
    {
-      p = plugin;
+
    }
+
+   private static ArrayList<EntityType> commonAnimagusShapes = new ArrayList<EntityType>()
+   {{
+      add(EntityType.COW);
+      add(EntityType.PIG);
+      add(EntityType.HORSE);
+      add(EntityType.SHEEP);
+      add(EntityType.RABBIT);
+      add(EntityType.MULE);
+      add(EntityType.DONKEY);
+      add(EntityType.CAT);
+      add(EntityType.WOLF);
+      add(EntityType.LLAMA);
+      add(EntityType.FOX);
+   }};
+
+   private static ArrayList<EntityType> rareAnimagusShapes = new ArrayList<EntityType>()
+   {{
+      add(EntityType.OCELOT);
+      add(EntityType.POLAR_BEAR);
+      add(EntityType.TRADER_LLAMA);
+      add(EntityType.PANDA);
+      add(EntityType.TURTLE);
+   }};
+
+   private static ArrayList<EntityType> hostileAnimagusShapes = new ArrayList<EntityType>()
+   {{
+      add(EntityType.SPIDER);
+      add(EntityType.SLIME);
+      add(EntityType.CAVE_SPIDER);
+      add(EntityType.CREEPER);
+      add(EntityType.SILVERFISH);
+      add(EntityType.SHULKER);
+   }};
 
    static String wandLoreConjunction = " and ";
 
    /**
-    * Get all possible animagus shapes
-    *
-    * @return a list of all possible EntityTypes for animagus form
-    */
-   static ArrayList<EntityType> getAnimagusShapes ()
-   {
-      ArrayList<EntityType> animagusShapes = new ArrayList<>();
-
-      animagusShapes.add(EntityType.OCELOT);
-      animagusShapes.add(EntityType.WOLF);
-      animagusShapes.add(EntityType.COW);
-      animagusShapes.add(EntityType.PIG);
-      animagusShapes.add(EntityType.HORSE);
-      animagusShapes.add(EntityType.SHEEP);
-      animagusShapes.add(EntityType.RABBIT);
-      animagusShapes.add(EntityType.MULE);
-      animagusShapes.add(EntityType.DONKEY);
-      animagusShapes.add(EntityType.POLAR_BEAR);
-      animagusShapes.add(EntityType.LLAMA);
-
-      if (Ollivanders2.useHostileMobAnimagi)
-      {
-         animagusShapes.add(EntityType.SPIDER);
-         animagusShapes.add(EntityType.SLIME);
-         animagusShapes.add(EntityType.CAVE_SPIDER);
-         animagusShapes.add(EntityType.CREEPER);
-         animagusShapes.add(EntityType.EVOKER);
-         animagusShapes.add(EntityType.HUSK);
-         animagusShapes.add(EntityType.SILVERFISH);
-         animagusShapes.add(EntityType.WITCH);
-         animagusShapes.add(EntityType.VINDICATOR);
-         animagusShapes.add(EntityType.SHULKER);
-      }
-
-      return animagusShapes;
-   }
-
-
-   /**
     * Take an integer and get the corresponding year
+    *
     * @param year The year; must be between 1 and 7
     * @return The corresponding year or null if invalid input
     */
-   public static Year intToYear(int year) {
-      switch (year) {
+   public static Year intToYear(int year)
+   {
+      switch (year)
+      {
          case 1:
             return Year.YEAR_1;
          case 2:
@@ -87,12 +84,60 @@ public final class O2PlayerCommon
    }
 
    /**
+    * Get the animagus form for this player
+    *
+    * @return a list of all possible EntityTypes for animagus form
+    */
+   public EntityType getAnimagusForm(UUID pid)
+   {
+      // 1% chance to get a rare form
+      int form = Math.abs(pid.hashCode() % 100);
+      if (form > 0)
+      {
+         form = Math.abs(pid.hashCode() % rareAnimagusShapes.size());
+         return rareAnimagusShapes.get(form);
+      }
+
+      // if using hostile mob animagi, 10% chance of getting a hostile mob form
+      form = Math.abs(pid.hashCode() % 25);
+      if (form > 24)
+      {
+         form = Math.abs(pid.hashCode() % hostileAnimagusShapes.size());
+         return hostileAnimagusShapes.get(form);
+      }
+
+      // equal chance for common forms
+      form = Math.abs(pid.hashCode() % commonAnimagusShapes.size());
+      return commonAnimagusShapes.get(form);
+   }
+
+   /**
+    * Determine if an EntityType is an allowed Animagus form.
+    *
+    * @param form the animagus form to check
+    * @return true if this is an allowed form, false otherwise
+    */
+   public boolean isAllowedAnimagusForm(EntityType form)
+   {
+      if (Ollivanders2.useHostileMobAnimagi)
+      {
+         if (hostileAnimagusShapes.contains(form))
+            return true;
+      }
+
+      if (rareAnimagusShapes.contains(form))
+         return true;
+
+      return commonAnimagusShapes.contains(form);
+   }
+
+   /**
     * Does the player hold a wand item in their primary hand?
     *
     * @param player player to check.
     * @return True if the player holds a wand. False if not or if player is null.
     */
-   public boolean holdsWand (Player player)
+   public boolean holdsWand(Player player)
    {
       return holdsWand(player, EquipmentSlot.HAND);
    }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Players.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Players.java
@@ -550,6 +550,8 @@ public class O2Players
             }
          }
 
+         o2p.fix();
+
          deserializedMap.put(pid, o2p);
          recordCount++;
       }
@@ -597,5 +599,17 @@ public class O2Players
       Integer count = Ollivanders2API.common.integerFromString(value);
       if (count != null)
          o2p.setPotionCount(potionType, count);
+   }
+
+   /**
+    * Correct a player's animagus color form - for use when valueOf() on the current value fails
+    *
+    * @param pid              the player to correct
+    * @param correctedVariant the corrected value
+    */
+   public void fixPlayerAnimagusColorVariant(UUID pid, String correctedVariant)
+   {
+      O2Player player = getPlayer(pid);
+      player.setAnimagusColor(correctedVariant);
    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/AVIFORS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/AVIFORS.java
@@ -5,9 +5,7 @@ import me.libraryaddict.disguise.disguisetypes.MobDisguise;
 import me.libraryaddict.disguise.disguisetypes.watchers.ParrotWatcher;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
 import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Parrot;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
@@ -60,27 +58,7 @@ public final class AVIFORS extends FriendlyMobDisguise
       disguise = new MobDisguise(disguiseType);
 
       ParrotWatcher watcher = (ParrotWatcher)disguise.getWatcher();
-      int rand = Math.abs(Ollivanders2Common.random.nextInt() % 20);
-      if (rand > 18)
-      {
-         watcher.setVariant(Parrot.Variant.GRAY);
-      }
-      else if (rand > 14)
-      {
-         watcher.setVariant(Parrot.Variant.GREEN);
-      }
-      else if (rand > 11)
-      {
-         watcher.setVariant(Parrot.Variant.CYAN);
-      }
-      else if (rand > 6)
-      {
-         watcher.setVariant(Parrot.Variant.BLUE);
-      }
-      else
-      {
-         watcher.setVariant(Parrot.Variant.RED);
-      }
+      watcher.setVariant(common.getRandomParrotColor());
 
       watcher.setFlyingWithElytra(true);
    }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/AVIS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/AVIS.java
@@ -7,7 +7,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.Parrot;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
 
 import java.util.ArrayList;
 
@@ -85,19 +84,7 @@ public final class AVIS extends O2Spell
       {
          Parrot bird = (Parrot) location.getWorld().spawnEntity(location, EntityType.PARROT);
 
-         int rand = Math.abs(Ollivanders2Common.random.nextInt() % 5);
-         Parrot.Variant variant;
-         if (rand == 0)
-            variant = Parrot.Variant.CYAN;
-         else if (rand == 1)
-            variant = Parrot.Variant.GRAY;
-         else if (rand == 2)
-            variant = Parrot.Variant.BLUE;
-         else if (rand == 3)
-            variant = Parrot.Variant.GREEN;
-         else
-            variant = Parrot.Variant.RED;
-         bird.setVariant(variant);
+         bird.setVariant(common.getRandomParrotColor());
 
          birdCount++;
       }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/EQUUSIFORS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/EQUUSIFORS.java
@@ -50,12 +50,12 @@ public final class EQUUSIFORS extends FriendlyMobDisguise
       disguiseType = DisguiseType.getType(targetType);
       disguise = new MobDisguise(disguiseType);
 
-      HorseWatcher watcher = (HorseWatcher)disguise.getWatcher();
+      HorseWatcher watcher = (HorseWatcher) disguise.getWatcher();
       watcher.setAdult();
 
       // randomize appearance
       Ollivanders2Common common = new Ollivanders2Common(p);
-      watcher.setStyle(common.randomHorseStyle());
-      watcher.setColor(common.randomHorseColor());
+      watcher.setStyle(common.getRandomHorseStyle());
+      watcher.setColor(common.getRandomHorseColor());
    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_DEVITO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_DEVITO.java
@@ -10,7 +10,7 @@ import org.bukkit.entity.Player;
 
 /**
  * Created by Azami7 on 6/28/17.
- * <p>
+ *
  * Turn target player in to a chicken.
  *
  * @author Azami7

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_EQUUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_EQUUS.java
@@ -59,7 +59,7 @@ public final class INCARNATIO_EQUUS extends PlayerDisguise
       // randomize appearance
       Ollivanders2Common common = new Ollivanders2Common(p);
 
-      watcher.setStyle(common.randomHorseStyle());
-      watcher.setColor(common.randomHorseColor());
+      watcher.setStyle(common.getRandomHorseStyle());
+      watcher.setColor(common.getRandomHorseColor());
    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_FELIS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_FELIS.java
@@ -2,7 +2,7 @@ package net.pottercraft.ollivanders2.spell;
 
 import me.libraryaddict.disguise.disguisetypes.DisguiseType;
 import me.libraryaddict.disguise.disguisetypes.MobDisguise;
-import me.libraryaddict.disguise.disguisetypes.watchers.OcelotWatcher;
+import me.libraryaddict.disguise.disguisetypes.watchers.CatWatcher;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2Common;
@@ -36,8 +36,8 @@ public final class INCARNATIO_FELIS extends PlayerDisguise
    /**
     * Constructor.
     *
-    * @param plugin a callback to the MC plugin
-    * @param player the player who cast this spell
+    * @param plugin    a callback to the MC plugin
+    * @param player    the player who cast this spell
     * @param rightWand which wand the player was using
     */
    public INCARNATIO_FELIS(Ollivanders2 plugin, Player player, Double rightWand)
@@ -50,15 +50,15 @@ public final class INCARNATIO_FELIS extends PlayerDisguise
       initSpell();
       calculateSuccessRate();
 
-      targetType = EntityType.OCELOT;
+      targetType = EntityType.CAT;
       disguiseType = DisguiseType.getType(targetType);
       disguise = new MobDisguise(disguiseType);
 
-      OcelotWatcher watcher = (OcelotWatcher) disguise.getWatcher();
+      CatWatcher watcher = (CatWatcher) disguise.getWatcher();
       watcher.setAdult();
 
       Ollivanders2Common common = new Ollivanders2Common(p);
-      watcher.setType(common.randomOcelotType());
+      watcher.setType(common.getRandomCatType());
 
       int rand = Ollivanders2Common.random.nextInt() % 10;
       if (rand == 0)

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_LAMA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_LAMA.java
@@ -57,6 +57,6 @@ public final class INCARNATIO_LAMA extends PlayerDisguise
       watcher.setAdult();
 
       Ollivanders2Common common = new Ollivanders2Common(p);
-      watcher.setColor(common.randomLlamaColor());
+      watcher.setColor(common.getRandomLlamaColor());
    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_URSUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_URSUS.java
@@ -2,10 +2,14 @@ package net.pottercraft.ollivanders2.spell;
 
 import me.libraryaddict.disguise.disguisetypes.DisguiseType;
 import me.libraryaddict.disguise.disguisetypes.MobDisguise;
+import me.libraryaddict.disguise.disguisetypes.watchers.AgeableWatcher;
+import me.libraryaddict.disguise.disguisetypes.watchers.PandaWatcher;
 import me.libraryaddict.disguise.disguisetypes.watchers.PolarBearWatcher;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2Common;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Panda;
 import org.bukkit.entity.Player;
 
 /**
@@ -46,12 +50,30 @@ public class INCARNATIO_URSUS extends PlayerDisguise
       initSpell();
       calculateSuccessRate();
 
-      targetType = EntityType.POLAR_BEAR;
+      int rand = Math.abs(Ollivanders2Common.random.nextInt() % 20);
+
+      if (rand < 1) // 5% chance
+      {
+         targetType = EntityType.PANDA;
+      }
+      else
+      {
+         targetType = EntityType.POLAR_BEAR;
+      }
       disguiseType = DisguiseType.getType(targetType);
       disguise = new MobDisguise(disguiseType);
 
-      PolarBearWatcher watcher = (PolarBearWatcher) disguise.getWatcher();
+      AgeableWatcher watcher = (AgeableWatcher) disguise.getWatcher();
       watcher.setAdult();
-      watcher.setStanding(true);
+
+      if (watcher instanceof PolarBearWatcher)
+      {
+         ((PolarBearWatcher) watcher).setStanding(true);
+      }
+      else // Panda
+      {
+         ((PandaWatcher) watcher).setMainGene(Panda.Gene.NORMAL);
+         ((PandaWatcher) watcher).setSitting(false);
+      }
    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_URSUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_URSUS.java
@@ -68,7 +68,7 @@ public class INCARNATIO_URSUS extends PlayerDisguise
 
       if (watcher instanceof PolarBearWatcher)
       {
-         ((PolarBearWatcher) watcher).setStanding(true);
+         ((PolarBearWatcher) watcher).setStanding(false);
       }
       else // Panda
       {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_VACCULA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_VACCULA.java
@@ -51,7 +51,7 @@ public final class INCARNATIO_VACCULA extends PlayerDisguise
       calculateSuccessRate();
 
       int rand = Math.abs(Ollivanders2Common.random.nextInt() % 100);
-      if (rand == 0)
+      if (rand == 0) // 1% chance
          targetType = EntityType.MUSHROOM_COW;
       else
          targetType = EntityType.COW;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/LAPIFORS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/LAPIFORS.java
@@ -60,6 +60,6 @@ public final class LAPIFORS extends FriendlyMobDisguise
       RabbitWatcher watcher = (RabbitWatcher)disguise.getWatcher();
       watcher.setAdult();
 
-      watcher.setType(Ollivanders2API.common.randomRabbitType());
+      watcher.setType(Ollivanders2API.common.getRandomRabbitType());
    }
 }


### PR DESCRIPTION
* Added additional entity-specific watchers
* Added new mob types for existing LibsDisguises spells
* Fixed where Ocelots were being used for Cats since these are split out in 1.14
* Added logic to seed entity colors/types by uuid so they are always the same for any player
* Added a fix() function to use for cleanup of player data from earlier plugin versions
* Added "rare" animagus forms to make less common animals less common forms
* Removed unused plugin callback from O2PlayerCommon