### PR TITLE
Minor tweaks to books and player summary command

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
@@ -635,7 +635,7 @@ public class Ollivanders2 extends JavaPlugin
     * @param sender the player who issued the command
     * @return true if no error occurred
     */
-   private boolean playerSummary(@NotNull CommandSender sender, @NotNull Player player)
+   public boolean playerSummary(@NotNull CommandSender sender, @NotNull Player player)
    {
       if (debug)
          getLogger().info("Running playerSummary");
@@ -649,7 +649,7 @@ public class Ollivanders2 extends JavaPlugin
 
       StringBuilder summary = new StringBuilder();
 
-      summary.append("Ollivanders2 player summary:\n\n");
+      summary.append("Player summary:\n\n");
 
       // wand type
       if (o2p.foundWand())

--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2Common.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2Common.java
@@ -1459,12 +1459,16 @@ public class Ollivanders2Common
       if (!itemName.equalsIgnoreCase(name))
          return false;
 
-      List<String> itemLore = meta.getLore();
-      if (itemLore == null || itemLore.size() < 1)
-         return false;
+      // don't check lore on written books
+      if (material != Material.WRITTEN_BOOK)
+      {
+         List<String> itemLore = meta.getLore();
+         if (itemLore == null || itemLore.size() < 1)
+            return false;
 
-      if (!itemLore.get(0).equalsIgnoreCase(lore))
-         return false;
+         if (!itemLore.get(0).equalsIgnoreCase(lore))
+            return false;
+      }
 
       return true;
    }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/O2BookType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/O2BookType.java
@@ -110,4 +110,14 @@ public enum O2BookType
    {
       return className;
    }
+
+   /**
+    * Return the short title for a book. This is the display name title for the book item.
+    *
+    * @return the short title of the book
+    */
+   public String getShortTitle ()
+   {
+      return shortTitle;
+   }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/house/O2Houses.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/house/O2Houses.java
@@ -18,6 +18,7 @@ import org.bukkit.scoreboard.ScoreboardManager;
 import org.bukkit.scoreboard.Team;
 import org.bukkit.Server;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * "While you are here, your house will be something like your family within Hogwarts.  You will have classes with the

--- a/Ollivanders/src/net/pottercraft/ollivanders2/house/O2Houses.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/house/O2Houses.java
@@ -18,7 +18,6 @@ import org.bukkit.scoreboard.ScoreboardManager;
 import org.bukkit.scoreboard.Team;
 import org.bukkit.Server;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * "While you are here, your house will be something like your family within Hogwarts.  You will have classes with the

--- a/Ollivanders/src/net/pottercraft/ollivanders2/house/events/OllivandersPlayerSortedEvent.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/house/events/OllivandersPlayerSortedEvent.java
@@ -14,7 +14,7 @@ public class OllivandersPlayerSortedEvent extends PlayerEvent
      *
      * @param player the player who found their wand
      */
-    public OllivandersPlayerSortedEvent (Player player)
+    public OllivandersPlayerSortedEvent (@NotNull Player player)
     {
         super(player);
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/player/events/OllivandersPlayerFoundWandEvent.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/player/events/OllivandersPlayerFoundWandEvent.java
@@ -19,7 +19,7 @@ public final class OllivandersPlayerFoundWandEvent extends PlayerEvent
      *
      * @param player the player who found their wand
      */
-    public OllivandersPlayerFoundWandEvent (Player player)
+    public OllivandersPlayerFoundWandEvent (@NotNull Player player)
     {
         super(player);
     }


### PR DESCRIPTION
Minor tweaks needed for pottercraft plugin mechanics but will also be useful to other server customizations.

- added accessor for book short title
- added some NotNull/Nullable contracts
- updated text on player summary command to be more generic
- updated item comparison function to handle written books special case

Tested locally and on Pottercraft-Test
