### PR TITLE
Reparo fix

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effect.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effect.java
@@ -94,7 +94,7 @@ public abstract class O2Effect
       if (permanent)
          return;
 
-      duration -= i;
+      duration = duration - i;
       if (duration < 0)
       {
          kill();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effects.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effects.java
@@ -552,7 +552,7 @@ public class O2Effects
       if (activeEffects.containsKey(effectType))
       {
          O2Effect effect = activeEffects.get(effectType);
-         effect.duration -= amount;
+         effect.duration = effect.duration - amount;
       }
 
       effectsData.updatePlayerActiveEffects(pid, activeEffects);
@@ -583,7 +583,7 @@ public class O2Effects
 
          if (!effect.isPermanent())
          {
-            effect.duration -= effect.duration * (percent / 100);
+            effect.duration = effect.duration - (effect.duration * (percent / 100));
          }
       }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/MetelojinxSuper.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/MetelojinxSuper.java
@@ -55,7 +55,8 @@ public abstract class MetelojinxSuper extends O2Spell
          }
          else // storm and hasStorm() are not the same
          {
-            duration -= usesModifier * 1200;
+            duration = duration - (int)(usesModifier * 1200);
+
             if (duration < 0)
             {
                duration = -duration;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/REPARO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/REPARO.java
@@ -32,7 +32,7 @@ public final class REPARO extends O2Spell
       spellType = O2SpellType.REPARO;
       branch = O2MagicBranch.CHARMS;
 
-      flavorText = new ArrayList<String>()
+      flavorText = new ArrayList<>()
       {{
          add("The Mending Charm");
          add("Mr. Weasley took Harry's glasses, gave them a tap of his wand and returned them, good as new.");
@@ -66,6 +66,7 @@ public final class REPARO extends O2Spell
    protected void doCheckEffect ()
    {
       List<Item> items = getItems(1.5);
+
       for (Item item : items)
       {
          ItemStack stack = item.getItemStack();
@@ -74,15 +75,21 @@ public final class REPARO extends O2Spell
          if (itemMeta instanceof Damageable)
          {
             int damage = ((Damageable) itemMeta).getDamage();
-            damage -= usesModifier * usesModifier;
+
+            damage = damage - (int)usesModifier;
+
             if (damage < 0)
             {
                damage = 0;
             }
 
             ((Damageable) itemMeta).setDamage(damage);
+            stack.setItemMeta(itemMeta);
+
             item.setItemStack(stack);
             kill();
+
+            break;
          }
       }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/StationarySpellObj.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/StationarySpellObj.java
@@ -150,7 +150,7 @@ public abstract class StationarySpellObj implements Serializable
     */
    public void age (int i)
    {
-      duration -= i;
+      duration = duration - i;
 
       if (duration <= 0)
          kill();


### PR DESCRIPTION
- reparo was not properly setting the updated damage
- reparo was reparing the item twice because the repaired item was being picked up in the iterating loop
- use of -= not correct