### PR TITLE
1.17 support

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
@@ -1900,13 +1900,13 @@ public class Ollivanders2 extends JavaPlugin
 
       String versionString = Bukkit.getBukkitVersion();
 
-      if (versionString.startsWith("1.14") || versionString.startsWith("1.15") || versionString.startsWith("1.16"))
+      if (versionString.startsWith("1.16") || versionString.startsWith("1.17"))
       {
          return true;
       }
       else // anything lower than 1.14 set to 0 because this version of the plugin cannot run on < 1.14
       {
-         getLogger().warning("MC version " + versionString + ". This version of Ollivanders2 requires 1.14 or higher.");
+         getLogger().warning("MC version " + versionString + ". This version of Ollivanders2 requires 1.16 or higher.");
          return false;
       }
    }

--- a/Ollivanders/src/plugin.yml
+++ b/Ollivanders/src/plugin.yml
@@ -11,10 +11,6 @@ commands:
     description: This is the main admin command for the Ollivanders2 plugin
     usage: Example usage /Ollivanders2
 
-  Quidd:
-    description: This command creates a Quidditch arena.
-    usage: Example usage /Quidd Hogwarts
-
   Olli:
     description: This is a shortened-form version of the main plugin command
     usage: Example usage /Olli

--- a/Ollivanders/src/plugin.yml
+++ b/Ollivanders/src/plugin.yml
@@ -1,6 +1,6 @@
 name: Ollivanders2
 main: net.pottercraft.ollivanders2.Ollivanders2
-version: 2.6.2
+version: 2.6.3
 authors: [ Azami7, autumnwoz ]
 website: https://www.spigotmc.org/resources/ollivanders2.38992/
 softdepend: [ WorldGuard, LibsDisguises ]


### PR DESCRIPTION
Allow version 2.6 to run on MC 1.17.

Testing:
- MC 1.17 with no plugins
- MC 1.17 with WorldGuard

Open Issues:
- ProtocolLib has not been updated to support 1.17 so all Transfiguration that requires LibsDisguises will not work.