### PR TITLE
Apparate locations

### DIFF
--- a/Ollivanders/src/config.yml
+++ b/Ollivanders/src/config.yml
@@ -26,6 +26,7 @@ nonVerbalSpellCasting: false
 spellJournal: true
 hostileMobAnimagi: false
 deathExpLoss: false
+apparateLocations: false
 
 # Houses
 #

--- a/Ollivanders/src/net/pottercraft/ollivanders2/GsonDAO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/GsonDAO.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import net.pottercraft.ollivanders2.house.O2HouseType;
+import org.bukkit.Location;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -24,25 +25,22 @@ import java.util.Map.Entry;
 public class GsonDAO implements GenericDAO
 {
    final private Gson gson;
-   final private Ollivanders2 p;
 
    private static final String saveDirectory = "plugins/Ollivanders2";
    private static final String archiveDirectory = "plugins/Ollivanders2/archive";
    public static final String housesJSONFile = "O2Houses.txt";
    public static final String housePointsJSONFile = "O2HousePoints.txt";
+   public static final String apparateLocationsJSONFile = "O2ApparateLocations.txt";
    public static final String o2PlayerJSONFile = "O2Players.txt";
    public static final String o2StationarySpellsJSONFile = "O2StationarySpells.txt";
    public static final String o2PropheciesJSONFile = "O2Prophecies.txt";
 
    /**
     * Constructor
-    *
-    * @param plugin a reference to the plugin
     */
-   public GsonDAO(@NotNull Ollivanders2 plugin)
+   public GsonDAO()
    {
       gson = new GsonBuilder().setPrettyPrinting().create();
-      p = plugin;
    }
 
    /**
@@ -80,6 +78,25 @@ public class GsonDAO implements GenericDAO
 
       String json = gson.toJson(strMap);
       writeJSON(json, housePointsJSONFile);
+   }
+
+   /**
+    * Save the apparate locations
+    *
+    * @param locations the map of location names to Locations
+    */
+   public void writeApparateData(@NotNull HashMap<String, Location> locations)
+   {
+      Map<String, String []> serializedLocations = new HashMap<>();
+      for (Entry<String, Location> entry : locations.entrySet())
+      {
+         Location location = entry.getValue();
+         String[] locationAsArray = {location.getWorld().getName(), String.valueOf(location.getX()), String.valueOf(location.getY()), String.valueOf(location.getZ())};
+         serializedLocations.put(entry.getKey(), locationAsArray);
+      }
+
+      String json = gson.toJson(serializedLocations);
+      writeJSON(json, apparateLocationsJSONFile);
    }
 
    /**
@@ -158,7 +175,6 @@ public class GsonDAO implements GenericDAO
          }
          catch (Exception e)
          {
-            p.getLogger().warning("Failed to convert house " + house);
             if (Ollivanders2.debug)
                e.printStackTrace();
 
@@ -204,7 +220,6 @@ public class GsonDAO implements GenericDAO
          }
          catch (Exception e)
          {
-            p.getLogger().warning("Failed to convert house " + house);
             if (Ollivanders2.debug)
                e.printStackTrace();
 
@@ -294,13 +309,11 @@ public class GsonDAO implements GenericDAO
          dir.mkdirs();
          if (!file.createNewFile())
          {
-            p.getLogger().warning("Unable to create save file " + saveFile);
             return;
          }
       }
       catch (Exception e)
       {
-         p.getLogger().warning("Error creating save file " + saveFile);
          if (Ollivanders2.debug)
          {
             e.printStackTrace();
@@ -320,7 +333,6 @@ public class GsonDAO implements GenericDAO
       }
       catch (Exception e)
       {
-         p.getLogger().warning("Unable to write save file " + saveFile);
          if (Ollivanders2.debug)
          {
             e.printStackTrace();
@@ -346,19 +358,16 @@ public class GsonDAO implements GenericDAO
       {
          if (!file.exists())
          {
-            p.getLogger().info("Save file " + saveFile + " not found, skipping.");
             return null;
          }
 
          if (!file.canRead())
          {
-            p.getLogger().warning("No permissions to read " + saveFile + ". Skipping.");
             return null;
          }
       }
       catch (Exception e)
       {
-         p.getLogger().warning("Error trying to read " + saveFile + ". Skipping.");
          if (Ollivanders2.debug)
          {
             e.printStackTrace();
@@ -381,11 +390,9 @@ public class GsonDAO implements GenericDAO
          }
 
          bReader.close();
-         p.getLogger().info("Loaded save file " + saveFile);
       }
       catch (Exception e)
       {
-         p.getLogger().warning("Error trying to read " + saveFile + ". Skipping.");
          if (Ollivanders2.debug)
          {
             e.printStackTrace();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/GsonDAO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/GsonDAO.java
@@ -4,7 +4,9 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import net.pottercraft.ollivanders2.house.O2HouseType;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -236,6 +238,70 @@ public class GsonDAO implements GenericDAO
       }
 
       return map;
+   }
+
+   /**
+    * Read the apparate locations
+    *
+    * @return a map of apparate locations or null if load failed
+    */
+   @Nullable
+   public HashMap<String, Location> readApparateLocation ()
+   {
+      String json = readJSON(apparateLocationsJSONFile);
+      if (json == null)
+      {
+         return null;
+      }
+
+      Map<String, String []> serializedLocations = new HashMap<>();
+      serializedLocations = gson.fromJson(json, new TypeToken<Map<String, String []>>(){}.getType());
+
+      HashMap<String, Location> locations = new HashMap<>();
+      for (Entry<String, String[]> entry : serializedLocations.entrySet())
+      {
+         // get location name
+         String locationName = entry.getKey();
+         if (locationName == null || locationName.length() < 1)
+         {
+            continue;
+         }
+
+         if (entry.getValue().length != 4)
+         {
+            continue;
+         }
+
+         // get world
+         String worldName = entry.getValue()[0];
+         World world = Bukkit.getServer().getWorld(worldName);
+         if (world == null)
+         {
+            continue;
+         }
+
+         String xCoordStr = entry.getValue()[1];
+         String yCoordStr = entry.getValue()[2];
+         String zCoordStr = entry.getValue()[3];
+         double xCoord;
+         double yCoord;
+         double zCoord;
+
+         try
+         {
+            xCoord = Double.parseDouble(xCoordStr);
+            yCoord = Double.parseDouble(yCoordStr);
+            zCoord = Double.parseDouble(zCoordStr);
+         }
+         catch (Exception e)
+         {
+            continue;
+         }
+
+         locations.put(locationName, new Location(world, xCoord, yCoord, zCoord));
+      }
+
+      return locations;
    }
 
    /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
+import net.pottercraft.ollivanders2.spell.APPARATE;
+import org.bukkit.World;
 import quidditch.Arena;
 
 import net.pottercraft.ollivanders2.effect.O2Effect;
@@ -87,6 +89,7 @@ public class Ollivanders2 extends JavaPlugin
    public static boolean useSpellJournal;
    public static boolean useHostileMobAnimagi;
    public static boolean enableDeathExpLoss;
+   public static boolean apparateLocations;
    public static int divinationMaxDays = 4;
    public static boolean useHouses;
    public static boolean displayMessageOnSort;
@@ -340,6 +343,13 @@ public class Ollivanders2 extends JavaPlugin
       }
 
       //
+      // apparate locations, when true apparate will only work to named locations, not by coordinates
+      //
+      apparateLocations = getConfig().getBoolean("apparateLocations");
+      if (apparateLocations)
+         getLogger().info("Enabling apparate locations - apparation by coordinates disabled.");
+
+      //
       // divinationMaxDays
       //
       if (getConfig().isSet("divinationMaxDays"))
@@ -514,7 +524,8 @@ public class Ollivanders2 extends JavaPlugin
       if (cmd.getName().equalsIgnoreCase("Ollivanders2") || cmd.getName().equalsIgnoreCase("Olli"))
       {
          return runOllivanders(sender, args);
-      } else if (cmd.getName().equalsIgnoreCase("Quidd"))
+      }
+      else if (cmd.getName().equalsIgnoreCase("Quidd"))
       {
          if (sender.isOp())
          {
@@ -559,14 +570,14 @@ public class Ollivanders2 extends JavaPlugin
                Player target = getServer().getPlayer(args[1]);
                if (target != null)
                   return giveRandomWand(target);
+               else
+                  usageMessageWand(sender);
             }
          }
          else if (subCommand.equalsIgnoreCase("reload"))
             return runReloadConfigs(sender);
          else if (subCommand.equalsIgnoreCase("items") || subCommand.equalsIgnoreCase("item"))
-         {
             return runItems((Player) sender, args);
-         }
          else if (subCommand.equalsIgnoreCase("house") || subCommand.equalsIgnoreCase("houses"))
             return runHouse(sender, args);
          else if (subCommand.equalsIgnoreCase("debug"))
@@ -607,21 +618,15 @@ public class Ollivanders2 extends JavaPlugin
             }
          }
          else if (subCommand.equalsIgnoreCase("potions") || subCommand.equalsIgnoreCase("potion"))
-         {
             return runPotions(sender, args);
-         }
          else if (subCommand.equalsIgnoreCase("year") || subCommand.equalsIgnoreCase("years"))
-         {
             return runYear(sender, args);
-         }
          else if (subCommand.equalsIgnoreCase("effect") || subCommand.equalsIgnoreCase("effects"))
-         {
             return runEffect(sender, args);
-         }
          else if (subCommand.equalsIgnoreCase("prophecy") || subCommand.equalsIgnoreCase("prophecies"))
-         {
             return runProphecies(sender);
-         }
+         else if (subCommand.equalsIgnoreCase("apparate") || subCommand.equalsIgnoreCase("apparateLoc"))
+            return runApparateLocation(sender, args);
       }
 
       usageMessageOllivanders(sender);
@@ -768,13 +773,17 @@ public class Ollivanders2 extends JavaPlugin
       sender.sendMessage(chatColor
               + "You are running Ollivanders2 version " + this.getDescription().getVersion() + "\n"
               + "\nOllivanders2 commands:"
-              + "\nwands - gives a complete set of wands"
-              + "\nbooks - gives a complete set of spell books"
-              + "\nitems - gives a complete set of items"
+              + "\nwands - wand commands"
+              + "\nbooks - books commands"
+              + "\nitems - item commands"
+              + "\npotions - potions commands"
               // + "\nquidd - creates a quidditch pitch"
-              + "\nhouse - view and manage houses and house points"
-              + "\nyear - view and manage player years"
+              + "\nhouse - house commands"
+              + "\nyear - year commands"
+              + "\neffect - effects commands"
+              + "\nprophecy - list all active prophecies"
               + "\nsummary - gives a summary of wand type, house, year, and known spells"
+              + "\napparateLoc - apparation location commands"
               + "\nreload - reload the Ollivanders2 configs"
               + "\ndebug - toggles Ollivanders2 plugin debug output\n"
               + "\n" + "To run a command, type '/ollivanders2 [command]'."
@@ -1370,10 +1379,21 @@ public class Ollivanders2 extends JavaPlugin
       }
       else
       {
-         sender.sendMessage(chatColor + "Not enough arguments to /olli effect.\n");
+         usageMessageEffect(sender);
       }
 
       return true;
+   }
+
+   /**
+    * Usage message for Effect subcommands.
+    *
+    * @param sender the player that issued the command
+    */
+   private void usageMessageEffect(@NotNull CommandSender sender)
+   {
+      sender.sendMessage(chatColor
+              + "/ollivanders2 effect effect_name player_name - toggles the named effect on the player");
    }
 
    /**
@@ -1483,6 +1503,19 @@ public class Ollivanders2 extends JavaPlugin
    }
 
    /**
+    * Usage message for Item subcommands.
+    *
+    * @param sender the player that issued the command
+    */
+   private void usageMessageItem(@NotNull CommandSender sender)
+   {
+      sender.sendMessage(chatColor
+              + "Options to '/ollivanders2 house':"
+              + "\nlist - lists all items"
+              + "\nitem_name - gives the specified item");
+   }
+
+   /**
     * Build a list of all O2Items
     *
     * @return the list of items
@@ -1533,6 +1566,18 @@ public class Ollivanders2 extends JavaPlugin
       Ollivanders2API.common.givePlayerKit(player, kit);
 
       return true;
+   }
+
+   /**
+    * Usage message for Wand subcommands.
+    *
+    * @param sender the player that issued the command
+    */
+   private void usageMessageWand(@NotNull CommandSender sender)
+   {
+      sender.sendMessage(chatColor
+              + "/ollivanders2 wand - gives you one of every wand"
+              + "\n/ollivanders2 wand player_name - gives named player a random wand");
    }
 
    /**
@@ -2211,10 +2256,15 @@ public class Ollivanders2 extends JavaPlugin
       return true;
    }
 
+   /**
+    * Usage message for potion subcommands
+    *
+    * @param sender the command sender
+    */
    private void usageMessagePotions (CommandSender sender)
    {
       sender.sendMessage(chatColor
-              + "Usage: /olli potions"
+              + "Usage: /ollivanders2 potions"
               + "\ningredient list - lists all potions ingredients"
               + "\ningredient <ingredient name> - give you the ingredient with this name, if it exists"
               + "\nall - gives all Ollivanders2 potions, this may not fit in your inventory"
@@ -2365,6 +2415,123 @@ public class Ollivanders2 extends JavaPlugin
       sender.sendMessage(chatColor + output.toString());
 
       return true;
+   }
+
+   /**
+    * Run the apparate location subcommand
+    *
+    * @param sender the command sender
+    * @param args
+    * @return
+    */
+   public boolean runApparateLocation (@NotNull CommandSender sender, @NotNull String[] args)
+   {
+      if (!apparateLocations)
+      {
+         sender.sendMessage(chatColor
+                 + "Apprate locations are not currently enabled for your server."
+                 + "\nTo enable apparate locations, update the Ollivanders2 config.yml setting to true and restart your server."
+                 // TODO update wiki and uncomment
+                 //+ "\nFor help, see our documentation at ..."
+         );
+
+         return true;
+      }
+
+      if (args.length >= 2)
+      {
+         String subCommand = args[1];
+
+         if (subCommand.equalsIgnoreCase("list"))
+         {
+            APPARATE.listApparateLocations((Player)sender);
+            return true;
+         }
+         else if (subCommand.equalsIgnoreCase("add") || subCommand.equalsIgnoreCase("update"))
+         {
+            if (args.length < 6)
+            {
+               usageMessageApparateLocation(sender);
+               return true;
+            }
+
+            String locationName = args[2];
+
+            if (subCommand.equalsIgnoreCase("add") && APPARATE.doesLocationExist(locationName))
+            {
+               sender.sendMessage(chatColor + "An apparate location with that name already exists. If you want to update the location coordinates, use /ollivanders2 apparateLoc update.");
+               return true;
+            }
+            else if (subCommand.equalsIgnoreCase("update") && !APPARATE.doesLocationExist(locationName))
+            {
+               sender.sendMessage(chatColor + "An apparate location with that name does not exist. If you want to add a location coordinates, use /ollivanders2 apparateLoc add.");
+               return true;
+            }
+
+            String xCoord = args[3];
+            String yCoord = args[4];
+            String zCoord = args[5];
+            double x;
+            double y;
+            double z;
+            try
+            {
+               x = Double.parseDouble(xCoord);
+               y = Double.parseDouble(yCoord);
+               z = Double.parseDouble(zCoord);
+            }
+            catch (Exception e)
+            {
+               sender.sendMessage(chatColor + "Invalid coordinates for location.");
+               usageMessageApparateLocation(sender);
+               return true;
+            }
+
+            World world = ((Player) sender).getWorld();
+
+            APPARATE.addLocation(locationName, world, x, y, z);
+
+            sender.sendMessage(chatColor + "Apparate location " + locationName + " set. \nTo list all locations, use /ollivanders2 apparateLoc list.");
+            return true;
+         }
+         else if (subCommand.equalsIgnoreCase("remove"))
+         {
+            if (args.length < 3)
+            {
+               usageMessageApparateLocation(sender);
+               return true;
+            }
+
+            String locationName = args[2];
+
+            if (!APPARATE.removeLocation(locationName))
+            {
+               sender.sendMessage(chatColor + "Unable to remove location. Check name spelling and try again.\nTo list all locations, use /ollivanders2 apparateLoc list.");
+            }
+
+            return true;
+         }
+      }
+
+      usageMessageApparateLocation(sender);
+      return true;
+   }
+
+   /**
+    * Usage message for apparate location subcommands
+    *
+    * @param sender the command sender
+    */
+   private void usageMessageApparateLocation (CommandSender sender)
+   {
+      sender.sendMessage(chatColor
+              + "Usage: /ollivanders2 apparateLoc"
+              + "\nlist - lists all apparate locations"
+              + "\nadd <location name> <x> <y> <z> - adds an apparate location"
+              + "\nupdate <location name> <x> <y> <z> - updates named location to new coordinates"
+              + "\nremove <location name> - removes the specified apparate location"
+              + "\nExample: /ollivanders2 apparateLoc add hogsmeade 200 70 350"
+              + "\nExample: /ollivanders2 remove hogsmeade");
    }
 
    /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
@@ -2543,10 +2543,8 @@ public class Ollivanders2 extends JavaPlugin
 
             String locationName = args[2];
 
-            if (!APPARATE.removeLocation(locationName))
-            {
-               sender.sendMessage(chatColor + "Unable to remove location. Check name spelling and try again.\nTo list all locations, use /ollivanders2 apparateLoc list.");
-            }
+            APPARATE.removeLocation(locationName);
+            sender.sendMessage(chatColor + "Removed apparate location " + locationName);
 
             return true;
          }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
@@ -127,6 +127,7 @@ public class Ollivanders2 extends JavaPlugin
          Ollivanders2API.saveHouses();
       }
       Ollivanders2API.savePlayers();
+      APPARATE.saveApparateLocations();
 
       getLogger().info(this + " is now disabled!");
    }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2API.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2API.java
@@ -7,6 +7,7 @@ import net.pottercraft.ollivanders2.item.O2Items;
 import net.pottercraft.ollivanders2.player.O2PlayerCommon;
 import net.pottercraft.ollivanders2.player.O2Players;
 import net.pottercraft.ollivanders2.potion.O2Potions;
+import net.pottercraft.ollivanders2.spell.APPARATE;
 import net.pottercraft.ollivanders2.spell.O2Spells;
 import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpells;
 import org.jetbrains.annotations.NotNull;
@@ -129,6 +130,9 @@ public class Ollivanders2API
       {
          spells = new O2Spells(p);
       }
+
+      // load any spell static data
+      APPARATE.loadApparateLocations(p);
    }
 
    /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2WorldGuard.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2WorldGuard.java
@@ -91,7 +91,7 @@ public class Ollivanders2WorldGuard
             p.getLogger().info("State of " + flag.toString() + " for " + player.getDisplayName() + " is " + state.toString());
 
 
-         return (state == StateFlag.State.DENY);
+         return (state != StateFlag.State.DENY);
       }
       else
       {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/OllivandersListener.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/OllivandersListener.java
@@ -11,6 +11,7 @@ import net.pottercraft.ollivanders2.player.O2Player;
 import net.pottercraft.ollivanders2.player.O2WandCoreType;
 import net.pottercraft.ollivanders2.player.O2WandWoodType;
 import net.pottercraft.ollivanders2.player.events.OllivandersPlayerNotDestinedWandEvent;
+import net.pottercraft.ollivanders2.spell.APPARATE;
 import net.pottercraft.ollivanders2.spell.Divination;
 import net.pottercraft.ollivanders2.spell.FLAGRANTE;
 import net.pottercraft.ollivanders2.spell.O2Spell;
@@ -454,10 +455,7 @@ public class OllivandersListener implements Listener
          if (Ollivanders2.bookLearning && p.getO2Player(player).getSpellCount(spellType) < 1)
          {
             // if bookLearning is set to true then spell count must be > 0 to cast this spell
-            if (Ollivanders2.debug)
-            {
-               p.getLogger().info("onPlayerChat: bookLearning enforced");
-            }
+            common.printDebugMessage("doSpellCasting: bookLearning enforced", null, null, false);
             player.sendMessage(Ollivanders2.chatColor + "You do not know that spell yet. To learn a spell, you'll need to read a book about that spell.");
 
             return;
@@ -468,10 +466,7 @@ public class OllivandersListener implements Listener
          if (!Ollivanders2API.playerCommon.holdsWand(player))
          {
             // if they are not holding their destined wand, casting success is reduced
-            if (Ollivanders2.debug)
-            {
-               p.getLogger().info("onPlayerChat: player not holding destined wand");
-            }
+            common.printDebugMessage("doSpellCasting: player not holding destined wand", null, null, false);
 
             int uses = p.getO2Player(player).getSpellCount(spellType);
             castSuccess = Math.random() < (1.0 - (100.0 / (uses + 101.0)));
@@ -480,23 +475,17 @@ public class OllivandersListener implements Listener
          // wandless spells
          if (O2Spells.wandlessSpells.contains(spellType) || Divination.divinationSpells.contains(spellType))
          {
-            if (Ollivanders2.debug)
-            {
-               p.getLogger().info("onPlayerChat: allow wandless casting of " + spellType);
-            }
+            common.printDebugMessage("doSpellCasting: allow wandless casting of " + spellType, null, null, false);
             castSuccess = true;
          }
 
          if (castSuccess)
          {
-            if (Ollivanders2.debug)
-            {
-               p.getLogger().info("onPlayerChat: begin casting " + spellType);
-            }
+            common.printDebugMessage("doSpellCasting: begin casting " + spellType, null, null, false);
 
             if (spellType == O2SpellType.APPARATE)
             {
-               apparate(player, words);
+               p.addProjectile(new APPARATE(p, player, 1.0, words));
             }
             else if (spellType == O2SpellType.PORTUS)
             {
@@ -534,121 +523,7 @@ public class OllivandersListener implements Listener
       }
       else
       {
-         if (Ollivanders2.debug)
-         {
-            p.getLogger().info("Either no spell cast attempted or not allowed to cast");
-         }
-      }
-   }
-
-   /**
-    * Teleports sender to either specified location or to eye target location. Respects anti-apparition and anti-disapparition spells.
-    *
-    * @param sender Player apparating
-    * @param words  Typed in words
-    */
-   private void apparate(@NotNull Player sender, @NotNull String[] words)
-   {
-      boolean canApparateOut = true;
-
-      for (StationarySpellObj stat : Ollivanders2API.getStationarySpells(p).getActiveStationarySpells())
-      {
-         if (stat instanceof NULLUM_EVANESCUNT && stat.isInside(sender.getLocation()))
-         {
-            stat.flair(10);
-            canApparateOut = false;
-         }
-      }
-      if (sender.isPermissionSet("Ollivanders2.BYPASS"))
-      {
-         if (sender.hasPermission("Ollivanders2.BYPASS"))
-         {
-            canApparateOut = true;
-         }
-      }
-      if (canApparateOut)
-      {
-         int uses = p.incrementSpellCount(sender, O2SpellType.APPARATE);
-         Location from = sender.getLocation().clone();
-         Location to;
-         if (words.length == 4)
-         {
-            try
-            {
-               to = new Location(sender.getWorld(),
-                     Double.parseDouble(words[1]),
-                     Double.parseDouble(words[2]),
-                     Double.parseDouble(words[3]));
-            }
-            catch (NumberFormatException e)
-            {
-               to = sender.getLocation().clone();
-            }
-         }
-         else
-         {
-            Location eyeLocation = sender.getEyeLocation();
-            Material inMat = eyeLocation.getBlock().getType();
-            int distance = 0;
-            while ((inMat == Material.AIR || inMat == Material.FIRE || inMat == Material.WATER || inMat == Material.LAVA) && distance < 160)
-            {
-               eyeLocation = eyeLocation.add(eyeLocation.getDirection());
-               distance++;
-               inMat = eyeLocation.getBlock().getType();
-            }
-            to = eyeLocation.subtract(eyeLocation.getDirection()).clone();
-         }
-         to.setPitch(from.getPitch());
-         to.setYaw(from.getYaw());
-         double distance = from.distance(to);
-         double radius;
-
-         if (Ollivanders2API.playerCommon.holdsWand(sender))
-         {
-            radius = 1 / Math.sqrt(uses) * distance * 0.1 * Ollivanders2API.playerCommon.wandCheck(sender);
-         }
-         else
-         {
-            radius = 1 / Math.sqrt(uses) * distance * 0.01;
-         }
-         double newX = to.getX() - (radius / 2) + (radius * Math.random());
-         double newZ = to.getZ() - (radius / 2) + (radius * Math.random());
-         to.setX(newX);
-         to.setZ(newZ);
-         boolean canApparateIn = true;
-         for (StationarySpellObj stat : Ollivanders2API.getStationarySpells(p).getActiveStationarySpells())
-         {
-            if (stat instanceof NULLUM_APPAREBIT && stat.isInside(to))
-            {
-               stat.flair(10);
-               canApparateIn = false;
-            }
-         }
-         if (sender.isPermissionSet("Ollivanders2.BYPASS"))
-         {
-            if (sender.hasPermission("Ollivanders2.BYPASS"))
-            {
-               canApparateIn = true;
-            }
-         }
-         if (canApparateIn)
-         {
-            p.addTeleportEvent(sender, sender.getLocation(), to, true);
-
-            // also take nearby entities with them
-            for (Entity e : sender.getWorld().getEntities())
-            {
-               if (from.distance(e.getLocation()) <= 2)
-               {
-                  if (e instanceof Player)
-                  {
-                     p.addTeleportEvent((Player) e, e.getLocation(), to, true);
-                  }
-                  else
-                     e.teleport(to);
-               }
-            }
-         }
+         common.printDebugMessage("doSpellCasting: Either no spell cast attempted or not allowed to cast", null, null, false);
       }
    }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Prophecies.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Prophecies.java
@@ -176,7 +176,7 @@ public class O2Prophecies
    {
       List<Map<String, String>> prophecies = serializeProphecies();
 
-      GsonDAO gsonLayer = new GsonDAO(p);
+      GsonDAO gsonLayer = new GsonDAO();
       gsonLayer.writeSaveData(prophecies, GsonDAO.o2PropheciesJSONFile);
    }
 
@@ -185,7 +185,7 @@ public class O2Prophecies
     */
    private void loadProphecies ()
    {
-      GsonDAO gsonLayer = new GsonDAO(p);
+      GsonDAO gsonLayer = new GsonDAO();
       List<Map<String, String>> prophecies = gsonLayer.readSavedDataListMap(GsonDAO.o2PropheciesJSONFile);
 
       if (prophecies == null)

--- a/Ollivanders/src/net/pottercraft/ollivanders2/house/O2Houses.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/house/O2Houses.java
@@ -163,7 +163,7 @@ public class O2Houses
     */
    private void loadHouses()
    {
-      GsonDAO gsonLayer = new GsonDAO(p);
+      GsonDAO gsonLayer = new GsonDAO();
       Map <UUID, O2HouseType> houses = gsonLayer.readHouses();
       if (houses != null)
       {
@@ -189,7 +189,7 @@ public class O2Houses
    public void saveHouses()
    {
       // write house data out as JSON
-      GsonDAO gsonLayer = new GsonDAO(p);
+      GsonDAO gsonLayer = new GsonDAO();
       gsonLayer.writeHouses(O2HouseMap);
 
       Map <O2HouseType, Integer> housePoints = new HashMap<>();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Players.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Players.java
@@ -148,7 +148,7 @@ public class O2Players
          return;
       }
 
-      GsonDAO gsonLayer = new GsonDAO(p);
+      GsonDAO gsonLayer = new GsonDAO();
       gsonLayer.writeSaveData(serializedMap, GsonDAO.o2PlayerJSONFile);
    }
 
@@ -157,7 +157,7 @@ public class O2Players
     */
    public void loadO2Players ()
    {
-      GsonDAO gsonLayer = new GsonDAO(p);
+      GsonDAO gsonLayer = new GsonDAO();
 
       // load players from the save file, if it exists
       Map<String, Map<String, String>> serializedMap = gsonLayer.readSavedDataMapStringMap(GsonDAO.o2PlayerJSONFile);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/APPARATE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/APPARATE.java
@@ -28,17 +28,10 @@ import java.util.Map;
  */
 public final class APPARATE extends O2Spell
 {
-    /*
-    static
-    {
-        APPARATE.loadApparateLocations();
-    }
-     */
-
     /**
      * Apparate locations
      */
-    private final static HashMap<String, Location> apparateLocations = new HashMap<>();
+    private static HashMap<String, Location> apparateLocations = new HashMap<>();
 
     /**
      * The arguments to the apparate spell
@@ -319,12 +312,9 @@ public final class APPARATE extends O2Spell
      * @param name the name of the location to remove
      * @return true if successfully removed, false otherwise
      */
-    public static boolean removeLocation (@NotNull String name)
+    public static void removeLocation (@NotNull String name)
     {
-        if (apparateLocations.remove(name.toLowerCase()) == null)
-            return false;
-
-        return true;
+        apparateLocations.remove(name.toLowerCase());
     }
 
     /**
@@ -350,14 +340,44 @@ public final class APPARATE extends O2Spell
     }
 
     /**
-     * Load saved data for this spell
+     * Return a map of all apparate locations
+     *
+     * @return a map of all apparate locations
+     */
+    @NotNull
+    public static Map<String, Location> getAllApparateLocations ()
+    {
+        return new HashMap<String, Location>(apparateLocations);
+    }
+
+    /**
+     * Save all apparate locations
      */
     public static void saveApparateLocations ()
     {
-        if (Ollivanders2.apparateLocations)
-        {
-            GsonDAO gsonLayer = new GsonDAO();
-            gsonLayer.writeApparateData(apparateLocations);
-        }
+        if (!Ollivanders2.apparateLocations)
+            return;
+
+        GsonDAO gsonLayer = new GsonDAO();
+        gsonLayer.writeApparateData(apparateLocations);
+    }
+
+    /**
+     * Load all saved apparate locations
+     *
+     * @param p a callback to the plugin
+     */
+    public static void loadApparateLocations (Ollivanders2 p)
+    {
+        if (!Ollivanders2.apparateLocations)
+            return;
+
+        GsonDAO gsonLayer = new GsonDAO();
+        HashMap<String, Location> loadedLoactions = gsonLayer.readApparateLocation();
+
+        if (loadedLoactions != null)
+            apparateLocations = loadedLoactions;
+
+        p.getLogger().info("Loaded " + apparateLocations.size() + " apparate locations.");
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/APPARATE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/APPARATE.java
@@ -7,23 +7,41 @@ import net.pottercraft.ollivanders2.Ollivanders2WorldGuard;
 import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpellType;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Apparition code for players who have over 100 uses in apparition.
  *
- * @author lownes
  * @author Azami7
  * @version Ollivanders2
  */
 public final class APPARATE extends O2Spell
 {
+    /**
+     * Apparate locations
+     */
+    private final static HashMap<String, Location> apparateLocations = new HashMap<>();
+
+    /**
+     * The arguments to the apparate spell
+     */
+    private final String[] wordsArray;
+
+    /**
+     * Max distance to apparate for line of sight apparating
+     */
+    private final int maxLineOfSight = 160;
+
     /**
      * Default constructor for use in generating spell text.  Do not use to cast the spell.
      */
@@ -45,6 +63,8 @@ public final class APPARATE extends O2Spell
                 + "To apparate to the location of your cursor, within 140 meters, just say the word apparate. "
                 + "Your accuracy is determined by the distance traveled and your experience. "
                 + "If there are any entities close to you when you apparate, they will be taken with you as well by side-along apparition.";
+
+        wordsArray = null;
     }
 
     /**
@@ -53,8 +73,9 @@ public final class APPARATE extends O2Spell
      * @param plugin    a callback to the MC plugin
      * @param player    the player who cast this spell
      * @param rightWand which wand the player was using
+     * @param wordsArray the arguments to the apparate spell
      */
-    public APPARATE(@NotNull Ollivanders2 plugin, @NotNull Player player, @NotNull Double rightWand)
+    public APPARATE(@NotNull Ollivanders2 plugin, @NotNull Player player, @NotNull Double rightWand, @NotNull String[] wordsArray)
     {
         super(plugin, player, rightWand);
         spellType = O2SpellType.APPARATE;
@@ -62,9 +83,7 @@ public final class APPARATE extends O2Spell
 
         initSpell();
 
-        // world-guard flags
-        if (Ollivanders2.worldGuardEnabled)
-           worldGuardFlags.add(Flags.EXIT_VIA_TELEPORT);
+        this.wordsArray = wordsArray;
     }
 
     /**
@@ -79,46 +98,35 @@ public final class APPARATE extends O2Spell
             return;
         }
 
-        // check to see if the player can apparate out of this location
-        if (canApparateFrom())
+        Location destination = getDestination();
+        if (!canApparateTo(destination))
         {
-            Location from = player.getLocation().clone();
-            Location to;
-            Location eyeLocation = player.getEyeLocation();
-            Material inMat = eyeLocation.getBlock().getType();
-            int distance = 0;
-            while ((inMat == Material.AIR || inMat == Material.FIRE || inMat == Material.WATER || inMat == Material.LAVA) && distance < 160)
-            {
-                eyeLocation = eyeLocation.add(eyeLocation.getDirection());
-                distance++;
-                inMat = eyeLocation.getBlock().getType();
-            }
-            to = eyeLocation.subtract(eyeLocation.getDirection()).clone();
-            to.setPitch(from.getPitch());
-            to.setYaw(from.getYaw());
-            double radius = (1 / usesModifier) * from.distance(to) * 0.1;
-            double newX = (to.getX() - (radius / 2)) + (radius * Math.random());
-            double newZ = (to.getZ() - (radius / 2)) + (radius * Math.random());
-            to.setX(newX);
-            to.setZ(newZ);
+            p.spellFailedMessage(player);
+            kill();
+            return;
+        }
 
-            // check to see if the player can apparate in to the target location
-            if (canApparateTo(to))
-            {
-                player.getWorld().createExplosion(from.getX(), from.getY(), from.getZ(), 2, false, false);
+        Location source = player.getLocation();
+        if (!canApparateFrom(source))
+        {
+            p.spellFailedMessage(player);
+            kill();
+            return;
+        }
 
-                player.teleport(to);
-                for (Entity e : player.getWorld().getEntities())
+        p.addTeleportEvent(player, player.getLocation(), destination, true);
+
+        // also take nearby players with them
+        for (Entity e : player.getWorld().getEntities())
+        {
+            if (source.distance(e.getLocation()) <= 2)
+            {
+                if (e instanceof Player)
                 {
-                    if (from.distance(e.getLocation()) <= 2)
-                    {
-                        e.teleport(to);
-                    }
+                    p.addTeleportEvent((Player) e, e.getLocation(), destination, true);
                 }
-
-                // where the player actually ended up
-                Location resultingLocation = player.getLocation();
-                player.getWorld().createExplosion(resultingLocation.getX(), resultingLocation.getY(), resultingLocation.getZ(), 2, false, false);
+                else
+                    e.teleport(destination);
             }
         }
 
@@ -126,25 +134,98 @@ public final class APPARATE extends O2Spell
     }
 
     /**
+     * Get the apparate destination.
+     *
+     * @return the destination or null if
+     */
+    @NotNull
+    private Location getDestination ()
+    {
+        Location destination = null;
+
+        if (Ollivanders2.apparateLocations) // player must specify named location
+        {
+            if (wordsArray.length == 2)
+            {
+                destination = getLocationByName(wordsArray[1]);
+            }
+        }
+        else
+        {
+            if (wordsArray.length == 4)
+            {
+                String xCoord = wordsArray[1];
+                String yCoord = wordsArray[2];
+                String zCoord = wordsArray[3];
+                double x;
+                double y;
+                double z;
+
+                try
+                {
+                    x = Double.parseDouble(xCoord);
+                    y = Double.parseDouble(yCoord);
+                    z = Double.parseDouble(zCoord);
+                    destination = new Location(player.getWorld(), x, y, z);
+                }
+                catch (Exception e) { }
+            }
+        }
+
+        if (destination == null)
+            destination = getLineOfSightLocation();
+
+        return destination;
+    }
+
+    /**
+     * Get a line of sight location for apparating without specifying a location.
+     *
+     * @return a line of sight location up to max blocks
+     */
+    @NotNull
+    private Location getLineOfSightLocation ()
+    {
+        Location currentLocation = player.getEyeLocation();
+        Material material = currentLocation.getBlock().getType();
+
+        int distance = 0;
+        while ((projectilePassThrough.contains(material)) && distance < maxLineOfSight)
+        {
+            currentLocation = currentLocation.add(currentLocation.getDirection());
+            distance++;
+            material = currentLocation.getBlock().getType();
+        }
+
+        return currentLocation.subtract(currentLocation.getDirection()).clone();
+    }
+
+    /**
      * Check to see if the player can apparate out of this location.
      *
      * @return true if the player can apparate, false otherwise
      */
-    private boolean canApparateFrom()
+    private boolean canApparateFrom(@NotNull Location source)
     {
         // check world guard permissions at location
         if (Ollivanders2.worldGuardEnabled)
         {
             Ollivanders2WorldGuard wg = new Ollivanders2WorldGuard(p);
 
-            if (!wg.checkWGFlag(player, location, Flags.EXIT_VIA_TELEPORT))
+            if (!wg.checkWGFlag(player, source, Flags.EXIT_VIA_TELEPORT))
             {
                 return false;
             }
         }
 
-        // check for Nullum Evanescunt at location
-        return Ollivanders2API.getStationarySpells(p).checkLocationForSpell(player.getLocation(), O2StationarySpellType.NULLUM_EVANESCUNT);
+        // check for Nullum Apparebit at destination
+        if (Ollivanders2API.getStationarySpells(p).checkLocationForSpell(player.getLocation(), O2StationarySpellType.NULLUM_EVANESCUNT))
+        {
+            common.printDebugMessage("Nullum Evanescunt at source blocks teleport.", null, null, false);
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -162,11 +243,101 @@ public final class APPARATE extends O2Spell
 
             if (!wg.checkWGFlag(player, destination, Flags.ENTRY))
             {
+                common.printDebugMessage("Player does not have ENTRY permissions to destination", null, null, false);
                 return false;
             }
         }
 
         // check for Nullum Apparebit at destination
-        return Ollivanders2API.getStationarySpells(p).checkLocationForSpell(player.getLocation(), O2StationarySpellType.NULLUM_APPAREBIT);
+        if (Ollivanders2API.getStationarySpells(p).checkLocationForSpell(player.getLocation(), O2StationarySpellType.NULLUM_APPAREBIT))
+        {
+            common.printDebugMessage("Nullum Apparebit at destination blocks teleport.", null, null, false);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * List all apparate locations
+     *
+     * @param player player to display the list to
+     */
+    public static void listApparateLocations (@NotNull Player player)
+    {
+        if (apparateLocations.size() < 1)
+        {
+            player.sendMessage(Ollivanders2.chatColor + "No apparate locations.");
+        }
+        else
+        {
+            StringBuilder builder = new StringBuilder();
+            builder.append("Apparate locations:");
+            for (Map.Entry<String, Location> entry : apparateLocations.entrySet())
+            {
+                builder.append("\n").append(entry.getKey());
+                Location loc = entry.getValue();
+                builder.append(" ").append((int)(loc.getX()));
+                builder.append(" ").append((int)(loc.getY()));
+                builder.append(" ").append((int)(loc.getZ()));
+            }
+
+            player.sendMessage(Ollivanders2.chatColor + builder.toString());
+        }
+    }
+
+    /**
+     * Add an apparate location
+     *
+     * @param name the name of the location to add
+     * @param world the location world
+     * @param x x-coord
+     * @param y y-coord
+     * @param z z-coord
+     * @return true if successfully added, false otherwise
+     */
+    public static boolean addLocation (@NotNull String name, @NotNull World world, double x, double y, double z)
+    {
+        Location location = new Location(world, x, y, z);
+
+        apparateLocations.put(name.toLowerCase(), location);
+
+        return false;
+    }
+
+    /**
+     * Remove an apparate location
+     *
+     * @param name the name of the location to remove
+     * @return true if successfully removed, false otherwise
+     */
+    public static boolean removeLocation (@NotNull String name)
+    {
+        if (apparateLocations.remove(name.toLowerCase()) == null)
+            return false;
+
+        return true;
+    }
+
+    /**
+     * Check if a named apparate location exists.
+     *
+     * @param name the location name
+     * @return true if it exists in the list, false otherwise
+     */
+    public static boolean doesLocationExist (@NotNull String name)
+    {
+        return apparateLocations.containsKey(name.toLowerCase());
+    }
+
+    /**
+     * Return an apparate location by name
+     * @param name the location name
+     * @return the location if found, null otherwise
+     */
+    @Nullable
+    public Location getLocationByName (@NotNull String name)
+    {
+        return apparateLocations.get(name.toLowerCase());
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/APPARATE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/APPARATE.java
@@ -1,6 +1,7 @@
 package net.pottercraft.ollivanders2.spell;
 
 import com.sk89q.worldguard.protection.flags.Flags;
+import net.pottercraft.ollivanders2.GsonDAO;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2API;
 import net.pottercraft.ollivanders2.Ollivanders2WorldGuard;
@@ -27,6 +28,13 @@ import java.util.Map;
  */
 public final class APPARATE extends O2Spell
 {
+    /*
+    static
+    {
+        APPARATE.loadApparateLocations();
+    }
+     */
+
     /**
      * Apparate locations
      */
@@ -339,5 +347,17 @@ public final class APPARATE extends O2Spell
     public Location getLocationByName (@NotNull String name)
     {
         return apparateLocations.get(name.toLowerCase());
+    }
+
+    /**
+     * Load saved data for this spell
+     */
+    public static void saveApparateLocations ()
+    {
+        if (Ollivanders2.apparateLocations)
+        {
+            GsonDAO gsonLayer = new GsonDAO();
+            gsonLayer.writeApparateData(apparateLocations);
+        }
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spell.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spell.java
@@ -81,6 +81,11 @@ public abstract class O2Spell implements Teachable
    protected boolean permanent = false;
 
    /**
+    * Is this a wandless spell
+    */
+   boolean isWandless = false;
+
+   /**
     * The callback to the MC plugin
     */
    Ollivanders2 p;
@@ -495,7 +500,10 @@ public abstract class O2Spell implements Teachable
       // the number of times the spell has been cast and then halved if the player is not using their
       // destined wand, doubled if they are using the elder wand
       spellUses = p.getSpellCount(player, spellType);
-      usesModifier = spellUses / rightWand;
+      if (isWandless)
+         usesModifier = spellUses;
+      else
+         usesModifier = spellUses / rightWand;
 
       // if the caster is affected by HIGHER_SKILL, double their usesModifier
       if (Ollivanders2API.getPlayers(p).playerEffects.hasEffect(player.getUniqueId(), O2EffectType.HIGHER_SKILL))

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpells.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpells.java
@@ -205,7 +205,7 @@ public class O2StationarySpells
    {
       List <Map<String, String>> serializedList = serializeO2StationarySpells();
 
-      GsonDAO gsonLayer = new GsonDAO(p);
+      GsonDAO gsonLayer = new GsonDAO();
       gsonLayer.writeSaveData(serializedList, GsonDAO.o2StationarySpellsJSONFile);
    }
 
@@ -214,7 +214,7 @@ public class O2StationarySpells
     */
    void loadO2StationarySpells ()
    {
-      GsonDAO gsonLayer = new GsonDAO(p);
+      GsonDAO gsonLayer = new GsonDAO();
       List<Map<String, String>> serializedSpells = gsonLayer.readSavedDataListMap(GsonDAO.o2StationarySpellsJSONFile);
 
       if (serializedSpells == null)


### PR DESCRIPTION
Added support for apparating by named location rather than by coordinate. When enabled, coordinates cannot be used. Locations are persisted to the plugin directory.

- refactored apparate entirely - it was implemented twice (once in spell, once in OllivandersListener, no idea why, way over-complicated and the implementations didn't even match :/
- added support for named apparate locations
- added isWandless flag to spells so we dont have to remember to override the rightWand arg in constructors
- fixed usage messages - commands missing, some had no usage messages
- fixed really bad bug in WG state check where it was sending back the opposite result of what we want - yikes
- fixed debug messages to use printDebugMessage
- removed plugin param to GsonDAO constructor since we don't really need it and then it can be used in static functions
- added save for apparate locations