### PR TITLE
Zone config rework

### DIFF
--- a/Ollivanders/src/config.yml
+++ b/Ollivanders/src/config.yml
@@ -81,30 +81,39 @@ overrideVersionCheck: false
 # Zones
 #
 # https://github.com/Azami7/Ollivanders2/wiki/Configuration#zones
-zones:
+#
+# zones:
+#  global:
+#    allowed-spells:
+#      -
+#    disallowed-spells:
+#      - AVADA_KEDAVRA
+#  example-wg-region:
+#    type: World_Guard
+#    allowed-spells:
+#      - LUMOS
+#      - NOX
+#      - INFORMOUS
+#    disallowed-spells:
+#      -
+#  example-world:
+#    type: World
+#    world: nether
+#    allowed-spells:
+#      -
+#    disallowed-spells:
+#      - APPARATE
+#  example-cuboid:
+#    type: Cuboid
+#    world: world
+#    area: 100 0 300 400 100 700
+#    allowed-spells:
+#      -
+#    disallowed-spells:
+#      - VOLATUS
+ zones:
   global:
     allowed-spells:
       -
     disallowed-spells:
       -
-  example-wg-region:
-    type: World_Guard
-    allowed-spells:
-      -
-    disallowed-spells:
-      -
-  example-world:
-    type: World
-    world: world
-    allowed-spells:
-      - 
-    disallowed-spells:
-      -
-  example-cuboid:
-    type: Cuboid
-    world: world
-    area: 0 0 0 0 0 0
-    allowed-spells:
-      - 
-    disallowed-spells:
-      - 

--- a/Ollivanders/src/config.yml
+++ b/Ollivanders/src/config.yml
@@ -82,14 +82,25 @@ overrideVersionCheck: false
 #
 # https://github.com/Azami7/Ollivanders2/wiki/Configuration#zones
 zones:
-  default-world:
+  global:
+    allowed-spells:
+      -
+    disallowed-spells:
+      -
+  example-wg-region:
+    type: World_Guard
+    allowed-spells:
+      -
+    disallowed-spells:
+      -
+  example-world:
     type: World
     world: world
     allowed-spells:
       - 
     disallowed-spells:
       -
-  default-cuboid:
+  example-cuboid:
     type: Cuboid
     world: world
     area: 0 0 0 0 0 0

--- a/Ollivanders/src/config.yml
+++ b/Ollivanders/src/config.yml
@@ -88,7 +88,7 @@ zones:
     allowed-spells:
       - 
     disallowed-spells:
-      - 
+      -
   default-cuboid:
     type: Cuboid
     world: world

--- a/Ollivanders/src/net/pottercraft/ollivanders2/GsonDAO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/GsonDAO.java
@@ -3,6 +3,7 @@ package net.pottercraft.ollivanders2;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.house.O2HouseType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/O2Color.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/O2Color.java
@@ -1,5 +1,6 @@
 package net.pottercraft.ollivanders2;
 
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
@@ -1814,122 +1814,12 @@ public class Ollivanders2 extends JavaPlugin
          return false;
       }
 
-      boolean cast = isSpellTypeAllowed(player.getLocation(), spell);
+      boolean cast = Ollivanders2API.getSpells(this).isSpellTypeAllowed(player.getLocation(), spell);
 
       if (!cast && verbose)
       {
          spellCannotBeCastMessage(player);
       }
-      return cast;
-   }
-
-   /**
-    * Determine if this spell can exist here based on zone config
-    *
-    * @param loc   the location the spell was cast
-    * @param spell the spell to check
-    * @return true if the spell can exist, false otherwise
-    */
-   public boolean isSpellTypeAllowed(@NotNull Location loc, @NotNull O2SpellType spell)
-   {
-      if (zoneConfig == null)
-      {
-         getLogger().info("isSpellTypeAllowed: no zone config");
-         return true;
-      }
-
-      boolean cast = true;
-      double x = loc.getX();
-      double y = loc.getY();
-      double z = loc.getZ();
-
-      for (String zone : zoneConfig.getKeys(false))
-      {
-         String prefix = zone + ".";
-         String type = zoneConfig.getString(prefix + "type");
-         String world = zoneConfig.getString(prefix + "world");
-         String areaString = zoneConfig.getString(prefix + "area");
-
-         if (type == null || world == null || areaString == null)
-            return true;
-
-         boolean allAllowed = false;
-         boolean allDisallowed = false;
-         List<O2SpellType> allowedSpells = new ArrayList<>();
-         for (String spellString : zoneConfig.getStringList(prefix + "allowed-spells"))
-         {
-            if (spellString.equalsIgnoreCase("ALL"))
-            {
-               allAllowed = true;
-            } else
-            {
-               allowedSpells.add(Ollivanders2API.getSpells(this).getSpellTypeByName(spellString));
-            }
-         }
-         List<O2SpellType> disallowedSpells = new ArrayList<>();
-         for (String spellString : zoneConfig.getStringList(prefix + "disallowed-spells"))
-         {
-            if (spellString.equalsIgnoreCase("ALL"))
-            {
-               allDisallowed = true;
-            }
-            else
-            {
-               disallowedSpells.add(Ollivanders2API.getSpells(this).getSpellTypeByName(spellString));
-            }
-         }
-         if (type.equalsIgnoreCase("World"))
-         {
-            if (loc.getWorld() != null && loc.getWorld().getName().equals(world))
-            {
-               if (allowedSpells.contains(spell) || allAllowed)
-               {
-                  return true;
-               }
-               if (disallowedSpells.contains(spell) || allDisallowed)
-               {
-                  cast = false;
-               }
-            }
-         }
-         if (type.equalsIgnoreCase("Cuboid"))
-         {
-            String[] areaStringList = areaString.split(" ");
-            List<Integer> area = new ArrayList<>();
-            for (String a : areaStringList)
-            {
-               area.add(Integer.parseInt(a));
-            }
-            if (area.size() < 6)
-            {
-               for (int i = 0; i < 6; i++)
-               {
-                  area.set(i, 0);
-               }
-            }
-            if (loc.getWorld() != null && loc.getWorld().getName().equals(world))
-            {
-               if ((area.get(0) < x) && (x < area.get(3)))
-               {
-                  if ((area.get(1) < y) && (y < area.get(4)))
-                  {
-                     if ((area.get(2) < z) && (z < area.get(5)))
-                     {
-                        if (allowedSpells.contains(spell) || allAllowed)
-                        {
-                           return true;
-                        }
-                        if (disallowedSpells.contains(spell) || allDisallowed)
-                        {
-                           cast = false;
-                        }
-                     }
-                  }
-               }
-            }
-         }
-      }
-
       return cast;
    }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
@@ -1823,101 +1823,104 @@ public class Ollivanders2 extends JavaPlugin
    }
 
    /**
-    * Determine if this spell can exist here
+    * Determine if this spell can exist here based on zone config
     *
-    * @param loc   the location of the spell
+    * @param loc   the location the spell was cast
     * @param spell the spell to check
     * @return true if the spell can exist, false otherwise
     */
    public boolean isSpellTypeAllowed(@NotNull Location loc, @NotNull O2SpellType spell)
    {
+      if (zoneConfig == null)
+      {
+         getLogger().info("isSpellTypeAllowed: no zone config");
+         return true;
+      }
+
       boolean cast = true;
       double x = loc.getX();
       double y = loc.getY();
       double z = loc.getZ();
 
-      if (zoneConfig != null)
+      for (String zone : zoneConfig.getKeys(false))
       {
-         for (String zone : zoneConfig.getKeys(false))
+         String prefix = zone + ".";
+         String type = zoneConfig.getString(prefix + "type");
+         String world = zoneConfig.getString(prefix + "world");
+         String areaString = zoneConfig.getString(prefix + "area");
+
+         if (type == null || world == null || areaString == null)
+            return true;
+
+         boolean allAllowed = false;
+         boolean allDisallowed = false;
+         List<O2SpellType> allowedSpells = new ArrayList<>();
+         for (String spellString : zoneConfig.getStringList(prefix + "allowed-spells"))
          {
-            String prefix = zone + ".";
-            String type = zoneConfig.getString(prefix + "type");
-            String world = zoneConfig.getString(prefix + "world");
-            String areaString = zoneConfig.getString(prefix + "area");
-
-            if (type == null || world == null || areaString == null)
-               return true;
-
-            boolean allAllowed = false;
-            boolean allDisallowed = false;
-            List<O2SpellType> allowedSpells = new ArrayList<>();
-            for (String spellString : zoneConfig.getStringList(prefix + "allowed-spells"))
+            if (spellString.equalsIgnoreCase("ALL"))
             {
-               if (spellString.equalsIgnoreCase("ALL"))
+               allAllowed = true;
+            } else
+            {
+               allowedSpells.add(Ollivanders2API.getSpells(this).getSpellTypeByName(spellString));
+            }
+         }
+         List<O2SpellType> disallowedSpells = new ArrayList<>();
+         for (String spellString : zoneConfig.getStringList(prefix + "disallowed-spells"))
+         {
+            if (spellString.equalsIgnoreCase("ALL"))
+            {
+               allDisallowed = true;
+            }
+            else
+            {
+               disallowedSpells.add(Ollivanders2API.getSpells(this).getSpellTypeByName(spellString));
+            }
+         }
+         if (type.equalsIgnoreCase("World"))
+         {
+            if (loc.getWorld() != null && loc.getWorld().getName().equals(world))
+            {
+               if (allowedSpells.contains(spell) || allAllowed)
                {
-                  allAllowed = true;
-               } else
+                  return true;
+               }
+               if (disallowedSpells.contains(spell) || allDisallowed)
                {
-                  allowedSpells.add(Ollivanders2API.getSpells(this).getSpellTypeByName(spellString));
+                  cast = false;
                }
             }
-            List<O2SpellType> disallowedSpells = new ArrayList<>();
-            for (String spellString : zoneConfig.getStringList(prefix + "disallowed-spells"))
+         }
+         if (type.equalsIgnoreCase("Cuboid"))
+         {
+            String[] areaStringList = areaString.split(" ");
+            List<Integer> area = new ArrayList<>();
+            for (String a : areaStringList)
             {
-               if (spellString.equalsIgnoreCase("ALL"))
+               area.add(Integer.parseInt(a));
+            }
+            if (area.size() < 6)
+            {
+               for (int i = 0; i < 6; i++)
                {
-                  allDisallowed = true;
-               }
-               else
-               {
-                  disallowedSpells.add(Ollivanders2API.getSpells(this).getSpellTypeByName(spellString));
+                  area.set(i, 0);
                }
             }
-            if (type.equalsIgnoreCase("World"))
+            if (loc.getWorld() != null && loc.getWorld().getName().equals(world))
             {
-               if (loc.getWorld() != null && loc.getWorld().getName().equals(world))
+               if ((area.get(0) < x) && (x < area.get(3)))
                {
-                  if (allowedSpells.contains(spell) || allAllowed)
+                  if ((area.get(1) < y) && (y < area.get(4)))
                   {
-                     return true;
-                  }
-                  if (disallowedSpells.contains(spell) || allDisallowed)
-                  {
-                     cast = false;
-                  }
-               }
-            }
-            if (type.equalsIgnoreCase("Cuboid"))
-            {
-               String[] areaStringList = areaString.split(" ");
-               List<Integer> area = new ArrayList<>();
-               for (String a : areaStringList)
-               {
-                  area.add(Integer.parseInt(a));
-               }
-               if (area.size() < 6)
-               {
-                  for (int i = 0; i < 6; i++)
-                  {
-                     area.set(i, 0);
-                  }
-               }
-               if (loc.getWorld() != null && loc.getWorld().getName().equals(world))
-               {
-                  if ((area.get(0) < x) && (x < area.get(3)))
-                  {
-                     if ((area.get(1) < y) && (y < area.get(4)))
+                     if ((area.get(2) < z) && (z < area.get(5)))
                      {
-                        if ((area.get(2) < z) && (z < area.get(5)))
+                        if (allowedSpells.contains(spell) || allAllowed)
                         {
-                           if (allowedSpells.contains(spell) || allAllowed)
-                           {
-                              return true;
-                           }
-                           if (disallowedSpells.contains(spell) || allDisallowed)
-                           {
-                              cast = false;
-                           }
+                           return true;
+                        }
+                        if (disallowedSpells.contains(spell) || allDisallowed)
+                        {
+                           cast = false;
                         }
                      }
                   }
@@ -1925,6 +1928,7 @@ public class Ollivanders2 extends JavaPlugin
             }
          }
       }
+
       return cast;
    }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import quidditch.Arena;
 
 import net.pottercraft.ollivanders2.effect.O2Effect;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2API.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2API.java
@@ -1,6 +1,7 @@
 package net.pottercraft.ollivanders2;
 
 import net.pottercraft.ollivanders2.book.O2Books;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.divination.O2Prophecies;
 import net.pottercraft.ollivanders2.house.O2Houses;
 import net.pottercraft.ollivanders2.item.O2Items;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2WorldGuard.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2WorldGuard.java
@@ -7,6 +7,7 @@ import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import com.sk89q.worldguard.protection.regions.RegionContainer;
 import com.sk89q.worldguard.protection.regions.RegionQuery;
 import org.bukkit.Bukkit;
@@ -179,5 +180,28 @@ public class Ollivanders2WorldGuard
 
       LocalPlayer wgPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
       return regionSet.testState(wgPlayer, Flags.BUILD);
+   }
+
+   /**
+    * Determine if a location is in a region by name
+    *
+    * @param regionName the name of the region to check
+    * @param location the location to check
+    * @return true if it is inside a region with this name, false otherwise
+    */
+   public boolean isLocationInRegionByName(String regionName, Location location)
+   {
+      ApplicableRegionSet regionSet = getWGRegionSet(location);
+
+      if (regionSet == null || regionSet.size() < 1)
+         return false;
+
+      for (ProtectedRegion region : regionSet.getRegions())
+      {
+         if (region.getId().equalsIgnoreCase(regionName))
+            return true;
+      }
+
+      return false;
    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2WorldGuard.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2WorldGuard.java
@@ -199,7 +199,9 @@ public class Ollivanders2WorldGuard
       for (ProtectedRegion region : regionSet.getRegions())
       {
          if (region.getId().equalsIgnoreCase(regionName))
+         {
             return true;
+         }
       }
 
       return false;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/OllivandersListener.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/OllivandersListener.java
@@ -1,6 +1,7 @@
 package net.pottercraft.ollivanders2;
 
 import net.pottercraft.ollivanders2.book.O2Books;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.effect.BURNING;
 import net.pottercraft.ollivanders2.effect.O2Effect;
 import net.pottercraft.ollivanders2.effect.BABBLING;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/OllivandersSchedule.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/OllivandersSchedule.java
@@ -402,7 +402,7 @@ class OllivandersSchedule implements Runnable
       {
          for (Player player : world.getPlayers())
          {
-            if (Ollivanders2API.common.isBroom(player.getInventory().getItemInMainHand()) && p.isSpellTypeAllowed(player.getLocation(), O2SpellType.VOLATUS))
+            if (Ollivanders2API.common.isBroom(player.getInventory().getItemInMainHand()) && Ollivanders2API.getSpells(p).isSpellTypeAllowed(player.getLocation(), O2SpellType.VOLATUS))
             {
                player.setAllowFlight(true);
                player.setFlying(true);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/OllivandersSchedule.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/OllivandersSchedule.java
@@ -8,6 +8,7 @@ import java.util.ListIterator;
 import java.util.Set;
 import java.util.UUID;
 
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.effect.O2EffectType;
 import net.pottercraft.ollivanders2.player.O2Player;
 import net.pottercraft.ollivanders2.spell.GEMINIO;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/BookTexts.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/BookTexts.java
@@ -4,7 +4,7 @@ import java.util.Map;
 import java.util.HashMap;
 
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.potion.O2PotionType;
 import net.pottercraft.ollivanders2.spell.O2SpellType;
 import net.pottercraft.ollivanders2.Ollivanders2;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/O2Books.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/O2Books.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.effect.O2EffectType;
 import net.pottercraft.ollivanders2.Ollivanders2API;
 import net.pottercraft.ollivanders2.potion.O2PotionType;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/common/Cuboid.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/common/Cuboid.java
@@ -33,12 +33,12 @@ public class Cuboid
 
         if (area.length == 6)
         {
-            int x1 = area[0];
-            int y1 = area[1];
-            int z1 = area[2];
-            int x2 = area[3];
-            int y2 = area[4];
-            int z2 = area[5];
+            x1 = area[0];
+            y1 = area[1];
+            z1 = area[2];
+            x2 = area[3];
+            y2 = area[4];
+            z2 = area[5];
         }
     }
 
@@ -48,13 +48,16 @@ public class Cuboid
      * @param location the location to check
      * @return true if inside, false otherwise
      */
-    public boolean isInside (@NotNull Location location)
+    public boolean isInside (@NotNull Location location, Ollivanders2Common common)
     {
         World world = location.getWorld();
         if (world == null)
+        {
+            common.printDebugMessage("Cuboid.isInside: World is null", null, null, true);
             return false;
+        }
 
-        return isInside(world.getName(), (int)(location.getY()), (int)(location.getX()), (int)(location.getZ()));
+        return isInside(world.getName(), (int)(location.getX()), (int)(location.getY()), (int)(location.getZ()), common);
     }
 
     /**
@@ -66,32 +69,42 @@ public class Cuboid
      * @param z the z-coordinate
      * @return true if inside, false otherwise
      */
-    public boolean isInside (String world, int x, int y, int z)
+    public boolean isInside (String world, int x, int y, int z, Ollivanders2Common common)
     {
         if (!worldName.equalsIgnoreCase(world))
-            return false;
-
-        if ((x1 > x2 && x < x1 && x > x2) || (x1 < x2 && x > x1 && x < x2))
         {
-            if ((y1 > y2 && y < y1 && y > y2) || (y1 < y2 && y > y1 && y < y2))
+            return false;
+        }
+
+        if ((x1 > x2 && x <= x1 && x >= x2) || (x1 < x2 && x >= x1 && x <= x2))
+        {
+            if ((y1 > y2 && y <= y1 && y >= y2) || (y1 < y2 && y >= y1 && y <= y2))
             {
-                if ((z1 > z2 && z < z1 && z > z2) || (z1 < z2 && x > z1 && z < z2))
+                if ((z1 > z2 && z <= z1 && z >= z2) || (z1 < z2 && x >= z1 && z <= z2))
+                {
                     return true;
+                }
                 else
+                {
                     return false;
+                }
             }
             else
+            {
                 return false;
+            }
         }
         else
+        {
             return false;
+        }
     }
 
     /**
      * Parse a cuboid area from a string
      *
-     * @param areaString
-     * @return an int array of 2 x, y, z coordinate or null if parse failed
+     * @param areaString a string of two x, y, z coordinates in the format "0 0 0 0 0 0"
+     * @return an int array of two x, y, z coordinates or null if parse failed
      */
     @Nullable
     public static int[] parseArea (@NotNull String areaString)

--- a/Ollivanders/src/net/pottercraft/ollivanders2/common/Cuboid.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/common/Cuboid.java
@@ -1,7 +1,9 @@
 package net.pottercraft.ollivanders2.common;
 
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * An Area Cuboid
@@ -10,6 +12,8 @@ import org.jetbrains.annotations.NotNull;
  */
 public class Cuboid
 {
+    String worldName;
+
     int x1 = 0;
     int y1 = 0;
     int z1 = 0;
@@ -20,10 +24,13 @@ public class Cuboid
     /**
      * Constructor
      *
+     * @param world the name of the world this cuboid is in
      * @param area two opposite corner points of the Cuboid
      */
-    public Cuboid (@NotNull int[] area)
+    public Cuboid (@NotNull String world, @NotNull int[] area)
     {
+        worldName = world;
+
         if (area.length == 6)
         {
             int x1 = area[0];
@@ -43,19 +50,27 @@ public class Cuboid
      */
     public boolean isInside (@NotNull Location location)
     {
-        return isInside((int)(location.getY()), (int)(location.getX()), (int)(location.getZ()));
+        World world = location.getWorld();
+        if (world == null)
+            return false;
+
+        return isInside(world.getName(), (int)(location.getY()), (int)(location.getX()), (int)(location.getZ()));
     }
 
     /**
-     * Is the location inside this Cuboid
+     * Is the location point inside this Cuboid
      *
+     * @param world the name of the world this point is in
      * @param x the x-coordinate
      * @param y the y-coordinate
      * @param z the z-coordinate
      * @return true if inside, false otherwise
      */
-    public boolean isInside (int x, int y, int z)
+    public boolean isInside (String world, int x, int y, int z)
     {
+        if (!worldName.equalsIgnoreCase(world))
+            return false;
+
         if ((x1 > x2 && x < x1 && x > x2) || (x1 < x2 && x > x1 && x < x2))
         {
             if ((y1 > y2 && y < y1 && y > y2) || (y1 < y2 && y > y1 && y < y2))
@@ -70,6 +85,41 @@ public class Cuboid
         }
         else
             return false;
+    }
+
+    /**
+     * Parse a cuboid area from a string
+     *
+     * @param areaString
+     * @return an int array of 2 x, y, z coordinate or null if parse failed
+     */
+    @Nullable
+    public static int[] parseArea (@NotNull String areaString)
+    {
+        if (!areaString.contains(" "))
+            return null;
+
+        String[] splits = areaString.split(" ");
+        if (splits.length != 6)
+            return null;
+
+        int[] area = new int[6];
+
+        try
+        {
+            area[0] = Integer.parseInt(splits[0]);
+            area[1] = Integer.parseInt(splits[1]);
+            area[2] = Integer.parseInt(splits[2]);
+            area[3] = Integer.parseInt(splits[3]);
+            area[4] = Integer.parseInt(splits[4]);
+            area[5] = Integer.parseInt(splits[5]);
+        }
+        catch (Exception e)
+        {
+            return null;
+        }
+
+        return area;
     }
 }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/common/Cuboid.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/common/Cuboid.java
@@ -1,0 +1,75 @@
+package net.pottercraft.ollivanders2.common;
+
+import org.bukkit.Location;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An Area Cuboid
+ *
+ * @author Azami7
+ */
+public class Cuboid
+{
+    int x1 = 0;
+    int y1 = 0;
+    int z1 = 0;
+    int x2 = 0;
+    int y2 = 0;
+    int z2 = 0;
+
+    /**
+     * Constructor
+     *
+     * @param area two opposite corner points of the Cuboid
+     */
+    public Cuboid (@NotNull int[] area)
+    {
+        if (area.length == 6)
+        {
+            int x1 = area[0];
+            int y1 = area[1];
+            int z1 = area[2];
+            int x2 = area[3];
+            int y2 = area[4];
+            int z2 = area[5];
+        }
+    }
+
+    /**
+     * Is the location inside this Cuboid
+     *
+     * @param location the location to check
+     * @return true if inside, false otherwise
+     */
+    public boolean isInside (@NotNull Location location)
+    {
+        return isInside((int)(location.getY()), (int)(location.getX()), (int)(location.getZ()));
+    }
+
+    /**
+     * Is the location inside this Cuboid
+     *
+     * @param x the x-coordinate
+     * @param y the y-coordinate
+     * @param z the z-coordinate
+     * @return true if inside, false otherwise
+     */
+    public boolean isInside (int x, int y, int z)
+    {
+        if ((x1 > x2 && x < x1 && x > x2) || (x1 < x2 && x > x1 && x < x2))
+        {
+            if ((y1 > y2 && y < y1 && y > y2) || (y1 < y2 && y > y1 && y < y2))
+            {
+                if ((z1 > z2 && z < z1 && z > z2) || (z1 < z2 && x > z1 && z < z2))
+                    return true;
+                else
+                    return false;
+            }
+            else
+                return false;
+        }
+        else
+            return false;
+    }
+}
+

--- a/Ollivanders/src/net/pottercraft/ollivanders2/common/Ollivanders2Common.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/common/Ollivanders2Common.java
@@ -1,4 +1,4 @@
-package net.pottercraft.ollivanders2;
+package net.pottercraft.ollivanders2.common;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -13,6 +13,8 @@ import java.util.Random;
 import java.util.UUID;
 
 import me.libraryaddict.disguise.disguisetypes.RabbitType;
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
 import net.pottercraft.ollivanders2.item.O2ItemType;
 import net.pottercraft.ollivanders2.player.O2PlayerCommon;
 import net.pottercraft.ollivanders2.player.O2WandCoreType;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Divination.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Divination.java
@@ -4,7 +4,7 @@ import net.pottercraft.ollivanders2.effect.O2Effect;
 import net.pottercraft.ollivanders2.effect.O2EffectType;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Prophecy.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Prophecy.java
@@ -4,7 +4,7 @@ import net.pottercraft.ollivanders2.effect.O2Effect;
 import net.pottercraft.ollivanders2.effect.O2EffectType;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.player.O2Player;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/AGGRESSION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/AGGRESSION.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 
 import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 
 import org.bukkit.entity.Creature;
 import org.bukkit.entity.LivingEntity;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/BABBLING.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/BABBLING.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.UUID;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.jetbrains.annotations.NotNull;
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/BURNING.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/BURNING.java
@@ -1,7 +1,7 @@
 package net.pottercraft.ollivanders2.effect;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Effect;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effect.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effect.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.UUID;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.jetbrains.annotations.NotNull;
 
 /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effects.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effects.java
@@ -2,7 +2,7 @@ package net.pottercraft.ollivanders2.effect;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/PotionEffectSuper.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/PotionEffectSuper.java
@@ -1,7 +1,7 @@
 package net.pottercraft.ollivanders2.effect;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/WEALTH.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/WEALTH.java
@@ -2,7 +2,7 @@ package net.pottercraft.ollivanders2.effect;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/house/O2Houses.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/house/O2Houses.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.GsonDAO;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.Player;
 import org.bukkit.scoreboard.Objective;
 import org.bukkit.scoreboard.Score;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Player.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Player.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
 
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
 import net.pottercraft.ollivanders2.O2Color;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/player/O2PlayerCommon.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/player/O2PlayerCommon.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/player/O2WandCoreType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/player/O2WandCoreType.java
@@ -1,7 +1,6 @@
 package net.pottercraft.ollivanders2.player;
 
-import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Material;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/player/O2WandWoodType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/player/O2WandWoodType.java
@@ -1,6 +1,6 @@
 package net.pottercraft.ollivanders2.player;
 
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Material;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/FORGETFULLNESS_POTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/FORGETFULLNESS_POTION.java
@@ -3,7 +3,7 @@ package net.pottercraft.ollivanders2.potion;
 import net.pottercraft.ollivanders2.item.O2ItemType;
 import net.pottercraft.ollivanders2.player.O2Player;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.spell.O2SpellType;
 import org.bukkit.Color;
 import org.bukkit.entity.Player;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2Potion.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2Potion.java
@@ -9,7 +9,7 @@ import java.util.Map.Entry;
 import net.pottercraft.ollivanders2.item.O2ItemType;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.player.O2Player;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Teachable;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2Potions.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2Potions.java
@@ -9,7 +9,7 @@ import java.util.List;
 import net.pottercraft.ollivanders2.item.O2ItemType;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/ALIQUAM_FLOO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/ALIQUAM_FLOO.java
@@ -4,7 +4,7 @@ import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.stationaryspell.StationarySpellObj;
 import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpellType;
 import org.bukkit.Location;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/AMATO_ANIMO_ANIMATO_ANIMAGUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/AMATO_ANIMO_ANIMATO_ANIMAGUS.java
@@ -7,7 +7,7 @@ import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2API;
 import net.pottercraft.ollivanders2.player.O2Player;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/AddO2Effect.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/AddO2Effect.java
@@ -5,7 +5,7 @@ import net.pottercraft.ollivanders2.effect.O2EffectType;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/AddPotionEffect.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/AddPotionEffect.java
@@ -2,7 +2,7 @@ package net.pottercraft.ollivanders2.spell;
 
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffectType;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/BRACKIUM_EMENDO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/BRACKIUM_EMENDO.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.pottercraft.ollivanders2.O2MagicBranch;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/BlockTransfiguration.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/BlockTransfiguration.java
@@ -9,7 +9,7 @@ import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/DEFODIO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/DEFODIO.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpellType;
 import org.bukkit.Location;
 import org.bukkit.Material;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/DEPRIMO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/DEPRIMO.java
@@ -7,7 +7,7 @@ import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/DISSENDIUM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/DISSENDIUM.java
@@ -4,7 +4,7 @@ import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.stationaryspell.COLLOPORTUS;
 import net.pottercraft.ollivanders2.stationaryspell.StationarySpellObj;
 import org.bukkit.Location;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/ENGORGIO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/ENGORGIO.java
@@ -3,7 +3,7 @@ package net.pottercraft.ollivanders2.spell;
 import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.Ageable;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/EQUUSIFORS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/EQUUSIFORS.java
@@ -5,7 +5,7 @@ import me.libraryaddict.disguise.disguisetypes.MobDisguise;
 import me.libraryaddict.disguise.disguisetypes.watchers.HorseWatcher;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/EntityTransfiguration.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/EntityTransfiguration.java
@@ -2,7 +2,7 @@ package net.pottercraft.ollivanders2.spell;
 
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/FIENDFYRE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/FIENDFYRE.java
@@ -6,7 +6,7 @@ import java.util.List;
 import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.stationaryspell.StationarySpellObj;
 import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpellType;
 import org.bukkit.World;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/FriendlyMobDisguise.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/FriendlyMobDisguise.java
@@ -2,7 +2,7 @@ package net.pottercraft.ollivanders2.spell;
 
 import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/HARMONIA_NECTERE_PASSUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/HARMONIA_NECTERE_PASSUS.java
@@ -2,6 +2,7 @@ package net.pottercraft.ollivanders2.spell;
 
 import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.*;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.stationaryspell.StationarySpellObj;
 import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpellType;
 import org.bukkit.Bukkit;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_EQUUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_EQUUS.java
@@ -5,7 +5,7 @@ import me.libraryaddict.disguise.disguisetypes.MobDisguise;
 import me.libraryaddict.disguise.disguisetypes.watchers.HorseWatcher;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_FELIS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_FELIS.java
@@ -5,7 +5,7 @@ import me.libraryaddict.disguise.disguisetypes.MobDisguise;
 import me.libraryaddict.disguise.disguisetypes.watchers.CatWatcher;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_LAMA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_LAMA.java
@@ -5,7 +5,7 @@ import me.libraryaddict.disguise.disguisetypes.MobDisguise;
 import me.libraryaddict.disguise.disguisetypes.watchers.LlamaWatcher;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_LUPI.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_LUPI.java
@@ -5,7 +5,7 @@ import me.libraryaddict.disguise.disguisetypes.MobDisguise;
 import me.libraryaddict.disguise.disguisetypes.watchers.WolfWatcher;
 import net.pottercraft.ollivanders2.O2Color;
 import net.pottercraft.ollivanders2.O2MagicBranch;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_PORCILLI.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_PORCILLI.java
@@ -5,7 +5,7 @@ import me.libraryaddict.disguise.disguisetypes.MobDisguise;
 import me.libraryaddict.disguise.disguisetypes.watchers.PigWatcher;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_URSUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_URSUS.java
@@ -7,7 +7,7 @@ import me.libraryaddict.disguise.disguisetypes.watchers.PandaWatcher;
 import me.libraryaddict.disguise.disguisetypes.watchers.PolarBearWatcher;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Panda;
 import org.bukkit.entity.Player;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_VACCULA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/INCARNATIO_VACCULA.java
@@ -5,7 +5,7 @@ import me.libraryaddict.disguise.disguisetypes.MobDisguise;
 import me.libraryaddict.disguise.disguisetypes.watchers.AgeableWatcher;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/INFORMOUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/INFORMOUS.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.stationaryspell.ALIQUAM_FLOO;
 import net.pottercraft.ollivanders2.stationaryspell.COLLOPORTUS;
 import net.pottercraft.ollivanders2.stationaryspell.HARMONIA_NECTERE_PASSUS;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/IncendioSuper.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/IncendioSuper.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.block.Block;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/LEGILIMENS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/LEGILIMENS.java
@@ -5,7 +5,7 @@ import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.player.O2Player;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/LIGATIS_COR.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/LIGATIS_COR.java
@@ -8,7 +8,7 @@ import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.player.O2WandCoreType;
 import org.bukkit.Location;
 import org.bukkit.Material;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/LUMOS_DUO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/LUMOS_DUO.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.O2MagicBranch;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/LUMOS_MAXIMA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/LUMOS_MAXIMA.java
@@ -3,7 +3,7 @@ package net.pottercraft.ollivanders2.spell;
 import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.World;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/LUMOS_SOLEM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/LUMOS_SOLEM.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/MELOFORS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/MELOFORS.java
@@ -2,7 +2,7 @@ package net.pottercraft.ollivanders2.spell;
 
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/MORTUOS_SUSCITATE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/MORTUOS_SUSCITATE.java
@@ -2,7 +2,7 @@ package net.pottercraft.ollivanders2.spell;
 
 import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.O2MagicBranch;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Item;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spell.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spell.java
@@ -344,7 +344,7 @@ public abstract class O2Spell implements Teachable
       boolean isAllowed = true;
 
       // determine if this spell is allowed in this location per Ollivanders2 config
-      if (!p.isSpellTypeAllowed(location, spellType))
+      if (!Ollivanders2API.getSpells(p).isSpellTypeAllowed(location, spellType))
       {
          kill();
          isAllowed = false;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spell.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spell.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 
 import net.pottercraft.ollivanders2.effect.O2EffectType;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.Teachable;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2API;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spells.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spells.java
@@ -1,7 +1,10 @@
 package net.pottercraft.ollivanders2.spell;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Cuboid;
+import org.bukkit.Location;
+import org.bukkit.configuration.ConfigurationSection;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -18,14 +21,80 @@ import java.util.Map;
  */
 public class O2Spells
 {
+    /**
+     * Common functions
+     */
     private final Ollivanders2Common common;
 
+    /**
+     * List of loaded spells
+     */
     final private Map<String, O2SpellType> O2SpellMap = new HashMap<>();
 
+    /**
+     * Wandless spells
+     */
     public static final List<O2SpellType> wandlessSpells = new ArrayList<>()
     {{
         add(O2SpellType.AMATO_ANIMO_ANIMATO_ANIMAGUS);
     }};
+
+    /**
+     * Spell allowed/disallowed zones
+     */
+    private ConfigurationSection zoneConfig;
+    private ArrayList<O2SpellType> globalDisallowedSpells = new ArrayList<>();
+    private ArrayList<O2SpellType> globalAllowedSpells = new ArrayList<>();
+
+    private enum spellZoneType
+    {
+        WORLD_GUARD,
+        CUBOID;
+    }
+
+    private class SpellZone
+    {
+        spellZoneType zoneType;
+        Cuboid cuboid = null;
+
+        ArrayList<O2SpellType> disallowedSpells = new ArrayList<>();
+        ArrayList<O2SpellType> allowedSpells = new ArrayList<>();
+
+        SpellZone (@NotNull spellZoneType type, int[] area, @NotNull ArrayList<O2SpellType> allowed, @NotNull ArrayList<O2SpellType> disallowed)
+        {
+            zoneType = type;
+
+            if (type == spellZoneType.WORLD_GUARD)
+                cuboid = new Cuboid(area);
+
+            allowedSpells = new ArrayList<>(allowed);
+            disallowedSpells = new ArrayList<>(disallowed);
+        }
+
+        /**
+         * Is the spell allowed in this zone
+         *
+         * @param spellType the spell to check
+         * @return true if allowed, false otherwise
+         */
+        public boolean isAllowed (O2SpellType spellType, Location location)
+        {
+            // is this location in this zone
+            if (zoneType == spellZoneType.WORLD_GUARD)
+            {
+
+            }
+            else
+            {
+                if (cuboid == null)
+                    return true;
+
+
+            }
+
+            return true;
+        }
+    }
 
     /**
      * Constructor
@@ -43,6 +112,8 @@ public class O2Spells
 
             O2SpellMap.put(spellType.getSpellName().toLowerCase(), spellType);
         }
+
+        loadZoneConfig(plugin);
     }
 
     /**
@@ -93,5 +164,88 @@ public class O2Spells
     public boolean isLoaded(@NotNull O2SpellType spellType)
     {
         return O2SpellMap.containsValue(spellType);
+    }
+
+    /**
+     * Load the zone config for spells
+     *
+     * @param p a callback to the plugin
+     */
+    public void loadZoneConfig (@NotNull Ollivanders2 p)
+    {
+        zoneConfig = p.getConfig().getConfigurationSection("zones");
+
+        if (zoneConfig == null)
+            return;
+
+        loadGlobalZoneConfig(p);
+
+
+    }
+
+    private void loadGlobalZoneConfig (@NotNull Ollivanders2 p)
+    {
+        if (zoneConfig == null)
+            return;
+
+        for (String zone : zoneConfig.getKeys(false))
+        {
+            if (!zone.equalsIgnoreCase("default-world"))
+                continue;
+
+            // check allowed first since globalAllowedSpells has precedence over globalDisallowedSpells
+            for (String spell : zoneConfig.getStringList(zone + ".allowed-spells"))
+            {
+                O2SpellType spellType = O2SpellType.spellTypeFromString(spell);
+                if (spellType != null && isLoaded(spellType))
+                    globalAllowedSpells.add(spellType);
+            }
+
+            if (globalAllowedSpells.size() > 0)
+                return;
+
+            for (String spell : zoneConfig.getStringList(zone + ".disallowed-spells"))
+            {
+                O2SpellType spellType = O2SpellType.spellTypeFromString(spell);
+                if (spellType != null)
+                    globalDisallowedSpells.add(spellType);
+            }
+        }
+    }
+
+    /**
+     * Check if a spell is allowed based on zone config
+     *
+     * @param spellType the spell type to check
+     * @param location the location of the spell
+     * @return true if spell is allowed, false otherwise
+     */
+    public boolean checkSpellZoneConfig (@NotNull O2SpellType spellType, @NotNull Location location)
+    {
+        if (!isLoaded(spellType))
+            return false;
+
+
+
+        return true;
+    }
+
+    /**
+     * Check if a spell is allowed based on zone config
+     *
+     * @param spellname the name of the spell
+     * @param location the location of the spell
+     * @return true if spell is allowed, false otherwise
+     */
+    public boolean checkSpellZoneConfig (@NotNull String spellname, @NotNull Location location)
+    {
+        O2SpellType spellType = O2SpellType.spellTypeFromString(spellname);
+
+        if (spellType != null)
+        {
+            return checkSpellZoneConfig(spellType, location);
+        }
+        else
+            return true;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/PACK.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/PACK.java
@@ -3,7 +3,7 @@ package net.pottercraft.ollivanders2.spell;
 import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.stationaryspell.COLLOPORTUS;
 import org.bukkit.Material;
 import org.bukkit.block.Block;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/PARTIS_TEMPORUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/PARTIS_TEMPORUS.java
@@ -2,7 +2,7 @@ package net.pottercraft.ollivanders2.spell;
 
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.Player;
 
 import net.pottercraft.ollivanders2.Ollivanders2;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/PETRIFICUS_TOTALUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/PETRIFICUS_TOTALUS.java
@@ -4,7 +4,7 @@ import net.pottercraft.ollivanders2.effect.IMMOBILIZE;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/PRIOR_INCANTATO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/PRIOR_INCANTATO.java
@@ -3,7 +3,7 @@ package net.pottercraft.ollivanders2.spell;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.player.O2Player;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/PROPHETEIA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/PROPHETEIA.java
@@ -3,7 +3,7 @@ package net.pottercraft.ollivanders2.spell;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/PROTEGO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/PROTEGO.java
@@ -2,7 +2,7 @@ package net.pottercraft.ollivanders2.spell;
 
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.stationaryspell.StationarySpellObj;
 import org.bukkit.entity.Player;
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/Pyrotechnia.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/Pyrotechnia.java
@@ -12,7 +12,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.meta.FireworkMeta;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.jetbrains.annotations.NotNull;
 
 /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/REPARIFORS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/REPARIFORS.java
@@ -4,7 +4,7 @@ import net.pottercraft.ollivanders2.effect.O2EffectType;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/ReduceO2Effect.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/ReduceO2Effect.java
@@ -4,7 +4,7 @@ import net.pottercraft.ollivanders2.effect.O2EffectType;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/RemovePotionEffect.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/RemovePotionEffect.java
@@ -2,7 +2,7 @@ package net.pottercraft.ollivanders2.spell;
 
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffectType;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/StationarySpell.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/StationarySpell.java
@@ -4,7 +4,7 @@ import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.stationaryspell.StationarySpellObj;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/Transfiguration.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/Transfiguration.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 
 import org.bukkit.Location;
 import org.bukkit.World;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/VENTO_FOLIO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/VENTO_FOLIO.java
@@ -2,7 +2,7 @@ package net.pottercraft.ollivanders2.spell;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.effect.FLYING;
 import org.bukkit.entity.Player;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HARMONIA_NECTERE_PASSUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HARMONIA_NECTERE_PASSUS.java
@@ -4,7 +4,7 @@ import java.util.*;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpells.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpells.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 import net.pottercraft.ollivanders2.GsonDAO;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Location;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/REPELLO_MUGGLETON.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/REPELLO_MUGGLETON.java
@@ -2,7 +2,7 @@ package net.pottercraft.ollivanders2.stationaryspell;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/StationarySpellObj.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/StationarySpellObj.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.Ollivanders2Common;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.LivingEntity;


### PR DESCRIPTION
Rewrote entirely how zone config works:

- made zone config actually work again (no idea why it broke, didn't even try to investigate since it needed to be rewritten anyway)
- moved to O2Spells from main plugin class
- zone config is only loaded once at game start rather than every time a spell is checked
- added support for WG regions as zones
- moved Ollivanders2Common to a new common package for better organization (this made a lot of file changes but they are just include changes)