### PR TITLE
Rewrote brooms

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/AGGRESSION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/AGGRESSION.java
@@ -168,4 +168,10 @@ public class AGGRESSION extends O2Effect
     */
    @Override
    public void setPermanent (boolean perm) { }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/ANIMAGUS_EFFECT.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/ANIMAGUS_EFFECT.java
@@ -314,4 +314,10 @@ public class ANIMAGUS_EFFECT extends ShapeShiftSuper
     */
    @Override
    public void setPermanent(boolean perm) { }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/ANIMAGUS_INCANTATION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/ANIMAGUS_INCANTATION.java
@@ -33,4 +33,10 @@ public class ANIMAGUS_INCANTATION extends O2Effect
     */
    @Override
    public void checkEffect () { }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/AWAKE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/AWAKE.java
@@ -36,4 +36,10 @@ public class AWAKE extends O2Effect
    {
       age(1);
    }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/AWAKE_ANTIDOTE_LESSER.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/AWAKE_ANTIDOTE_LESSER.java
@@ -27,4 +27,10 @@ public class AWAKE_ANTIDOTE_LESSER extends O2EffectAntidoteSuper
         o2EffectType = O2EffectType.AWAKE;
         strength = 0.25;
     }
+
+    /**
+     * Do any cleanup related to removing this effect from the player
+     */
+    @Override
+    public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/BABBLING.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/BABBLING.java
@@ -132,4 +132,10 @@ public class BABBLING extends O2Effect
       if (Ollivanders2.debug)
          p.getLogger().info("Changed " + event.getPlayer().getDisplayName() + "'s chat from \"" + message + "\" to \"" + newMessage + "\"");
    }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/BABBLING_ANTIDOTE_LESSER.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/BABBLING_ANTIDOTE_LESSER.java
@@ -27,4 +27,10 @@ public class BABBLING_ANTIDOTE_LESSER extends O2EffectAntidoteSuper
         o2EffectType = O2EffectType.BABBLING;
         strength = 0.25;
     }
+
+    /**
+     * Do any cleanup related to removing this effect from the player
+     */
+    @Override
+    public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/BLINDNESS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/BLINDNESS.java
@@ -29,4 +29,10 @@ public class BLINDNESS extends PotionEffectSuper
       divinationText.add("will become unable to see");
       divinationText.add("will be struck by a terrible affliction");
    }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/BROOM_FLYING.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/BROOM_FLYING.java
@@ -1,0 +1,31 @@
+package net.pottercraft.ollivanders2.effect;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+/**
+ * Broom flying effect - different in that it is always permanent and doesn't make a smoke effect.
+ *
+ * @author Azami7
+ */
+public class BROOM_FLYING extends FLYING
+{
+    /**
+     * Constructor
+     *
+     * @param plugin   a callback to the MC plugin
+     * @param duration the duration of the effect
+     * @param pid      the ID of the player this effect acts on
+     */
+    public BROOM_FLYING (@NotNull Ollivanders2 plugin, int duration, @NotNull UUID pid)
+    {
+        super(plugin, duration, pid);
+
+        effectType = O2EffectType.FLYING;
+
+        doSmokeEffect = false;
+        permanent = true;
+    }
+}

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/BURNING.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/BURNING.java
@@ -105,4 +105,10 @@ public class BURNING extends O2Effect
     */
    @Override
    public void setPermanent(boolean perm) { }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/CONFUSION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/CONFUSION.java
@@ -29,4 +29,10 @@ public class CONFUSION extends PotionEffectSuper
       divinationText.add("will be struck by a terrible affliction");
       divinationText.add("will suffer a mental breakdown");
    }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/FAST_LEARNING.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/FAST_LEARNING.java
@@ -35,4 +35,10 @@ public class FAST_LEARNING extends O2Effect
    {
       age(1);
    }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/FLYING.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/FLYING.java
@@ -10,10 +10,12 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Grants player flight
  *
- * @author lownes
+ * @author azami7
  */
 public class FLYING extends O2Effect
 {
+   boolean doSmokeEffect = true;
+
    /**
     * Constructor
     *
@@ -21,7 +23,7 @@ public class FLYING extends O2Effect
     * @param duration the duration of the effect
     * @param pid      the ID of the player this effect acts on
     */
-   public FLYING(@NotNull Ollivanders2 plugin, int duration, @NotNull UUID pid)
+   public FLYING (@NotNull Ollivanders2 plugin, int duration, @NotNull UUID pid)
    {
       super(plugin, duration, pid);
 
@@ -42,12 +44,32 @@ public class FLYING extends O2Effect
          if (duration > 1)
          {
             target.setAllowFlight(true);
-            target.getWorld().playEffect(target.getLocation(), org.bukkit.Effect.SMOKE, 4);
-         } else
+            if (doSmokeEffect)
+               target.getWorld().playEffect(target.getLocation(), org.bukkit.Effect.SMOKE, 4);
+         }
+         else
          {
             target.setAllowFlight(false);
          }
-      } else
+      }
+      else
          kill();
+   }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove ()
+   {
+      Player player = p.getServer().getPlayer(targetID);
+      if (player != null)
+      {
+         if (!player.isOp())
+         {
+            player.setAllowFlight(false);
+            player.setFlying(false);
+         }
+      }
    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/HARM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/HARM.java
@@ -29,4 +29,10 @@ public class HARM extends PotionEffectSuper
       divinationText.add("shall be cursed");
       divinationText.add("will be develop a terrible illness");
    }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/HARM_ANTIDOTE_LESSER.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/HARM_ANTIDOTE_LESSER.java
@@ -28,4 +28,10 @@ public class HARM_ANTIDOTE_LESSER extends PotionEffectAntidoteSuper
         potionEffectType = PotionEffectType.HARM;
         strength = 0.25;
     }
+
+    /**
+     * Do any cleanup related to removing this effect from the player
+     */
+    @Override
+    public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/HEAL.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/HEAL.java
@@ -28,4 +28,10 @@ public class HEAL extends PotionEffectSuper
         divinationText.add("will be blessed by fortune");
         divinationText.add("shall be blessed");
     }
+
+    /**
+     * Do any cleanup related to removing this effect from the player
+     */
+    @Override
+    public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/HEALTH_BOOST.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/HEALTH_BOOST.java
@@ -29,4 +29,10 @@ public class HEALTH_BOOST extends PotionEffectSuper
         divinationText.add("shall be blessed");
         divinationText.add("will rise to become more powerful");
     }
+
+    /**
+     * Do any cleanup related to removing this effect from the player
+     */
+    @Override
+    public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/HIGHER_SKILL.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/HIGHER_SKILL.java
@@ -35,4 +35,10 @@ public class HIGHER_SKILL extends O2Effect
    {
       age(1);
    }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/HUNGER.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/HUNGER.java
@@ -29,4 +29,10 @@ public class HUNGER extends PotionEffectSuper
         divinationText.add("shall be cursed");
         divinationText.add("will become insatiable");
     }
+
+    /**
+     * Do any cleanup related to removing this effect from the player
+     */
+    @Override
+    public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/IMMOBILIZE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/IMMOBILIZE.java
@@ -35,4 +35,10 @@ public class IMMOBILIZE extends O2Effect
    {
       age(1);
    }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/IMPROVED_BOOK_LEARNING.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/IMPROVED_BOOK_LEARNING.java
@@ -35,4 +35,10 @@ public class IMPROVED_BOOK_LEARNING extends O2Effect
    {
       age(1);
    }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/LUCK.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/LUCK.java
@@ -29,4 +29,10 @@ public class LUCK extends PotionEffectSuper
       divinationText.add("shall find success in everything they do");
       divinationText.add("will become infallible");
    }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/LYCANTHROPY.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/LYCANTHROPY.java
@@ -146,4 +146,10 @@ public class LYCANTHROPY extends ShapeShiftSuper
     */
    @Override
    public void setPermanent(boolean perm) { }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/LYCANTHROPY_RELIEF.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/LYCANTHROPY_RELIEF.java
@@ -30,4 +30,10 @@ public class LYCANTHROPY_RELIEF extends O2Effect
    {
       age(1);
    }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/LYCANTHROPY_SPEECH.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/LYCANTHROPY_SPEECH.java
@@ -38,4 +38,10 @@ public class LYCANTHROPY_SPEECH extends BABBLING
       permanent = true;
       maxWords = 3;
    }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/MUCUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/MUCUS.java
@@ -46,4 +46,10 @@ public class MUCUS extends O2Effect
             kill();
       }
    }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/MUTED_SPEECH.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/MUTED_SPEECH.java
@@ -34,4 +34,10 @@ public class MUTED_SPEECH extends O2Effect
    {
       age(1);
    }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/NIGHT_VISION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/NIGHT_VISION.java
@@ -28,4 +28,10 @@ public class NIGHT_VISION extends PotionEffectSuper
       divinationText.add("will feel fishy");
       divinationText.add("will no longer fear water");
    }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effect.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effect.java
@@ -141,7 +141,12 @@ public abstract class O2Effect
    /**
     * This is the effect's action. age() must be called in this if you want the effect to age and die eventually.
     */
-   public void checkEffect () { }
+   abstract public void checkEffect ();
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   abstract public void doRemove ();
 
    /**
     * Is this effect permanent.

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effects.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effects.java
@@ -472,6 +472,9 @@ public class O2Effects
       if (effect != null)
       {
          effect.kill();
+
+         playerEffects.get(effectType).doRemove();
+
          playerEffects.remove(effectType);
       }
       else

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/POISON.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/POISON.java
@@ -29,4 +29,10 @@ public class POISON extends PotionEffectSuper
         divinationText.add("will be cursed");
         divinationText.add("will be possessed by a demon spirit");
     }
+
+    /**
+     * Do any cleanup related to removing this effect from the player
+     */
+    @Override
+    public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/POISON_ANTIDOTE_LESSER.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/POISON_ANTIDOTE_LESSER.java
@@ -28,4 +28,10 @@ public class POISON_ANTIDOTE_LESSER extends PotionEffectAntidoteSuper
         potionEffectType = PotionEffectType.POISON;
         strength = 0.25;
     }
+
+    /**
+     * Do any cleanup related to removing this effect from the player
+     */
+    @Override
+    public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/SLEEPING.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/SLEEPING.java
@@ -63,17 +63,6 @@ public class SLEEPING extends O2Effect
       }
    }
 
-   @Override
-   public void kill ()
-   {
-      if (sleeping)
-      {
-         playerWake();
-      }
-
-      kill = true;
-   }
-
    /**
     * Put the player to sleep.
     */
@@ -100,17 +89,19 @@ public class SLEEPING extends O2Effect
    }
 
    /**
-    * Wake the player up.
+    * Do any cleanup related to removing this effect from the player
     */
-   private void playerWake ()
+   @Override
+   public void doRemove ()
    {
-      Ollivanders2API.getPlayers(p).playerEffects.removeEffect(targetID, O2EffectType.SLEEP_SPEECH);
-      sleeping = false;
+      if (sleeping)
+      {
+         Ollivanders2API.getPlayers(p).playerEffects.removeEffect(targetID, O2EffectType.SLEEP_SPEECH);
+         sleeping = false;
 
-      Player target = p.getServer().getPlayer(targetID);
-      if (target != null)
-         target.sendMessage(Ollivanders2.chatColor + "You awaken from a deep sleep.");
-      else
-         kill();
+         Player target = p.getServer().getPlayer(targetID);
+         if (target != null)
+            target.sendMessage(Ollivanders2.chatColor + "You awaken from a deep sleep.");
+      }
    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/SLEEP_SPEECH.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/SLEEP_SPEECH.java
@@ -38,4 +38,10 @@ public class SLEEP_SPEECH extends BABBLING
       permanent = true;
       maxWords = 1;
    }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/SLOWNESS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/SLOWNESS.java
@@ -29,4 +29,10 @@ public class SLOWNESS extends PotionEffectSuper
         divinationText.add("will be struck by a terrible affliction");
         divinationText.add("will suffer a mental breakdown");
     }
+
+    /**
+     * Do any cleanup related to removing this effect from the player
+     */
+    @Override
+    public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/SPEED.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/SPEED.java
@@ -20,4 +20,10 @@ public class SPEED extends PotionEffectSuper
 
         divinationText.add("will make haste");
     }
+
+    /**
+     * Do any cleanup related to removing this effect from the player
+     */
+    @Override
+    public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/SPEED_SPEEDIER.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/SPEED_SPEEDIER.java
@@ -21,4 +21,10 @@ public class SPEED_SPEEDIER extends PotionEffectSuper
         divinationText.add("will make haste");
         divinationText.add("will wear the boots of Mercury");
     }
+
+    /**
+     * Do any cleanup related to removing this effect from the player
+     */
+    @Override
+    public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/SPEED_SPEEDIEST.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/SPEED_SPEEDIEST.java
@@ -21,4 +21,10 @@ public class SPEED_SPEEDIEST extends PotionEffectSuper
         divinationText.add("will wear the boots of Mercury");
         divinationText.add("will move with the power of the gods");
     }
+
+    /**
+     * Do any cleanup related to removing this effect from the player
+     */
+    @Override
+    public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/SUSPENSION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/SUSPENSION.java
@@ -52,15 +52,6 @@ public class SUSPENSION extends O2Effect
       }
    }
 
-   @Override
-   public void kill ()
-   {
-      release();
-      removeAdditionalEffect();
-
-      kill = true;
-   }
-
    /**
     * Suspend the player in the air.
     */
@@ -137,5 +128,15 @@ public class SUSPENSION extends O2Effect
       {
          Ollivanders2API.getPlayers(p).playerEffects.removeEffect(targetID, effectType);
       }
+   }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove ()
+   {
+      release();
+      removeAdditionalEffect();
    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/UNLUCK.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/UNLUCK.java
@@ -28,4 +28,10 @@ public class UNLUCK extends PotionEffectSuper
         divinationText.add("shall be cursed");
         divinationText.add("will find nothing but misfortune");
     }
+
+    /**
+     * Do any cleanup related to removing this effect from the player
+     */
+    @Override
+    public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/UNLUCK_ANTIDOTE_LESSER.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/UNLUCK_ANTIDOTE_LESSER.java
@@ -28,4 +28,10 @@ public class UNLUCK_ANTIDOTE_LESSER extends PotionEffectAntidoteSuper
         potionEffectType = PotionEffectType.UNLUCK;
         strength = 0.25;
     }
+
+    /**
+     * Do any cleanup related to removing this effect from the player
+     */
+    @Override
+    public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/WATER_BREATHING.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/WATER_BREATHING.java
@@ -28,4 +28,10 @@ public class WATER_BREATHING extends PotionEffectSuper
       divinationText.add("will feel fishy");
       divinationText.add("will no longer fear water");
    }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/WEAKNESS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/WEAKNESS.java
@@ -28,4 +28,10 @@ public class WEAKNESS extends PotionEffectSuper
         divinationText.add("will be cursed by weakness");
         divinationText.add("will be struck by a terrible affliction");
     }
+
+    /**
+     * Do any cleanup related to removing this effect from the player
+     */
+    @Override
+    public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/WEALTH.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/WEALTH.java
@@ -90,4 +90,10 @@ public class WEALTH extends O2Effect
    {
       strength = s;
    }
+
+   /**
+    * Do any cleanup related to removing this effect from the player
+    */
+   @Override
+   public void doRemove () { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/item/O2Item.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/item/O2Item.java
@@ -3,10 +3,13 @@ package net.pottercraft.ollivanders2.item;
 import net.pottercraft.ollivanders2.O2Color;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -30,6 +33,11 @@ public class O2Item
    final private O2ItemType itemType;
 
    /**
+    * Namespace key for NTB flags
+    */
+   NamespacedKey o2ItemTypeKey;
+
+   /**
     * Constructor
     *
     * @param plugin reference to the plugin
@@ -39,6 +47,8 @@ public class O2Item
    {
       p = plugin;
       itemType = type;
+
+      o2ItemTypeKey = new NamespacedKey(p, "o2enchantment_id");
    }
 
    /**
@@ -48,7 +58,7 @@ public class O2Item
     * @return an ItemStack of this item
     */
    @Nullable
-   public ItemStack getItem(int amount)
+   public ItemStack getItem (int amount)
    {
       Material materialType = itemType.getMaterial();
       short variant = itemType.getVariant();
@@ -76,6 +86,9 @@ public class O2Item
          ((PotionMeta) meta).setColor(O2Color.getBukkitColorByNumber(variant).getBukkitColor());
       }
 
+      PersistentDataContainer container = meta.getPersistentDataContainer();
+      container.set(o2ItemTypeKey, PersistentDataType.STRING, name);
+
       o2Item.setItemMeta(meta);
 
       return o2Item;
@@ -85,7 +98,7 @@ public class O2Item
     * @return the O2ItemType
     */
    @NotNull
-   public O2ItemType getType()
+   public O2ItemType getType ()
    {
       return itemType;
    }
@@ -94,7 +107,7 @@ public class O2Item
     * @return the item name
     */
    @NotNull
-   public String getName()
+   public String getName ()
    {
       return itemType.getName();
    }
@@ -103,8 +116,24 @@ public class O2Item
     * @return the material type
     */
    @NotNull
-   public Material getMaterialType()
+   public Material getMaterialType ()
    {
       return itemType.getMaterial();
+   }
+
+   /**
+    * Get the item type for this item stack
+    *
+    * @param itemStack the item stack to check
+    * @return the O2ItemType, if it is one, or null otherwise
+    */
+   @Nullable
+   static public O2ItemType getItemType (@NotNull ItemStack itemStack)
+   {
+      ItemMeta meta = itemStack.getItemMeta();
+      if (meta == null)
+         return null;
+
+      return O2ItemType.getTypeByName(meta.getDisplayName());
    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/item/O2ItemType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/item/O2ItemType.java
@@ -20,7 +20,7 @@ public enum O2ItemType
    BOOM_BERRY_JUICE(Material.POTION, (short) 11, "Boom Berry Juice", null),
    BOOMSLANG_SKIN(Material.ROTTEN_FLESH, (short) 0, "Boomslang Skin", null),
    BONE(Material.BONE, (short) 0, "Bone", null),
-   BROOMSTICK(Material.STICK, (short) 0, "Broomstick", "Flying vehicle used by magical folk"),
+   BROOMSTICK(Material.STICK, (short) 0, "Broomstick", null),
    CHIZPURFLE_FANGS(Material.PUMPKIN_SEEDS, (short) 0, "Chizpurfle Fangs", null),
    CRUSHED_FIRE_SEEDS(Material.REDSTONE, (short) 0, "Crushed Fire Seeds", null),
    DEATHS_HEAD_MOTH_CHRYSALIS(Material.COAL, (short) 0, "Death's Head Moth Chrysalis", null),
@@ -157,5 +157,22 @@ public enum O2ItemType
    public void setMaterial(@NotNull Material m)
    {
       material = m;
+   }
+
+   /**
+    * Return the type by name
+    * @param itemName the name of the item
+    * @return the type if found, null otherwise
+    */
+   @Nullable
+   public static O2ItemType getTypeByName (@NotNull String itemName)
+   {
+      for (O2ItemType itemType : O2ItemType.values())
+      {
+         if (itemType.name.equalsIgnoreCase(itemName))
+            return itemType;
+      }
+
+      return null;
    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/item/enchantment/Enchantment.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/item/enchantment/Enchantment.java
@@ -2,9 +2,11 @@ package net.pottercraft.ollivanders2.item.enchantment;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.common.Ollivanders2Common;
+import org.bukkit.craftbukkit.libs.jline.internal.Nullable;
 import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.ItemDespawnEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -31,6 +33,11 @@ public abstract class Enchantment
     int magnitude;
 
     /**
+     * Optional lore to add to the item for this enchantment, such as for a broom
+     */
+    String lore;
+
+    /**
      * Common functions
      */
     Ollivanders2Common common;
@@ -40,11 +47,13 @@ public abstract class Enchantment
      *
      * @param plugin a callback to the plugin
      * @param mag the magnitude of this enchantment
+     * @param itemLore the optional lore for this enchantment
      */
-    public Enchantment (@NotNull Ollivanders2 plugin, int mag)
+    public Enchantment (@NotNull Ollivanders2 plugin, int mag, @Nullable String itemLore)
     {
         p = plugin;
         magnitude = mag;
+        lore = itemLore;
 
         common = new Ollivanders2Common(p);
     }
@@ -69,6 +78,13 @@ public abstract class Enchantment
      * @param event the item drop event
      */
     abstract public void doItemDrop (@NotNull PlayerDropItemEvent event);
+
+    /**
+     * Handle item held events
+     *
+     * @param event the item drop event
+     */
+    abstract public void doItemHeld (@NotNull PlayerItemHeldEvent event);
 
     /**
      * Get the name of this enchantment.

--- a/Ollivanders/src/net/pottercraft/ollivanders2/item/enchantment/FLAGRANTE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/item/enchantment/FLAGRANTE.java
@@ -9,7 +9,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.ItemDespawnEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Flagrante Curse causes objects to emit searing heat when touched.
@@ -34,10 +36,11 @@ public class FLAGRANTE extends Enchantment
      *
      * @param plugin a callback to the plugin
      * @param mag the magnitude of this enchantment
+     * @param itemLore the optional lore for this enchantment
      */
-    public FLAGRANTE (@NotNull Ollivanders2 plugin, int mag)
+    public FLAGRANTE (@NotNull Ollivanders2 plugin, int mag, @Nullable String itemLore)
     {
-        super(plugin, mag);
+        super(plugin, mag, itemLore);
         enchantmentType = ItemEnchantmentType.GEMINIO;
     }
 
@@ -90,4 +93,11 @@ public class FLAGRANTE extends Enchantment
     {
         event.setCancelled(true);
     }
+
+    /**
+     * Handle item held events
+     *
+     * @param event the item drop event
+     */
+    public void doItemHeld (@NotNull PlayerItemHeldEvent event) { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/item/enchantment/GEMINIO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/item/enchantment/GEMINIO.java
@@ -7,8 +7,10 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.ItemDespawnEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Geminio Curse is used to curse an object into multiplying repeatedly when touched.
@@ -23,10 +25,11 @@ public class GEMINIO extends Enchantment
      *
      * @param plugin a callback to the plugin
      * @param mag the magnitude of this enchantment
+     * @param itemLore the optional lore for this enchantment
      */
-    public GEMINIO (@NotNull Ollivanders2 plugin, int mag)
+    public GEMINIO (@NotNull Ollivanders2 plugin, int mag, @Nullable String itemLore)
     {
-        super(plugin, mag);
+        super(plugin, mag, itemLore);
         enchantmentType = ItemEnchantmentType.GEMINIO;
     }
 
@@ -72,4 +75,11 @@ public class GEMINIO extends Enchantment
     {
         event.setCancelled(true);
     }
+
+    /**
+     * Handle item held events
+     *
+     * @param event the item drop event
+     */
+    public void doItemHeld (@NotNull PlayerItemHeldEvent event) { }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/item/enchantment/ItemEnchantmentType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/item/enchantment/ItemEnchantmentType.java
@@ -1,31 +1,79 @@
 package net.pottercraft.ollivanders2.item.enchantment;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+/**
+ * Types of item enchantments
+ *
+ * @author Azami7
+ */
 public enum ItemEnchantmentType
 {
-    FLAGRANTE ("flagrante", FLAGRANTE.class),
-    GEMINIO ("geminio", GEMINIO.class),
+    FLAGRANTE ("flagrante", FLAGRANTE.class, null),
+    GEMINIO ("geminio", GEMINIO.class, null),
+    VOLATUS ("volatus", VOLATUS.class, "Flying vehicle used by magical folk"),
     ;
 
+    /**
+     * The name of this enchantment for display purposes
+     */
     final String name;
+
+    /**
+     * The class, for reflection
+     */
     final Class<?> className;
 
-    ItemEnchantmentType (@NotNull String label, @NotNull Class<?> cName)
+    /**
+     * Optional lore to add to the enchanted item
+     */
+    final String lore;
+
+    /**
+     * Constructor.
+     *
+     * @param displayName the name for this enchantment
+     * @param cName the class for the enchantment
+     * @param itemLore the lore for the enchanted item, can be null
+     */
+    ItemEnchantmentType (@NotNull String displayName, @NotNull Class<?> cName, @Nullable String itemLore)
     {
-        name = label;
+        name = displayName;
         className = cName;
+        lore = itemLore;
     }
 
+    /**
+     * Get the display name
+     *
+     * @return the display name
+     */
     @NotNull
     public String getName ()
     {
         return name;
     }
 
+    /**
+     * Get the class
+     *
+     * @return the class
+     */
     @NotNull
     public Class<?> getClassName()
     {
         return className;
+    }
+
+    /**
+     * Get the lore
+     *
+     * @return the lore
+     */
+    @Nullable
+    public String getLore ()
+    {
+        return lore;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/item/enchantment/VOLATUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/item/enchantment/VOLATUS.java
@@ -1,0 +1,140 @@
+package net.pottercraft.ollivanders2.item.enchantment;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
+import net.pottercraft.ollivanders2.effect.BROOM_FLYING;
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.event.entity.ItemDespawnEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerItemHeldEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Volatus - add broom flight to an item
+ *
+ * @author Azami7
+ */
+public class VOLATUS extends Enchantment
+{
+    /**
+     * Constructor
+     *
+     * @param plugin a callback to the plugin
+     * @param mag the magnitude of this enchantment
+     * @param itemLore the optional lore for this enchantment
+     */
+    public VOLATUS (@NotNull Ollivanders2 plugin, int mag, String itemLore)
+    {
+        super(plugin, mag, itemLore);
+        enchantmentType = ItemEnchantmentType.VOLATUS;
+    }
+
+    /**
+     * Handle item pickup events
+     *
+     * @param event the item pickup event
+     */
+    @Override
+    public void doItemPickup (@NotNull EntityPickupItemEvent event) { }
+
+    /**
+     * Handle item drop events
+     *
+     * @param event the item drop event
+     */
+    @Override
+    public void doItemDrop (@NotNull PlayerDropItemEvent event) { }
+
+    /**
+     * Handle item pickup events
+     *
+     * @param event the item despawn event
+     */
+    @Override
+    public void doItemDespawn (@NotNull ItemDespawnEvent event) { }
+
+    /**
+     * Handle item held events
+     *
+     * @param event the item drop event
+     */
+    public void doItemHeld (@NotNull PlayerItemHeldEvent event)
+    {
+        Player player = event.getPlayer();
+
+        new BukkitRunnable()
+        {
+            @Override
+            public void run()
+            {
+                checkBroomStatus(player);
+            }
+        }.runTaskLater(p, Ollivanders2Common.ticksPerSecond);
+    }
+
+    /**
+     * A broom was either held or stopped being held - check to see if the player is still holding a least 1 broom
+     *
+     * @param player the player to check
+     */
+    void checkBroomStatus (Player player)
+    {
+        // do they have a broom in either hand?
+        if (isHoldingBroom(player))
+        {
+            p.getLogger().info("player is holding a broom");
+            BROOM_FLYING effect = new BROOM_FLYING(p, 5, player.getUniqueId());
+            Ollivanders2API.getPlayers(p).playerEffects.addEffect(effect);
+        }
+        else
+        {
+            p.getLogger().info("player is not holding a broom");
+            Ollivanders2API.getPlayers(p).playerEffects.removeEffect(player.getUniqueId(), O2EffectType.FLYING);
+        }
+    }
+
+    /**
+     * Is the player holding a broom?
+     *
+     * @param player the player to check
+     * @return true if they are holding a broom, false otherwise
+     */
+    private boolean isHoldingBroom (Player player)
+    {
+        ItemStack primaryItem = player.getInventory().getItemInMainHand();
+        String eTypeStr = Ollivanders2API.getItems(p).enchantedItems.getEnchantmentType(primaryItem);
+
+        if (eTypeStr != null)
+        {
+            p.getLogger().info("primary hand eTypeStr = " + eTypeStr);
+            if (eTypeStr.equalsIgnoreCase(enchantmentType.toString()))
+            {
+                p.getLogger().info("broom in main hand");
+                return true;
+            }
+        }
+
+        ItemStack secondaryItem = player.getInventory().getItemInOffHand();
+        eTypeStr = Ollivanders2API.getItems(p).enchantedItems.getEnchantmentType(secondaryItem);
+
+        if (eTypeStr != null)
+        {
+            p.getLogger().info("secondary hand eTypeStr = " + eTypeStr);
+
+            if (eTypeStr.equalsIgnoreCase(enchantmentType.toString()))
+            {
+                p.getLogger().info("broom in off hand");
+                return true;
+            }
+        }
+
+        p.getLogger().info("not holding a broom");
+        return false;
+    }
+
+}

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/ItemEnchant.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/ItemEnchant.java
@@ -3,6 +3,8 @@ package net.pottercraft.ollivanders2.spell;
 import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.item.O2Item;
+import net.pottercraft.ollivanders2.item.O2ItemType;
 import net.pottercraft.ollivanders2.item.enchantment.ItemEnchantmentType;
 import org.bukkit.Material;
 import org.bukkit.entity.Item;
@@ -10,6 +12,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -24,6 +27,11 @@ public abstract class ItemEnchant extends O2Spell
     * The type of enchantment
     */
    protected ItemEnchantmentType enchantmentType;
+
+   /**
+    * The list of item types that this can enchant, if limited. When empty, all item types can be enchanted
+    */
+   protected ArrayList<O2ItemType> itemTypeAllowlist = new ArrayList<>();
 
    /**
     * Minimum magnitude
@@ -114,6 +122,14 @@ public abstract class ItemEnchant extends O2Spell
          if (Ollivanders2API.common.isWand(item.getItemStack()))
          {
             continue;
+         }
+
+         // if this enchantment has a whitelist, check it
+         if (itemTypeAllowlist.size() > 0)
+         {
+            O2ItemType itemType = O2Item.getItemType(item.getItemStack());
+            if (itemType == null || !(itemTypeAllowlist.contains(itemType)))
+               continue;
          }
 
          // if this item is already enchanted, skip it

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/VOLATUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/VOLATUS.java
@@ -1,25 +1,21 @@
 package net.pottercraft.ollivanders2.spell;
 
-import java.util.List;
+import java.util.ArrayList;
 
-import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.O2MagicBranch;
-import org.bukkit.enchantments.Enchantment;
-import org.bukkit.entity.Item;
+import net.pottercraft.ollivanders2.item.O2ItemType;
+import net.pottercraft.ollivanders2.item.enchantment.ItemEnchantmentType;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Enchants a flying broomstick.
+ * Enchants a broomstick to fly.
  *
- * @author lownes
  * @author Azami7
  */
-public final class VOLATUS extends O2Spell
+public final class VOLATUS extends ItemEnchant
 {
    /**
     * Default constructor for use in generating spell text.  Do not use to cast the spell.
@@ -31,11 +27,15 @@ public final class VOLATUS extends O2Spell
       spellType = O2SpellType.VOLATUS;
       branch = O2MagicBranch.CHARMS;
 
+      flavorText = new ArrayList<>()
+      {{
+         add("\"As every school-age wizard knows, the fact that we fly on broomsticks is probably our worst-kept secret. No Muggle illustration of a witch is complete without a broom and however ludicrous these drawings are (for none of the broomsticks depicted by Muggles would stay up in the air for a moment), they remind us that we were careless for far too many centuries to be surprised that broomsticks and magic are inextricably linked in the Muggle mind.\" -Kennilworthy Whisp, Quidditch Through the Ages");
+      }};
+
       text = "Volatus is used to enchant a broomstick for flight. "
               + "To make a magical broomstick, you must first craft a broomstick.  This recipe requires two sticks and a wheat. "
               + "Place the first stick in the upper-right corner, the next stick in the center, and the wheat in the lower-left. "
-              + "Once you have a broomstick, place it in the ground in front of you and cast the spell Volatus at it. "
-              + "Your experience with this spell determines how fast the broomstick can go.";
+              + "Once you have a broomstick, place it in the ground in front of you and cast the spell Volatus at it.";
    }
 
    /**
@@ -45,62 +45,23 @@ public final class VOLATUS extends O2Spell
     * @param player    the player who cast this spell
     * @param rightWand which wand the player was using
     */
-   public VOLATUS(@NotNull Ollivanders2 plugin, @NotNull Player player, @NotNull Double rightWand)
+   public VOLATUS (@NotNull Ollivanders2 plugin, @NotNull Player player, @NotNull Double rightWand)
    {
       super(plugin, player, rightWand);
 
       spellType = O2SpellType.VOLATUS;
       branch = O2MagicBranch.CHARMS;
+
+      enchantmentType = ItemEnchantmentType.VOLATUS;
+
+      // set to only work for broomsticks
+      itemTypeAllowlist.add(O2ItemType.BROOMSTICK);
+
+      // magnitude = (int) ((usesModifier / 4) * strength)
+      strength = 0.25;
+      // spell experience of 200 would result in a natural magnitude of 12.5
+      maxMagnitude = 10; // 2^10
+
       initSpell();
-
-      // world guard flags
-      if (Ollivanders2.worldGuardEnabled)
-      {
-         worldGuardFlags.add(Flags.ITEM_DROP);
-         worldGuardFlags.add(Flags.ITEM_PICKUP);
-      }
-   }
-
-   @Override
-   protected void doCheckEffect ()
-   {
-      for (Item item : getItems(1.5))
-      {
-         ItemStack stack = item.getItemStack();
-         if (usesModifier >= 1 && isBroom(stack))
-         {
-            stack.addUnsafeEnchantment(Enchantment.PROTECTION_FALL, (int) usesModifier);
-            item.setItemStack(stack);
-         }
-         return;
-      }
-
-      if (hasHitTarget())
-      {
-         kill();
-      }
-   }
-
-   /**
-    * Finds out if an item is a broom.
-    *
-    * @param item - Item in question.
-    * @return True if yes.
-    */
-   public boolean isBroom(@NotNull ItemStack item)
-   {
-      if (item.getType() == Ollivanders2.broomstickMaterial)
-      {
-         ItemMeta meta = item.getItemMeta();
-
-         if (meta != null && meta.hasLore())
-         {
-            List<String> lore = meta.getLore();
-
-            return (lore != null && lore.contains("Flying vehicle used by magical folk"));
-         }
-      }
-
-      return false;
    }
 }


### PR DESCRIPTION
- made VOLATUS an ItemEnchant spell
- added optional lore to enchanted items
- added onItemHeld listener for enchanted items
- added BROOM_FLYING effect that extends FLYING but is always permanent and doesn't do the smoke effect
- added a cleanup function to effects so toggling FLYING properly unsets flying from non-Ops
- changed the couple of existing effects with cleanup steps to use cleanup function
- added NTB tags for O2Items to mark them and a getItemType() function to tell what type of O2Item something is
- added a getTypeByName to O2ItemType
- added item type allow list to ItemEnchant to optionally limit what items can be enchanted