### PR TITLE
Add broom enable/disable config

### DIFF
--- a/Ollivanders/src/README.md
+++ b/Ollivanders/src/README.md
@@ -1,9 +1,67 @@
 #Ollivanders2
+
+You've been accepted to MC Hogwarts School of Witchcraft and Wizardy.
+
 ##What is Ollivanders2?
+Ollivanders2 is reboot of the Ollivanders Bukkit plugin which adds the magic from Harry Potter to your Minecraft server.
 
-Ollivanders2 is a updated version of the original Ollivanders plugin for the Spigot platform.  It is currently
-in use and being maintained by pottercraft.net.  Ollivanders seeks to bring the world of Harry Potter to Minecraft.
+##Server Admins
+For more information running Ollivanders2 on your server and to download Ollivanders2 on your server, see our 
+[Spigot Page](https://www.spigotmc.org/resources/ollivanders2.38992/) and 
+[Ollivanders2 Wiki on GitHub](https://github.com/Azami7/Ollivanders2/wiki).
 
-For more information check out the [Bukkit Dev page](http://dev.bukkit.org/bukkit-plugins/ollivanders/).
+###Important notes for running Ollivanders2 ==> READ THIS <==
+1. Ollvanders2 requires your server is running with Java 11. Earlier versions will not work and the plugin will not load.
+2. Verify that the version of Ollivanders2 you have matches the version of MC you are running. Mismatched versions will 
+either cause the plugin to unload (if it detects a MC version too low) or missing/broken features (if your MC is too high).
 
+###Configuring Ollivanders2
+Ollivanders2 comes configured by default with the least intrusive options for your server. You can edit the 
+`````config.yml````` file in `````/plugins/Ollivanders2````` to change these settings.
+
+Be sure to read the [Documentation for Ollivanders2 config](https://github.com/Azami7/Ollivanders2/wiki/Configuration) 
+before making changes.
+
+##Discord
+Want to talk to the plugin designers, other server admins, or need support? Join our 
+[Discord Server](https://discord.gg/ANWvCWeQ96).
+
+##Development
 Current code repository at https://github.com/Azami7/Ollivanders2
+
+###Building Ollivanders2
+Java 11 is required to build Ollivanders2.
+
+Additional libraries you will need to build Ollivanders2:
+* gson 2.6.2 
+* spigot 1.16.5
+* worldedit 7.2.6 
+* worldguard 7.0.4 
+* jetbrains annotations 17.0.0
+* libsdisguises 10.0.25 
+
+In IntelliJ:
+1. File -> Project Structure -> Project
+1. Set Project SDK to your version of Java 11 (we use Corretto)
+1. File -> Project Structure -> Modules
+1. Set Module SDK to your version of Java 11
+
+Stop here and try to build the project. If you don't see a ton of errors (should be every file), your SDK is not 
+configured correctly.  
+
+1. File -> Project Structure -> Modules
+1. Add the above listed libraries to the module list
+
+Build again and everything should be happy. Yay!
+
+###Creating the Ollivanders2 jar
+Creating the jar for Ollivanders is pretty simple. All you will need is the compiled source plus the gson-2.6.2 jar. 
+
+In IntelliJ:
+1. File -> Project Structure -> Artifacts
+1. Make sure 'Ollivanders2' compiled source is listed. Note: you must have built successfully for this option to appear.
+1. Add the gson jar
+1. Build -> Build Artifacts -> Build
+
+If this worked, IntelliJ will have created an `````/out/artifacts````` directory in the top level of your Idea project directory.
+

--- a/Ollivanders/src/config.yml
+++ b/Ollivanders/src/config.yml
@@ -53,8 +53,9 @@ years: false
 #
 # https://github.com/Azami7/Ollivanders2/wiki/Configuration#magical-items
 flooPowder: REDSTONE
-broomstick: STICK
 witchDrop: false
+enableBrooms: true
+broomstick: STICK
 
 # Divination
 #

--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
@@ -102,7 +102,6 @@ public class Ollivanders2 extends JavaPlugin
    public static Material flooPowderMaterial;
    public static Material broomstickMaterial;
    public static boolean enableWitchDrop;
-   private ConfigurationSection zoneConfig;
    public static boolean hourlyBackup;
    public static boolean archivePreviousBackup;
 
@@ -147,13 +146,12 @@ public class Ollivanders2 extends JavaPlugin
       APPARATE.saveApparateLocations();
    }
 
+   /**
+    * Save plugin config
+    */
    private void savePluginConfig ()
    {
-      if (new File(pluginDir + "/config.yml").exists())
-      {
-         saveConfig();
-      }
-      else
+      if (!(new File(pluginDir + "/config.yml").exists()))
       {
          saveDefaultConfig();
       }
@@ -483,11 +481,6 @@ public class Ollivanders2 extends JavaPlugin
       {
          getLogger().info("Experimental - disabling version checks. This version of Ollivanders2 may not be compatible with you MC server api.");
       }
-
-      //
-      // Zones
-      //
-      zoneConfig = getConfig().getConfigurationSection("zones");
 
       //
       // Save options

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/O2Books.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/O2Books.java
@@ -468,6 +468,7 @@ public final class O2Books implements Listener
     * @param bookLore the lore from a book
     * @param player   the player reading the book
     */
+   @Deprecated
    public void readLore (@NotNull List<String> bookLore, @NotNull Player player)
    {
       if (!Ollivanders2.bookLearning)

--- a/Ollivanders/src/net/pottercraft/ollivanders2/item/O2ItemType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/item/O2ItemType.java
@@ -1,5 +1,6 @@
 package net.pottercraft.ollivanders2.item;
 
+import net.pottercraft.ollivanders2.item.enchantment.ItemEnchantmentType;
 import org.bukkit.Material;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -12,84 +13,85 @@ import org.jetbrains.annotations.Nullable;
  */
 public enum O2ItemType
 {
-   ACONITE(Material.ALLIUM, (short) 0, "Aconite", null),
-   ARMADILLO_BILE(Material.POTION, (short) 9, "Armadillo Bile", null),
-   BEZOAR(Material.COAL, (short) 1, "Bezoar", null), // charcoal
-   BILLYWIG_STING_SLIME(Material.SLIME_BALL, (short) 0, "Billywig Sting Slime", null),
-   BLOOD(Material.POTION, (short) 7, "Blood", null),
-   BOOM_BERRY_JUICE(Material.POTION, (short) 11, "Boom Berry Juice", null),
-   BOOMSLANG_SKIN(Material.ROTTEN_FLESH, (short) 0, "Boomslang Skin", null),
-   BONE(Material.BONE, (short) 0, "Bone", null),
-   BROOMSTICK(Material.STICK, (short) 0, "Broomstick", null),
-   CHIZPURFLE_FANGS(Material.PUMPKIN_SEEDS, (short) 0, "Chizpurfle Fangs", null),
-   CRUSHED_FIRE_SEEDS(Material.REDSTONE, (short) 0, "Crushed Fire Seeds", null),
-   DEATHS_HEAD_MOTH_CHRYSALIS(Material.COAL, (short) 0, "Death's Head Moth Chrysalis", null),
-   DEW_DROP(Material.GHAST_TEAR, (short) 0, "Dew Drop", null),
-   DITTANY(Material.BIRCH_SAPLING, (short) 0, "Dittany", null),
-   DRAGON_BLOOD(Material.POTION, (short) 1, "Dragon Blood", null),
-   DRAGONFLY_THORAXES(Material.BEETROOT_SEEDS, (short) 0, "Dragonfly Thoraxes", null),
-   DRIED_NETTLES(Material.OAK_SAPLING, (short) 0, "Dried Nettles", null),
-   EGG(Material.EGG, (short) 0, "Egg", null),
-   ELDER_WAND(Material.BLAZE_ROD, (short) 0, "Elder Wand", "Blaze and Ender Pearl"),
-   FAIRY_WING(Material.GOLD_NUGGET, (short) 0, "Fairy Wing", null),
-   FLOBBERWORM_MUCUS(Material.SLIME_BALL, (short) 0, "Flobberworm Mucus", null),
-   FLUXWEED(Material.VINE, (short) 0, "Fluxweed", null),
-   FLOO_POWDER(Material.REDSTONE, (short) 0, "Floo Powder", "Glittery, silver powder"),
-   FULGURITE(Material.GLOWSTONE_DUST, (short) 0, "Fulgurite", null),
-   GALANTHUS_NIVALIS(Material.AZURE_BLUET, (short) 0, "Galanthus Nivalis", null),
-   GALLEON(Material.GOLD_INGOT, (short) 0, "Galleon", null),
-   GINGER_ROOT(Material.BEETROOT, (short) 0, "Ginger Root", null),
-   GROUND_DRAGON_HORN(Material.GLOWSTONE_DUST, (short) 0, "Ground Dragon Horn", null),
-   GROUND_PORCUPINE_QUILLS(Material.GRAY_DYE, (short) 0, "Ground Porcupine Quills", null),
-   GROUND_SCARAB_BEETLE(Material.GUNPOWDER, (short) 0, "Ground Scarab Beetle", null),
-   GROUND_SNAKE_FANGS(Material.LIGHT_GRAY_DYE, (short) 0, "Ground Snake Fangs", null),
-   HONEYWATER(Material.POTION, (short) 0, "Honeywater", null),
-   HORKLUMP_JUICE(Material.DRAGON_BREATH, (short) 0, "Horklump Juice", null),
-   HORNED_SLUG_MUCUS(Material.SLIME_BALL, (short) 0, "Horned Slug Mucus", null),
-   HORN_OF_BICORN(Material.BLAZE_ROD, (short) 0, "Horn of Bicorn", null),
-   INFUSION_OF_WORMWOOD(Material.POTION, (short) 5, "Infusion of Wormwood", null),
-   INVISIBILITY_CLOAK(Material.CHAINMAIL_CHESTPLATE, (short) 0, "Cloak of Invisibility", "Silvery Transparent Cloak"),
-   JOBBERKNOLL_FEATHER(Material.FEATHER, (short) 0, "Jobberknoll Feather", null),
-   KNOTGRASS(Material.TALL_GRASS, (short) 0, "Knotgrass", null),
-   KNUT(Material.NETHERITE_INGOT, (short) 0, "Knut", null),
-   LACEWING_FLIES(Material.PUMPKIN_SEEDS, (short) 0, "Lacewing Flies", null),
-   LAVENDER_SPRIG(Material.LILAC, (short) 0, "Lavender Sprig", null),
-   LEECHES(Material.INK_SAC, (short) 0, "Leeches", null),
-   LETHE_RIVER_WATER(Material.POTION, (short) 0, "Lethe River Water", null), //bottle of water
-   LIONFISH_SPINES(Material.PUMPKIN_SEEDS, (short) 0, "Lionfish Spines", null),
-   MANDRAKE_LEAF(Material.LILY_PAD, (short) 0, "Mandrake Leaf", null),
-   MERCURY(Material.POTION, (short) 13, "Mercury", null), // silver liquid
-   MINT_SPRIG(Material.MELON_STEM, (short) 0, "Mint Sprig", null),
-   MISTLETOE_BERRIES(Material.NETHER_WART, (short) 0, "Mistletoe Berries", null),
-   MOONDEW_DROP(Material.GHAST_TEAR, (short) 0, "Moondew Drop", null),
-   PEWTER_CAULDRON (Material.CAULDRON, (short) 0, "Pewter Cauldron", null),
-   PLAYING_CARDS(Material.PAPER, (short) 0, "Playing Cards", null),
-   POISONOUS_POTATO(Material.POISONOUS_POTATO, (short) 0, "Poisonous Potato", null),
-   POWDERED_ASHPODEL_ROOT(Material.ORANGE_DYE, (short) 0, "Powedered Root of Asphodel", null),
-   POWDERED_SAGE(Material.LIME_DYE, (short) 0, "Powdered Sage", null),
-   ROTTEN_FLESH(Material.ROTTEN_FLESH, (short) 0, "Rotten Flesh", null),
-   RUNESPOOR_EGG(Material.EGG, (short) 0, "Runespoor Egg", null),
-   SALAMANDER_BLOOD(Material.POTION, (short) 7, "Salamander Blood", null),
-   SALAMANDER_FIRE(Material.BLAZE_POWDER, (short) 0, "Salamander Fire", null),
-   SICKLE(Material.IRON_INGOT, (short) 0, "Sickle", null),
-   SLOTH_BRAIN(Material.FERMENTED_SPIDER_EYE, (short) 0, "Sloth Brain", null),
-   SLOTH_BRAIN_MUCUS(Material.POTION, (short) 4, "Sloth Brain Mucus", null),
-   SOPOPHORUS_BEAN_JUICE(Material.POTION, (short) 13, "Sopophorus Bean Juice", null),
-   SPIDER_EYE(Material.SPIDER_EYE, (short) 0, "Spider Eye", null),
-   STANDARD_POTION_INGREDIENT(Material.SUGAR, (short) 0, "Standard Potion Ingredient", null),
-   TAROT_CARDS(Material.PAPER, (short) 0, "Tarot Cards", null),
-   TEA_LEAVES(Material.GREEN_DYE, (short) 0, "Tea Leaves", null),
-   UNICORN_HAIR(Material.STRING, (short) 0, "Unicorn Hair", null),
-   UNICORN_HORN(Material.BLAZE_ROD, (short) 0, "Unicorn Horn", null),
-   VALERIAN_SPRIGS(Material.VINE, (short) 0, "Valerian Sprigs", null),
-   VALERIAN_ROOT(Material.GOLDEN_CARROT, (short) 0, "Valerian Root", null),
-   WAND(Material.STICK, (short) 0, "Wand", null),
-   WOLFSBANE(Material.ALLIUM, (short) 0, "Wolfsbane", null);
+   ACONITE(Material.ALLIUM, (short) 0, "Aconite", null, null),
+   ARMADILLO_BILE(Material.POTION, (short) 9, "Armadillo Bile", null, null),
+   BEZOAR(Material.COAL, (short) 1, "Bezoar", null, null), // charcoal
+   BILLYWIG_STING_SLIME(Material.SLIME_BALL, (short) 0, "Billywig Sting Slime", null, null),
+   BLOOD(Material.POTION, (short) 7, "Blood", null, null),
+   BOOM_BERRY_JUICE(Material.POTION, (short) 11, "Boom Berry Juice", null, null),
+   BOOMSLANG_SKIN(Material.ROTTEN_FLESH, (short) 0, "Boomslang Skin", null, null),
+   BONE(Material.BONE, (short) 0, "Bone", null, null),
+   BROOMSTICK(Material.STICK, (short) 0, "Broomstick", null, ItemEnchantmentType.VOLATUS),
+   CHIZPURFLE_FANGS(Material.PUMPKIN_SEEDS, (short) 0, "Chizpurfle Fangs", null, null),
+   CRUSHED_FIRE_SEEDS(Material.REDSTONE, (short) 0, "Crushed Fire Seeds", null, null),
+   DEATHS_HEAD_MOTH_CHRYSALIS(Material.COAL, (short) 0, "Death's Head Moth Chrysalis", null, null),
+   DEW_DROP(Material.GHAST_TEAR, (short) 0, "Dew Drop", null, null),
+   DITTANY(Material.BIRCH_SAPLING, (short) 0, "Dittany", null, null),
+   DRAGON_BLOOD(Material.POTION, (short) 1, "Dragon Blood", null, null),
+   DRAGONFLY_THORAXES(Material.BEETROOT_SEEDS, (short) 0, "Dragonfly Thoraxes", null, null),
+   DRIED_NETTLES(Material.OAK_SAPLING, (short) 0, "Dried Nettles", null, null),
+   EGG(Material.EGG, (short) 0, "Egg", null, null),
+   ELDER_WAND(Material.BLAZE_ROD, (short) 0, "Elder Wand", "Blaze and Ender Pearl", null ),
+   FAIRY_WING(Material.GOLD_NUGGET, (short) 0, "Fairy Wing", null, null),
+   FLOBBERWORM_MUCUS(Material.SLIME_BALL, (short) 0, "Flobberworm Mucus", null, null),
+   FLUXWEED(Material.VINE, (short) 0, "Fluxweed", null, null),
+   FLOO_POWDER(Material.REDSTONE, (short) 0, "Floo Powder", "Glittery, silver powder", null),
+   FULGURITE(Material.GLOWSTONE_DUST, (short) 0, "Fulgurite", null, null),
+   GALANTHUS_NIVALIS(Material.AZURE_BLUET, (short) 0, "Galanthus Nivalis", null, null),
+   GALLEON(Material.GOLD_INGOT, (short) 0, "Galleon", null, null),
+   GINGER_ROOT(Material.BEETROOT, (short) 0, "Ginger Root", null, null),
+   GROUND_DRAGON_HORN(Material.GLOWSTONE_DUST, (short) 0, "Ground Dragon Horn", null, null),
+   GROUND_PORCUPINE_QUILLS(Material.GRAY_DYE, (short) 0, "Ground Porcupine Quills", null, null),
+   GROUND_SCARAB_BEETLE(Material.GUNPOWDER, (short) 0, "Ground Scarab Beetle", null, null),
+   GROUND_SNAKE_FANGS(Material.LIGHT_GRAY_DYE, (short) 0, "Ground Snake Fangs", null, null),
+   HONEYWATER(Material.POTION, (short) 0, "Honeywater", null, null),
+   HORKLUMP_JUICE(Material.DRAGON_BREATH, (short) 0, "Horklump Juice", null, null),
+   HORNED_SLUG_MUCUS(Material.SLIME_BALL, (short) 0, "Horned Slug Mucus", null, null),
+   HORN_OF_BICORN(Material.BLAZE_ROD, (short) 0, "Horn of Bicorn", null, null),
+   INFUSION_OF_WORMWOOD(Material.POTION, (short) 5, "Infusion of Wormwood", null, null),
+   INVISIBILITY_CLOAK(Material.CHAINMAIL_CHESTPLATE, (short) 0, "Cloak of Invisibility", "Silvery Transparent Cloak", null),
+   JOBBERKNOLL_FEATHER(Material.FEATHER, (short) 0, "Jobberknoll Feather", null, null),
+   KNOTGRASS(Material.TALL_GRASS, (short) 0, "Knotgrass", null, null),
+   KNUT(Material.NETHERITE_INGOT, (short) 0, "Knut", null, null),
+   LACEWING_FLIES(Material.PUMPKIN_SEEDS, (short) 0, "Lacewing Flies", null, null),
+   LAVENDER_SPRIG(Material.LILAC, (short) 0, "Lavender Sprig", null, null),
+   LEECHES(Material.INK_SAC, (short) 0, "Leeches", null, null),
+   LETHE_RIVER_WATER(Material.POTION, (short) 0, "Lethe River Water", null, null), //bottle of water
+   LIONFISH_SPINES(Material.PUMPKIN_SEEDS, (short) 0, "Lionfish Spines", null, null),
+   MANDRAKE_LEAF(Material.LILY_PAD, (short) 0, "Mandrake Leaf", null, null),
+   MERCURY(Material.POTION, (short) 13, "Mercury", null, null), // silver liquid
+   MINT_SPRIG(Material.MELON_STEM, (short) 0, "Mint Sprig", null, null),
+   MISTLETOE_BERRIES(Material.NETHER_WART, (short) 0, "Mistletoe Berries", null, null),
+   MOONDEW_DROP(Material.GHAST_TEAR, (short) 0, "Moondew Drop", null, null),
+   PEWTER_CAULDRON (Material.CAULDRON, (short) 0, "Pewter Cauldron", null, null),
+   PLAYING_CARDS(Material.PAPER, (short) 0, "Playing Cards", null, null),
+   POISONOUS_POTATO(Material.POISONOUS_POTATO, (short) 0, "Poisonous Potato", null, null),
+   POWDERED_ASHPODEL_ROOT(Material.ORANGE_DYE, (short) 0, "Powedered Root of Asphodel", null, null),
+   POWDERED_SAGE(Material.LIME_DYE, (short) 0, "Powdered Sage", null, null),
+   ROTTEN_FLESH(Material.ROTTEN_FLESH, (short) 0, "Rotten Flesh", null, null),
+   RUNESPOOR_EGG(Material.EGG, (short) 0, "Runespoor Egg", null, null),
+   SALAMANDER_BLOOD(Material.POTION, (short) 7, "Salamander Blood", null, null),
+   SALAMANDER_FIRE(Material.BLAZE_POWDER, (short) 0, "Salamander Fire", null, null),
+   SICKLE(Material.IRON_INGOT, (short) 0, "Sickle", null, null),
+   SLOTH_BRAIN(Material.FERMENTED_SPIDER_EYE, (short) 0, "Sloth Brain", null, null),
+   SLOTH_BRAIN_MUCUS(Material.POTION, (short) 4, "Sloth Brain Mucus", null, null),
+   SOPOPHORUS_BEAN_JUICE(Material.POTION, (short) 13, "Sopophorus Bean Juice", null, null),
+   SPIDER_EYE(Material.SPIDER_EYE, (short) 0, "Spider Eye", null, null),
+   STANDARD_POTION_INGREDIENT(Material.SUGAR, (short) 0, "Standard Potion Ingredient", null, null),
+   TAROT_CARDS(Material.PAPER, (short) 0, "Tarot Cards", null, null),
+   TEA_LEAVES(Material.GREEN_DYE, (short) 0, "Tea Leaves", null, null),
+   UNICORN_HAIR(Material.STRING, (short) 0, "Unicorn Hair", null, null),
+   UNICORN_HORN(Material.BLAZE_ROD, (short) 0, "Unicorn Horn", null, null),
+   VALERIAN_SPRIGS(Material.VINE, (short) 0, "Valerian Sprigs", null, null),
+   VALERIAN_ROOT(Material.GOLDEN_CARROT, (short) 0, "Valerian Root", null, null),
+   WAND(Material.STICK, (short) 0, "Wand", null, null),
+   WOLFSBANE(Material.ALLIUM, (short) 0, "Wolfsbane", null, null);
 
    private Material material;
    final private String name;
    final private String lore;
    final private short variant;
+   final private ItemEnchantmentType itemEnchantment;
 
    /**
     * Constructor
@@ -99,12 +101,13 @@ public enum O2ItemType
     * @param n the name of the item
     * @param l the lore for this item
     */
-   O2ItemType(@NotNull Material m, short v, @NotNull String n, @Nullable String l)
+   O2ItemType(@NotNull Material m, short v, @NotNull String n, @Nullable String l, @Nullable ItemEnchantmentType enchantment)
    {
       material = m;
       name = n;
       variant = v;
       lore = l;
+      itemEnchantment = enchantment;
    }
 
    /**
@@ -148,6 +151,12 @@ public enum O2ItemType
    {
       return material;
    }
+
+   /**
+    * @return the enchantment for this item if there is one, null otherwise
+    */
+   @Nullable
+   public ItemEnchantmentType getItemEnchantment() { return itemEnchantment; }
 
    /**
     * Set the material for this item

--- a/Ollivanders/src/net/pottercraft/ollivanders2/item/O2Items.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/item/O2Items.java
@@ -3,6 +3,7 @@ package net.pottercraft.ollivanders2.item;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.item.enchantment.EnchantedItems;
+import net.pottercraft.ollivanders2.item.enchantment.ItemEnchantmentType;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -70,9 +71,18 @@ public class O2Items
          return null;
       }
 
-      O2Item item = O2ItemMap.get(itemType);
+      O2Item o2item = O2ItemMap.get(itemType);
+      ItemStack itemStack = o2item.getItem(amount);
 
-      return item.getItem(amount);
+      // does this item need an enchantment on it?
+      ItemEnchantmentType enchantment = itemType.getItemEnchantment();
+      if (itemStack != null && enchantment != null)
+      {
+         String eid = common.getCurrentTimestamp() + " " + itemType.getName() + " " + enchantment.getName();
+         enchantedItems.addEnchantedItem(itemStack, enchantment, 1, eid);
+      }
+
+      return itemStack;
    }
 
    /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/item/enchantment/EnchantedItems.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/item/enchantment/EnchantedItems.java
@@ -53,6 +53,11 @@ public class EnchantedItems implements Listener
     HashMap<String, Enchantment> enchantedItems = new HashMap<>();
 
     /**
+     * Enchantment related config
+     */
+    public static boolean enableBrooms;
+
+    /**
      * Constructor
      *
      * @param plugin a callback to the plugin
@@ -65,6 +70,20 @@ public class EnchantedItems implements Listener
         enchantmentType = new NamespacedKey(p, "o2enchantment_name");
         enchantmentMagnitude = new NamespacedKey(p, "o2enchantment_magnitude");
         enchantmentID = new NamespacedKey(p, "o2enchantment_id");
+
+        initEnchantments();
+    }
+
+    private void initEnchantments()
+    {
+        //
+        // brooms
+        //
+        enableBrooms = p.getConfig().getBoolean("enableBrooms");
+        if (enableBrooms)
+        {
+            p.getLogger().info("Enabling brooms.");
+        }
     }
 
     /**
@@ -82,14 +101,31 @@ public class EnchantedItems implements Listener
 
         String eid = item.getUniqueId().toString();
 
+        addEnchantedItem(item.getItemStack(), eType, magnitude, eid);
+    }
+
+    /**
+     * Add enchanted item
+     *
+     * @param itemStack the enchanted item
+     * @param eType the type of enchantment
+     * @param magnitude the magnitude of enchantment
+     * @param eid the uniqueID for this enchantment
+     */
+    public void addEnchantedItem (@NotNull ItemStack itemStack, @NotNull ItemEnchantmentType eType, int magnitude, @NotNull String eid)
+    {
+        ItemMeta itemMeta = itemStack.getItemMeta();
+        if (itemMeta == null)
+            return;
+
         PersistentDataContainer container = itemMeta.getPersistentDataContainer();
         container.set(enchantmentID, PersistentDataType.STRING, eid);
         container.set(enchantmentMagnitude, PersistentDataType.INTEGER, magnitude);
         container.set(enchantmentType, PersistentDataType.STRING, eType.toString());
 
-        item.getItemStack().setItemMeta(itemMeta);
+        itemStack.setItemMeta(itemMeta);
 
-        Enchantment enchantment = getEnchantment(item.getItemStack());
+        Enchantment enchantment = getEnchantment(itemStack);
         if (enchantment == null)
             return;
 
@@ -102,13 +138,13 @@ public class EnchantedItems implements Listener
             }
             lore.add(enchantment.lore);
             itemMeta.setLore(lore);
-            item.getItemStack().setItemMeta(itemMeta);
+            itemStack.setItemMeta(itemMeta);
         }
 
         // store these in a hashmap for faster access later
         enchantedItems.put(eid, enchantment);
 
-        common.printDebugMessage("Added enchanted item " + item.getName() + " of type " + eType.getName(), null, null, false);
+        common.printDebugMessage("Added enchanted item " + itemMeta.getDisplayName() + " of type " + eType.getName(), null, null, false);
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/item/enchantment/VOLATUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/item/enchantment/VOLATUS.java
@@ -65,6 +65,9 @@ public class VOLATUS extends Enchantment
      */
     public void doItemHeld (@NotNull PlayerItemHeldEvent event)
     {
+        if (!EnchantedItems.enableBrooms)
+            return;
+
         Player player = event.getPlayer();
 
         new BukkitRunnable()
@@ -84,6 +87,9 @@ public class VOLATUS extends Enchantment
      */
     void checkBroomStatus (Player player)
     {
+        if (!EnchantedItems.enableBrooms)
+            return;
+
         // do they have a broom in either hand?
         if (isHoldingBroom(player))
         {
@@ -128,5 +134,4 @@ public class VOLATUS extends Enchantment
 
         return false;
     }
-
 }


### PR DESCRIPTION
- added enableBrooms, default set to true
- added item enchantments for O2ItemType since broomsticks were no longer by default flyable
- added support for setting item enchantments by ItemStack in addition to Item
- turned off writing config if the file exists since when it writes back out it loses all the helpful comments
- marked readLore as deprecated so we remember to clean it up in a few versions
- cleaned up unused zone config from Ollivanders2 (it was moved to O2Spells)