### PR TITLE
Potions Texts, Lumos and Nox fixes

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/O2Book.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/O2Book.java
@@ -253,14 +253,14 @@ public abstract class O2Book
    /**
     * Turn a spell text word list in to a set of pages that fit in an MC book.
     *
-    * Book pages cannot be more than 14 lines with ~18 characters per line, 256 characters max
+    * Book pages cannot be more than 14 lines with ~16 characters per line, 256 characters max
     * assume 2 lines for spell name, 1 blank line between name and flavor text, 1 blank link between flavor text
     * and description text, means the first page has 9 lines of ~15 characters + continue, subsequent pages are 13
     * lines of ~15 characters + continue.
     *
     * This means the first page for a spell can have ~175 characters and subsequent pages can be ~195.
     *
-    * Assumes there is no word in the list that is >= 200 characters.
+    * Assumes there is no word in the list that is >= max page size.
     *
     * @param words an array of all the words in the book
     * @return a list of book pages
@@ -271,7 +271,7 @@ public abstract class O2Book
       ArrayList<String> pages = new ArrayList<>();
 
       // first page
-      int remaining = 175;
+      int remaining = 150;
       StringBuilder page = new StringBuilder();
 
       // first page
@@ -299,7 +299,7 @@ public abstract class O2Book
       // remaining pages
       while (!words.isEmpty())
       {
-         remaining = 200;
+         remaining = 180;
          page = new StringBuilder();
 
          while (remaining > 0)

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/LUMOS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/LUMOS.java
@@ -16,6 +16,9 @@ import java.util.ArrayList;
  */
 public final class LUMOS extends AddPotionEffectInRadius
 {
+   public static int minRadius = 5;
+   public static int maxRadius = 20;
+
    /**
     * Default constructor for use in generating spell text.  Do not use to cast the spell.
     *
@@ -53,20 +56,27 @@ public final class LUMOS extends AddPotionEffectInRadius
       spellType = O2SpellType.LUMOS;
       branch = O2MagicBranch.CHARMS;
 
-      initSpell();
-
       effectTypes.add(PotionEffectType.NIGHT_VISION);
       amplifier = 1;
       minDurationInSeconds = 30;
       targetSelf = true;
 
+      initSpell();
+   }
+
+   @Override
+   void doInitSpell()
+   {
       durationInSeconds = (int) usesModifier;
       if (durationInSeconds < minDurationInSeconds)
-      {
          durationInSeconds = minDurationInSeconds;
-      } else if (durationInSeconds > maxDurationInSeconds)
-      {
+      else if (durationInSeconds > maxDurationInSeconds)
          durationInSeconds = maxDurationInSeconds;
-      }
+
+      radius = ((int)usesModifier) / 10;
+      if (radius < minRadius)
+         radius = minRadius;
+      else if (radius > maxRadius)
+         radius = maxRadius;
    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/NOX.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/NOX.java
@@ -55,8 +55,20 @@ public final class NOX extends RemovePotionEffectInRadius
       branch = O2MagicBranch.CHARMS;
       targetSelf = true;
 
-      initSpell();
-
       potionEffectTypes.add(PotionEffectType.NIGHT_VISION);
+
+      initSpell();
+   }
+
+   @Override
+   void doInitSpell()
+   {
+      // use the same min and max radius and Lumos
+
+      radius = ((int)usesModifier) / 10;
+      if (radius < LUMOS.minRadius)
+         radius = LUMOS.minRadius;
+      else if (radius > LUMOS.maxRadius)
+         radius = LUMOS.maxRadius;
    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/RemovePotionEffect.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/RemovePotionEffect.java
@@ -82,9 +82,7 @@ public abstract class RemovePotionEffect extends O2Spell
     void affectRadius(double radius, boolean flair)
     {
         if (flair)
-        {
             Ollivanders2Common.flair(location, (int)radius, 10);
-        }
 
         if (targetSelf)
         {
@@ -101,7 +99,7 @@ public abstract class RemovePotionEffect extends O2Spell
                 return;
             }
 
-            if (livingEntity.getUniqueId() == player.getUniqueId())
+            if (livingEntity.getUniqueId() == player.getUniqueId()) // already handled self above
                 continue;
 
             removePotionEffects(livingEntity);
@@ -118,6 +116,7 @@ public abstract class RemovePotionEffect extends O2Spell
     {
         for (PotionEffectType effectType : potionEffectTypes)
         {
+            common.printDebugMessage("Removing " + effectType.getName() + " from " + target.getName(), null, null, false);
             target.removePotionEffect(effectType);
         }
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/RemovePotionEffectInRadius.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/RemovePotionEffectInRadius.java
@@ -17,11 +17,6 @@ public class RemovePotionEffectInRadius extends RemovePotionEffect
     int radius = 5;
 
     /**
-     * Whether the spell targets the caster
-     */
-    boolean targetSelf = false;
-
-    /**
      * Default constructor for use in generating spell text.  Do not use to cast the spell.
      *
      * @param plugin the Ollivanders2 plugin


### PR DESCRIPTION
- decreased line size to prevent cutting off the ingredients lists for potions
- NOX was not targeting self (feel like we fixed this before...) because RemovePotionEffectInRadius incorrectly overwrote the targetSelf class variable
- Gave lumos and nox varing radius by spell skill level