### PR TITLE
Zone config, item amount, mcVersionCheck fix

### DIFF
--- a/Ollivanders/src/config.yml
+++ b/Ollivanders/src/config.yml
@@ -31,6 +31,8 @@ apparateLocations: false
 maxSpellLevel: false
 maxApparateDistance: 10000
 enableLycanthropy: true
+# Fast spells. This increases the speed spell projectiles are created. Can overload server and cause performance issues.
+fastSpells: false
 
 # Houses
 #
@@ -45,10 +47,6 @@ gryffindorColor: DARK_RED
 hufflepuffColor: GOLD
 ravenclawColor: BLUE
 slytherinColor: DARK_GREEN
-
-# Years
-#
-# https://github.com/Azami7/Ollivanders2/wiki/Configuration#years
 years: false
 
 # Magical Items
@@ -81,9 +79,6 @@ debug: false
 # Override version checks. This will force the plugin to load regardless of MC api version.
 # **IMPORTANT** Backup your plugins/Ollivanders2 directory before enabling this option - running unsupported versions may corrupt plugin data
 overrideVersionCheck: false
-#
-# Fast spells. This increases the speed spell projectiles are created. Can overload server and cause performance issues.
-fastSpells: false
 
 #
 # Zones

--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
@@ -1142,27 +1142,43 @@ public class Ollivanders2 extends JavaPlugin
 
       if (args.length < 2)
       {
-         player.sendMessage("You need to include the name of the item.");
-         return true;
+         usageMessageItem(player);
       }
-
-      if (args[1].equals("list"))
+      else if (args[1].equals("list"))
       {
          player.sendMessage("\n" + listAllItems());
-         return true;
       }
-
-      String itemName = Ollivanders2API.common.stringArrayToString(Arrays.copyOfRange(args, 1, args.length));
-      ItemStack item = items.getItemStartsWith(itemName, 1);
-
-      if (item == null)
+      else if (args[1].equals("give") && args.length >= 4)
       {
-         player.sendMessage("Unable to find an item with that name.");
-         return true;
-      }
+         int amount = 0;
+         try
+         {
+            amount = Integer.parseInt(args[2]);
+         }
+         catch (Exception e)
+         {
+            player.sendMessage("Unable to parse amount " + args[2]);
+         }
 
-      kit.add(item);
-      Ollivanders2API.common.givePlayerKit(player, kit);
+         if (amount > 64)
+            amount = 64;
+
+         String itemName = Ollivanders2API.common.stringArrayToString(Arrays.copyOfRange(args, 3, args.length));
+         ItemStack item = items.getItemStartsWith(itemName, amount);
+
+         if (item == null)
+         {
+            player.sendMessage("Unable to find an item \"" + itemName + "\'");
+            return true;
+         }
+
+         kit.add(item);
+         Ollivanders2API.common.givePlayerKit(player, kit);
+      }
+      else
+      {
+         usageMessageItem(player);
+      }
 
       return true;
    }
@@ -1175,9 +1191,9 @@ public class Ollivanders2 extends JavaPlugin
    private void usageMessageItem(@NotNull CommandSender sender)
    {
       sender.sendMessage(chatColor
-              + "Options to '/ollivanders2 house':"
+              + "Options to '/ollivanders2 item':"
               + "\nlist - lists all items"
-              + "\nitem_name - gives the specified item");
+              + "\ngive <count> <item_name> - gives the specified amount of the item");
    }
 
    /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
@@ -1508,7 +1508,7 @@ public class Ollivanders2 extends JavaPlugin
       }
       else // anything lower than 1.14 set to 0 because this version of the plugin cannot run on < 1.14
       {
-         getLogger().warning("MC version " + versionString + ". This version of Ollivanders2 requires 1.16 or higher.");
+         getLogger().warning("MC version " + versionString + ". This version of Ollivanders2 requires 1.17 or higher.");
          return false;
       }
    }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
@@ -1502,7 +1502,7 @@ public class Ollivanders2 extends JavaPlugin
 
       String versionString = Bukkit.getBukkitVersion();
 
-      if (versionString.startsWith("1.16") || versionString.startsWith("1.17"))
+      if (versionString.startsWith("1.17") || versionString.startsWith("1.18"))
       {
          return true;
       }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/item/O2ItemType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/item/O2ItemType.java
@@ -129,10 +129,11 @@ public enum O2ItemType
    /**
     * Constructor
     *
-    * @param m the material type
-    * @param v the variant information, this is 0 for most items but for things like potions it can control color
-    * @param n the name of the item
-    * @param l the lore for this item
+    * @param material the material type
+    * @param variant the variant information, this is 0 for most items but for things like potions it can control color
+    * @param name the name of the item
+    * @param lore the lore for this item
+    * @param enchantment the optional enchantment for this item
     */
    O2ItemType(@NotNull Material material, short variant, @NotNull String name, @Nullable String lore, @Nullable ItemEnchantmentType enchantment)
    {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/listeners/OllivandersListener.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/listeners/OllivandersListener.java
@@ -87,7 +87,7 @@ public class OllivandersListener implements Listener
    /**
     * Number of ticks to delay thread start for
     */
-   public static int threadDelay = Ollivanders2Common.ticksPerSecond;
+   public static int threadDelay = (int)(Ollivanders2Common.ticksPerSecond * 0.5);
 
    /**
     * Constructor

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spells.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spells.java
@@ -65,6 +65,9 @@ public class O2Spells
      */
     private ArrayList<SpellZone> spellZones = new ArrayList<>();
 
+    /**
+     * String keys for zone config
+     */
     private final static String allowedList = "allowed-spells";
     private final static String disallowList = "disallowed-spells";
     private final static String globalZoneName = "global";
@@ -139,9 +142,6 @@ public class O2Spells
      */
     public void onEnable()
     {
-        // load the zone config
-        loadZoneConfig(p);
-
         // load enabled spells
         for (O2SpellType spellType : O2SpellType.values())
         {
@@ -153,6 +153,9 @@ public class O2Spells
 
         // load any spell static data
         APPARATE.loadApparateLocations(p);
+
+        // load the zone config
+        loadZoneConfig(p);
     }
 
     /**
@@ -233,8 +236,8 @@ public class O2Spells
             {
                 common.printDebugMessage("Loading global zone config:", null, null, false);
 
-                globalAllowedSpells = getSpellsForZone(globalZoneName, allowedList);
-                globalDisallowedSpells = getSpellsForZone(globalZoneName, disallowList);
+                globalAllowedSpells = getSpellsForZone(zone, allowedList);
+                globalDisallowedSpells = getSpellsForZone(zone, disallowList);
             }
             else
             {
@@ -312,17 +315,17 @@ public class O2Spells
      * Get the spell for a specific list for a zone
      *
      * @param zoneName the name of the zone
-     * @param list the name of the list
+     * @param listName the name of the list
      * @return the spells for that zone list
      */
     @NotNull
-    private ArrayList<O2SpellType> getSpellsForZone(@NotNull String zoneName, @NotNull String list)
+    private ArrayList<O2SpellType> getSpellsForZone(@NotNull String zoneName, @NotNull String listName)
     {
         ArrayList<O2SpellType> spellList = new ArrayList<>();
 
-        common.printDebugMessage(list + ":", null, null, false);
+        common.printDebugMessage(listName + ":", null, null, false);
 
-        for (String spell : zoneConfig.getStringList(zoneName + "." + list))
+        for (String spell : zoneConfig.getStringList(zoneName + "." + listName))
         {
             O2SpellType spellType = O2SpellType.spellTypeFromString(spell.toUpperCase());
             if (spellType != null && isLoaded(spellType))
@@ -331,6 +334,10 @@ public class O2Spells
 
                 spellList.add(spellType);
             }
+            else if (spellType == null)
+                common.printDebugMessage("invalid spell " + spell, null, null, false);
+            else if (!isLoaded(spellType))
+                common.printDebugMessage(spell + " not loaded", null, null, false);
         }
 
         return spellList;

--- a/Ollivanders/src/plugin.yml
+++ b/Ollivanders/src/plugin.yml
@@ -1,6 +1,6 @@
 name: Ollivanders2
 main: net.pottercraft.ollivanders2.Ollivanders2
-version: 2.7-beta
+version: 2.7
 authors: [ Azami7, autumnwoz ]
 website: https://www.spigotmc.org/resources/ollivanders2.38992/
 softdepend: [ WorldGuard, LibsDisguises ]


### PR DESCRIPTION
- Changed item give command to take in an amount
- Decreased default thread delay to 0.5 seconds
- zone config is read before spells are loaded so none are added to the config
- updated mcVersionCheck to support 1.18 and remove 1.16 support