### PR TITLE
https://github.com/Azami7/Ollivanders2/issues/494

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/common/Ollivanders2Common.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/common/Ollivanders2Common.java
@@ -1103,7 +1103,7 @@ public class Ollivanders2Common
     * Determine if a player is facing a block type.
     *
     * @param player the player to check
-    * @return the cauldron if a player is facing one, null otherwise
+    * @return the block if a player is facing a block of this type, null otherwise
     */
    public Block playerFacingBlockType(@NotNull Player player, @NotNull Material blockType)
    {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/listeners/OllivandersListener.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/listeners/OllivandersListener.java
@@ -553,7 +553,7 @@ public class OllivandersListener implements Listener
 
             common.printDebugMessage("primaryHandInteractEvents: right click action", null, null, false);
 
-            Block cauldron = (Ollivanders2API.common.playerFacingBlockType(player, Material.CAULDRON));
+            Block cauldron = (Ollivanders2API.common.playerFacingBlockType(player, Material.WATER_CAULDRON));
             if ((cauldron != null) && (player.getInventory().getItemInOffHand().getType() == Material.GLASS_BOTTLE))
             {
                common.printDebugMessage("primaryHandInteractEvents: brewing potion", null, null, false);
@@ -938,22 +938,16 @@ public class OllivandersListener implements Listener
 
       // is the player sneaking
       if (!event.isSneaking())
-      {
          return;
-      }
 
-      Block cauldron = Ollivanders2API.common.playerFacingBlockType(player, Material.CAULDRON);
+      Block cauldron = Ollivanders2API.common.playerFacingBlockType(player, Material.WATER_CAULDRON);
       if (cauldron == null)
-      {
          return;
-      }
 
       // check that the item held is in their left hand
       ItemStack heldItem = player.getInventory().getItemInOffHand();
       if (heldItem.getType() == Material.AIR || heldItem.getAmount() == 0)
-      {
          return;
-      }
 
       ItemMeta meta = heldItem.getItemMeta();
       if (meta == null)
@@ -998,13 +992,15 @@ public class OllivandersListener implements Listener
          for (Entity e : cauldron.getWorld().getNearbyEntities(cauldron.getLocation(), 1, 1, 1))
          {
             if (e instanceof Item)
-            {
                e.remove();
-            }
          }
 
          player.getWorld().playEffect(cauldron.getLocation(), Effect.MOBSPAWNER_FLAMES, 0);
          player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BREWING_STAND_BREW, 1, 1);
+
+         // put potion in player's hand
+         ItemStack emptyBottle = player.getInventory().getItemInOffHand();
+         player.getInventory().remove(emptyBottle);
          player.getInventory().setItemInOffHand(potion);
       }
       else

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2Potions.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2Potions.java
@@ -202,11 +202,7 @@ public class O2Potions
    public ItemStack brewPotion(@NotNull Block cauldron, @NotNull Player brewer)
    {
       // make sure the block passed to us is a cauldron
-      if (cauldron.getType() != Material.CAULDRON)
-         return null;
-
-      // make sure cauldron has water in it
-      if (cauldron.isEmpty())
+      if (cauldron.getType() != Material.WATER_CAULDRON)
          return null;
 
       // get ingredients from the cauldron

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/HERBIVICUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/HERBIVICUS.java
@@ -24,8 +24,6 @@ import org.jetbrains.annotations.NotNull;
  */
 public final class HERBIVICUS extends O2Spell
 {
-   private List<CropState> stateList = new ArrayList<>();
-
    /**
     * Default constructor for use in generating spell text.  Do not use to cast the spell.
     *
@@ -62,15 +60,6 @@ public final class HERBIVICUS extends O2Spell
 
       // pass-through materials
       projectilePassThrough.add(Material.WATER);
-
-      stateList.add(CropState.SEEDED);
-      stateList.add(CropState.GERMINATED);
-      stateList.add(CropState.VERY_SMALL);
-      stateList.add(CropState.SMALL);
-      stateList.add(CropState.MEDIUM);
-      stateList.add(CropState.TALL);
-      stateList.add(CropState.VERY_TALL);
-      stateList.add(CropState.RIPE);
 
       initSpell();
    }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/OVOGNOSIS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/OVOGNOSIS.java
@@ -56,8 +56,8 @@ public class OVOGNOSIS extends Divination
         divinationType = O2DivinationType.OVOMANCY;
         branch = O2MagicBranch.DIVINATION;
 
-        facingBlock = Material.CAULDRON;
-        facingBlockString = "a cauldron";
+        facingBlock = Material.WATER_CAULDRON;
+        facingBlockString = "a water-filled cauldron";
 
         itemHeld = O2ItemType.EGG;
         itemHeldString = "an egg";


### PR DESCRIPTION
- updated potion brewing to handle new 1.17 WATER_CAULDRON material
- minor code formatting clean up
- added explicit removal of empty bottle from player's hand since it seems 1.17 was not doing that but putting the potion in the inv when the hand is already full
- removed unused crop state list from Herbivicus (leftover from pre 1.14 API upgrade I think)
- faced same cauldron issue with Ovognosis