### PR TITLE
Removed mcVersionCheck

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
@@ -317,13 +317,6 @@ public class Ollivanders2 extends JavaPlugin
         // read configuration
         initConfig();
 
-        // check MC version
-        if (!mcVersionCheck())
-        {
-            Bukkit.getPluginManager().disablePlugin(this);
-            return;
-        }
-
         // set up event listeners
         OllivandersListener ollivandersListener = new OllivandersListener(this);
         ollivandersListener.onEnable();
@@ -1509,25 +1502,6 @@ public class Ollivanders2 extends JavaPlugin
             spellCannotBeCastMessage(player);
 
         return cast;
-    }
-
-    /**
-     * Check to see what MC version is being run to determine what Ollivanders2 features are supported.
-     */
-    private boolean mcVersionCheck()
-    {
-        if (overrideVersionCheck)
-            return true;
-
-        String versionString = Bukkit.getBukkitVersion();
-
-        if (versionString.startsWith("1.17") || versionString.startsWith("1.18"))
-            return true;
-        else // anything lower than 1.14 set to 0 because this version of the plugin cannot run on < 1.14
-        {
-            getLogger().warning("MC version " + versionString + ". This version of Ollivanders2 requires 1.17 or higher.");
-            return false;
-        }
     }
 
     /**

--- a/Ollivanders/src/plugin.yml
+++ b/Ollivanders/src/plugin.yml
@@ -1,10 +1,10 @@
 name: Ollivanders2
 main: net.pottercraft.ollivanders2.Ollivanders2
-version: 2.7.2
+version: 2.8
 authors: [ Azami7, autumnwoz ]
 website: https://www.spigotmc.org/resources/ollivanders2.38992/
 softdepend: [ WorldGuard, LibsDisguises ]
-api-version: 1.17
+api-version: 1.18
 prefix: Ollivanders2
 commands:
   Ollivanders2:


### PR DESCRIPTION
Removed mcVersionCheck, we can rely on the built-in MC api-version (set in plugin.yml) check to ensure that servers use a supported version of the plugin.

Not sure why it shows changing the plugin version and api-version in plugin.yml from 2.9 - suspect I accidentally pulled a commit to 2.9 in to 2.8 that had that change in it as well.