### PR TITLE
Remove mcVersionCheck

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
@@ -317,13 +317,6 @@ public class Ollivanders2 extends JavaPlugin
         // read configuration
         initConfig();
 
-        // check MC version
-        if (!mcVersionCheck())
-        {
-            Bukkit.getPluginManager().disablePlugin(this);
-            return;
-        }
-
         // set up event listeners
         OllivandersListener ollivandersListener = new OllivandersListener(this);
         ollivandersListener.onEnable();
@@ -1509,25 +1502,6 @@ public class Ollivanders2 extends JavaPlugin
             spellCannotBeCastMessage(player);
 
         return cast;
-    }
-
-    /**
-     * Check to see what MC version is being run to determine what Ollivanders2 features are supported.
-     */
-    private boolean mcVersionCheck()
-    {
-        if (overrideVersionCheck)
-            return true;
-
-        String versionString = Bukkit.getBukkitVersion();
-
-        if (versionString.startsWith("1.17") || versionString.startsWith("1.18"))
-            return true;
-        else // anything lower than 1.14 set to 0 because this version of the plugin cannot run on < 1.14
-        {
-            getLogger().warning("MC version " + versionString + ". This version of Ollivanders2 requires 1.17 or higher.");
-            return false;
-        }
     }
 
     /**

--- a/Ollivanders/src/plugin.yml
+++ b/Ollivanders/src/plugin.yml
@@ -1,10 +1,10 @@
 name: Ollivanders2
 main: net.pottercraft.ollivanders2.Ollivanders2
-version: 2.9
+version: 2.7
 authors: [ Azami7, autumnwoz ]
 website: https://www.spigotmc.org/resources/ollivanders2.38992/
 softdepend: [ WorldGuard, LibsDisguises ]
-api-version: 1.19
+api-version: 1.17
 prefix: Ollivanders2
 commands:
   Ollivanders2:


### PR DESCRIPTION
We can rely on the built-in MC api-version check (from plugin.yml). Also fixed MC version in mainline back to 2.7.