### PR TITLE
todo cleanup on invisPlayer() and update Repello Muggleton

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/common/Ollivanders2Common.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/common/Ollivanders2Common.java
@@ -569,7 +569,10 @@ public class Ollivanders2Common {
      * @param radius    the radius of the flair
      * @param intensity intensity of the flair. If greater than 10, is reduced to 10.
      */
-    public static void flair(@NotNull Location location, int radius, int intensity) {
+    public static void flair(Location location, int radius, int intensity) {
+        if (location == null)
+            return;
+
         flair(location, radius, intensity, Particle.SMOKE);
     }
 
@@ -581,15 +584,18 @@ public class Ollivanders2Common {
      * @param intensity  intensity of the flair. If greater than 10, is reduced to 10.
      * @param effectType the particle effect to use
      */
-    public static void flair(@NotNull Location location, int radius, int intensity, Effect effectType) {
+    public static void flair(Location location, int radius, int intensity, Effect effectType) {
+        if (location == null)
+            return;
+
         if (intensity > 10)
             intensity = 10;
 
-        for (double inc = (Math.random() * Math.PI) / intensity; inc < Math.PI; inc += Math.PI / intensity) {
-            for (double azi = (Math.random() * Math.PI) / intensity; azi < 2 * Math.PI; azi += Math.PI / intensity) {
+        for (double inclusion = (Math.random() * Math.PI) / intensity; inclusion < Math.PI; inclusion += Math.PI / intensity) {
+            for (double azimuth = (Math.random() * Math.PI) / intensity; azimuth < 2 * Math.PI; azimuth += Math.PI / intensity) {
                 double[] sphere = new double[2];
-                sphere[0] = inc;
-                sphere[1] = azi;
+                sphere[0] = inclusion;
+                sphere[1] = azimuth;
                 Location effectLocation = location.clone().add(sphereToVector(sphere, radius));
 
                 if (effectLocation.getWorld() != null)
@@ -606,7 +612,10 @@ public class Ollivanders2Common {
      * @param intensity    intensity of the flair. If greater than 10, is reduced to 10.
      * @param particleType the particle to use
      */
-    public static void flair(@NotNull Location location, int radius, int intensity, Particle particleType) {
+    public static void flair(Location location, int radius, int intensity, Particle particleType) {
+        if (location == null)
+            return;
+
         if (intensity > 10)
             intensity = 10;
 
@@ -630,11 +639,11 @@ public class Ollivanders2Common {
      * @return Spherical coordinates in double array with indexes 0=inclination 1=azimuth
      */
     public static double[] vectorToSphere(@NotNull Vector vector) {
-        double inc = Math.acos(vector.getZ());
-        double azi = Math.atan2(vector.getY(), vector.getX());
+        double inclusion = Math.acos(vector.getZ());
+        double azimuth = Math.atan2(vector.getY(), vector.getX());
         double[] sphere = new double[2];
-        sphere[0] = inc;
-        sphere[1] = azi;
+        sphere[0] = inclusion;
+        sphere[1] = azimuth;
 
         return sphere;
     }
@@ -648,11 +657,11 @@ public class Ollivanders2Common {
      */
     @NotNull
     public static Vector sphereToVector(double[] sphere, int radius) {
-        double inc = sphere[0];
-        double azi = sphere[1];
-        double x = radius * Math.sin(inc) * Math.cos(azi);
-        double z = radius * Math.sin(inc) * Math.sin(azi);
-        double y = radius * Math.cos(inc);
+        double inclusion = sphere[0];
+        double azimuth = sphere[1];
+        double x = radius * Math.sin(inclusion) * Math.cos(azimuth);
+        double z = radius * Math.sin(inclusion) * Math.sin(azimuth);
+        double y = radius * Math.cos(inclusion);
 
         return new Vector(x, y, z);
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/listeners/OllivandersListener.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/listeners/OllivandersListener.java
@@ -6,6 +6,7 @@ import net.pottercraft.ollivanders2.Ollivanders2OwlPost;
 import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.effect.O2EffectType;
 import net.pottercraft.ollivanders2.player.O2Player;
+import net.pottercraft.ollivanders2.player.O2PlayerCommon;
 import net.pottercraft.ollivanders2.player.events.OllivandersPlayerFoundWandEvent;
 import net.pottercraft.ollivanders2.player.events.OllivandersPlayerNotDestinedWandEvent;
 import net.pottercraft.ollivanders2.potion.O2Potions;
@@ -19,7 +20,6 @@ import net.pottercraft.ollivanders2.spell.O2SpellType;
 import net.pottercraft.ollivanders2.potion.O2Potion;
 import net.pottercraft.ollivanders2.potion.O2SplashPotion;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -44,7 +44,6 @@ import org.bukkit.event.block.BlockBreakEvent;
 
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
-import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.entity.PotionSplashEvent;
@@ -65,16 +64,14 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Constructor;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 
 /**
  * Primary listener for events from the plugin
@@ -668,7 +665,7 @@ public class OllivandersListener implements Listener {
     public void cloakPlayer(@NotNull EntityTargetEvent event) {
         Entity target = event.getTarget();
         if (target instanceof Player) {
-            if (p.getO2Player((Player) target).isInvisible()) {
+            if (O2PlayerCommon.hasPotionEffect((Player) target, PotionEffectType.INVISIBILITY)) {
                 event.setCancelled(true);
                 common.printDebugMessage("cloakPlayer: cancelling EntityTargetEvent", null, null, false);
             }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Player.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Player.java
@@ -113,11 +113,6 @@ public class O2Player {
     private int souls = 0;
 
     /**
-     * Whether the player is currently invisible
-     */
-    private boolean isInvisible = false;
-
-    /**
      * Whether the player has found their destined wand yet
      */
     private boolean foundWand = false;
@@ -133,7 +128,7 @@ public class O2Player {
     private String animagusColor = null;
 
     /**
-     * Whether the player is a Muggle (i.e. not sorted)
+     * Whether the player is a Muggle (i.e. has not found their destined wand), true for all players initially
      */
     private boolean isMuggle = true;
 
@@ -518,38 +513,28 @@ public class O2Player {
     }
 
     /**
-     * Determine if this player is invisible.
-     *
-     * @return true if the player is invisible, false otherwise.
-     */
-    public boolean isInvisible() {
-        return isInvisible;
-    }
-
-    /**
-     * Set whether a player is invisible
-     *
-     * @param isInvisible true if the player is invisible, false if they are not
-     */
-    public void setInvisible(boolean isInvisible) {
-        this.isInvisible = isInvisible;
-    }
-
-    /**
-     * Determine if player is a muggle.
+     * Determine if player is a muggle. Admins are never muggles.
      *
      * @return true if they are a muggle, false otherwise
      */
     public boolean isMuggle() {
+        Player player = p.getServer().getPlayer(pid);
+        if (player != null && player.isOp())
+            return false;
+
         return isMuggle;
     }
 
     /**
-     * Set if a player is a muggle.
+     * Set if a player is a muggle. Admins are never muggles.
      *
      * @param isMuggle true if the player is a muggle
      */
     public void setMuggle(boolean isMuggle) {
+        Player player = p.getServer().getPlayer(pid);
+        if (player != null && player.isOp())
+            isMuggle = false;
+
         this.isMuggle = isMuggle;
     }
 
@@ -613,7 +598,8 @@ public class O2Player {
     }
 
     /**
-     * Initializer for the foundWand class variable for loading the player object.
+     * Initializer for the foundWand class variable for loading the player from saved data. This is different from setFoundWand
+     * which triggers a found wand event.
      *
      * @param found the value to set for foundWand
      */
@@ -622,12 +608,13 @@ public class O2Player {
     }
 
     /**
-     * Set whether the player has found their destined wand before.
+     * Set whether the player has found their destined wand before. Once a player finds their destined wand they are also
+     * no longer a muggle since they can do magic. This should not be called when loading from saved data, use initFoundWand().
      *
      * @param found set whether the player has found their destined wand
      */
     public void setFoundWand(boolean found) {
-        if (foundWand && found) {
+        if (found) {
             Player player = p.getServer().getPlayer(pid);
             if (player == null)
                 return;
@@ -636,6 +623,9 @@ public class O2Player {
 
             p.getServer().getPluginManager().callEvent(event);
             common.printDebugMessage("Fired OllivandersPlayerFoundWandEvent", null, null, false);
+
+            // once they have found their wand and can cast spells, they are no longer a muggle
+            setMuggle(false);
         }
 
         foundWand = found;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/player/O2PlayerCommon.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/player/O2PlayerCommon.java
@@ -18,6 +18,7 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -265,5 +266,22 @@ public final class O2PlayerCommon {
         for (ItemStack item : leftover.values()) {
             player.getWorld().dropItem(loc, item);
         }
+    }
+
+    /**
+     * Does a player have a particular potion effect?
+     *
+     * @param player the player to check
+     * @param effectType the potion effect type to check for
+     * @return
+     */
+    static public boolean hasPotionEffect(@NotNull Player player, @NotNull PotionEffectType effectType) {
+        for (PotionEffect effect: player.getActivePotionEffects()) {
+            if (effect.getType() == effectType) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spell.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spell.java
@@ -249,7 +249,7 @@ public abstract class O2Spell {
     }
 
     /**
-     * The spell-specific initialization based on usage, etc.. Must be overridden by each spell class that
+     * The spell-specific initialization based on usage, etc. Must be overridden by each spell class that
      * has any initializations.
      */
     void doInitSpell() {
@@ -287,7 +287,7 @@ public abstract class O2Spell {
      * Moves the projectile forward, creating a particle effect
      */
     public void move() {
-        // if this is somehow called when the spell is set to killed or we've already hit a target, do nothing
+        // if this is somehow called when the spell is set to killed, or we've already hit a target, do nothing
         if (isKilled() || hasHitTarget())
             return;
 
@@ -343,8 +343,8 @@ public abstract class O2Spell {
 
         p.getLogger().info("Checking " + target.getType());
 
-        // check blockAllowList
-        if (!(materialAllowList.contains(target.getType()))) {
+        // check blockAllowList, if it ia empty then all block types are allowed
+        if ((!materialAllowList.isEmpty()) && !(materialAllowList.contains(target.getType()))) {
             common.printDebugMessage(target.getType() + " is not in the material allow list", null, null, false);
             kill();
             return;
@@ -395,7 +395,7 @@ public abstract class O2Spell {
         // check every flag needed for this spell
         for (StateFlag flag : worldGuardFlags) {
             if (!Ollivanders2.worldGuardO2.checkWGFlag(player, location, flag)) {
-                common.printDebugMessage(spellType.toString() + " cannot be cast because of WorldGuard flag " + flag.toString(), null, null, false);
+                common.printDebugMessage(spellType.toString() + " cannot be cast because of WorldGuard flag " + flag, null, null, false);
                 return false;
             }
         }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/StationarySpell.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/StationarySpell.java
@@ -104,7 +104,12 @@ public abstract class StationarySpell extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (!centerOnCaster && !hasHitTarget())
+        // we do not want a spell projectile if the spell centers on the caster, this will set the target on the caster
+        if (centerOnCaster)
+            stopProjectile();
+
+        // if we have not hit a target, continue
+        if (!hasHitTarget())
             return;
 
         // set duration to be base time plus a modifier seconds per experience level for this spell

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/ALIQUAM_FLOO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/ALIQUAM_FLOO.java
@@ -100,13 +100,11 @@ public class ALIQUAM_FLOO extends O2StationarySpell {
      * @param flooName the name of this floo location
      */
     public ALIQUAM_FLOO(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, @NotNull String flooName) {
-        super(plugin);
+        super(plugin, pid, location);
 
         minRadius = minRadiusConfig;
         maxRadius = maxRadiusConfig;
         this.flooName = flooName;
-        setPlayerID(pid);
-        setLocation(location);
 
         init();
 
@@ -374,5 +372,10 @@ public class ALIQUAM_FLOO extends O2StationarySpell {
             event.setCancelled(true);
             common.printDebugMessage("ALIQUAM_FLOO: canceled EntityDamageEvent", null, null, false);
         }
+    }
+
+    @Override
+    void doCleanUp() {
+        stopWorking();
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/COLLOPORTUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/COLLOPORTUS.java
@@ -52,15 +52,13 @@ public class COLLOPORTUS extends O2StationarySpell {
      * @param location the center location of the spell
      */
     public COLLOPORTUS(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location) {
-        super(plugin);
+        super(plugin, pid, location);
 
         spellType = O2StationarySpellType.COLLOPORTUS;
         minRadius = minRadiusConfig;
         maxRadius = maxRadiusConfig;
         permanent = true;
 
-        setPlayerID(pid);
-        setLocation(location);
         radius = minRadius = maxRadius = minRadiusConfig;
         duration = 10;
 
@@ -160,4 +158,7 @@ public class COLLOPORTUS extends O2StationarySpell {
     @Override
     public void deserializeSpellData(@NotNull Map<String, String> spellData) {
     }
+
+    @Override
+    void doCleanUp() {}
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HARMONIA_NECTERE_PASSUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HARMONIA_NECTERE_PASSUS.java
@@ -76,15 +76,13 @@ public class HARMONIA_NECTERE_PASSUS extends O2StationarySpell {
      * @param twin     the location of this cabinet's twin
      */
     public HARMONIA_NECTERE_PASSUS(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, @NotNull Location twin) {
-        super(plugin);
+        super(plugin, pid, location);
 
         spellType = O2StationarySpellType.HARMONIA_NECTERE_PASSUS;
         minRadius = minRadiusConfig;
         maxRadius = maxRadiusConfig;
         permanent = true;
 
-        setPlayerID(pid);
-        setLocation(location);
         radius = minRadius = maxRadius = minRadiusConfig;
         duration = 10;
 
@@ -234,7 +232,7 @@ public class HARMONIA_NECTERE_PASSUS extends O2StationarySpell {
             return;
         }
 
-        // make sure they do not have a use cooldown on the twin or we'll just teleport them right back as soon as they arrive and trigger a move event
+        // make sure they do not have a use cooldown on the twin, or we'll just teleport them right back as soon as they arrive and trigger a move event
         if (twin.isUsing(player))
             return;
 
@@ -251,4 +249,7 @@ public class HARMONIA_NECTERE_PASSUS extends O2StationarySpell {
             }.runTaskLater(p, Ollivanders2Common.ticksPerSecond);
         }
     }
+
+    @Override
+    void doCleanUp() {}
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HORCRUX.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HORCRUX.java
@@ -60,13 +60,11 @@ public class HORCRUX extends O2StationarySpell {
      * @param location the center location of the spell
      */
     public HORCRUX(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location) {
-        super(plugin);
+        super(plugin, pid, location);
 
         spellType = O2StationarySpellType.HORCRUX;
         permanent = true;
 
-        setPlayerID(pid);
-        setLocation(location);
         radius = minRadius = maxRadius = minRadiusConfig;
         duration = 10;
 
@@ -173,4 +171,7 @@ public class HORCRUX extends O2StationarySpell {
         player.getWorld().playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, 1, 1);
         flair(5);
     }
+
+    @Override
+    void doCleanUp() {}
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/MOLLIARE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/MOLLIARE.java
@@ -57,15 +57,13 @@ public class MOLLIARE extends O2StationarySpell {
      * @param duration the duration of the spell
      */
     public MOLLIARE(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
-        super(plugin);
+        super(plugin, pid, location);
         spellType = O2StationarySpellType.MOLLIARE;
         minRadius = minRadiusConfig;
         maxRadius = maxRadiusConfig;
         minDuration = minDurationConfig;
         maxDuration = maxDurationConfig;
 
-        setPlayerID(pid);
-        setLocation(location);
         setRadius(radius);
         setDuration(duration);
 
@@ -107,4 +105,7 @@ public class MOLLIARE extends O2StationarySpell {
     @Override
     public void deserializeSpellData(@NotNull Map<String, String> spellData) {
     }
+
+    @Override
+    void doCleanUp() {}
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/MUFFLIATO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/MUFFLIATO.java
@@ -59,15 +59,13 @@ public class MUFFLIATO extends ShieldSpell {
      * @param duration the duration of the spell
      */
     public MUFFLIATO(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
-        super(plugin);
+        super(plugin, pid, location);
         spellType = O2StationarySpellType.MUFFLIATO;
         minRadius = minRadiusConfig;
         maxRadius = maxRadiusConfig;
         minDuration = minDurationConfig;
         maxDuration = maxDurationConfig;
 
-        setPlayerID(pid);
-        setLocation(location);
         setRadius(radius);
         setDuration(duration);
 
@@ -111,4 +109,7 @@ public class MUFFLIATO extends ShieldSpell {
     @Override
     public void deserializeSpellData(@NotNull Map<String, String> spellData) {
     }
+
+    @Override
+    void doCleanUp() {}
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/NULLUM_APPAREBIT.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/NULLUM_APPAREBIT.java
@@ -62,7 +62,7 @@ public class NULLUM_APPAREBIT extends O2StationarySpell {
      * @param duration the duration of the spell
      */
     public NULLUM_APPAREBIT(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
-        super(plugin);
+        super(plugin, pid, location);
         spellType = O2StationarySpellType.NULLUM_APPAREBIT;
 
         minRadius = minRadiusConfig;
@@ -70,8 +70,6 @@ public class NULLUM_APPAREBIT extends O2StationarySpell {
         minDuration = minDurationConfig;
         maxDuration = maxDurationConfig;
 
-        setPlayerID(pid);
-        setLocation(location);
         setRadius(radius);
         setDuration(duration);
 
@@ -194,4 +192,7 @@ public class NULLUM_APPAREBIT extends O2StationarySpell {
         player.getWorld().playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, 1, 1);
         flair(5);
     }
+
+    @Override
+    void doCleanUp() {}
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/NULLUM_EVANESCUNT.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/NULLUM_EVANESCUNT.java
@@ -45,7 +45,7 @@ public class NULLUM_EVANESCUNT extends O2StationarySpell {
      * @param duration the duration of the spell
      */
     public NULLUM_EVANESCUNT(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
-        super(plugin);
+        super(plugin, pid, location);
         spellType = O2StationarySpellType.NULLUM_EVANESCUNT;
 
         // make min/max radius and duration the same as Nullum Apparebit
@@ -54,8 +54,6 @@ public class NULLUM_EVANESCUNT extends O2StationarySpell {
         minDuration = NULLUM_APPAREBIT.minDurationConfig;
         maxDuration = NULLUM_APPAREBIT.maxDurationConfig;
 
-        setPlayerID(pid);
-        setLocation(location);
         setRadius(radius);
         setDuration(duration);
 
@@ -178,4 +176,7 @@ public class NULLUM_EVANESCUNT extends O2StationarySpell {
     @Override
     public void deserializeSpellData(@NotNull Map<String, String> spellData) {
     }
+
+    @Override
+    void doCleanUp() {}
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpell.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpell.java
@@ -28,6 +28,7 @@ import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.entity.EntityTeleportEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.jetbrains.annotations.NotNull;
@@ -114,6 +115,21 @@ public abstract class O2StationarySpell implements Serializable {
     public O2StationarySpell(@NotNull Ollivanders2 plugin) {
         p = plugin;
         common = new Ollivanders2Common(p);
+    }
+
+    /**
+     * Simple constructor used for deserializing saved stationary spells at server start. Do not use to cast spell.
+     *
+     * @param plugin   a callback to the MC plugin
+     * @param pid      the player who cast the spell
+     * @param location the center location of the spell
+     */
+    public O2StationarySpell(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location) {
+        p = plugin;
+        common = new Ollivanders2Common(p);
+
+        playerUUID = pid;
+        this.location = location;
     }
 
     /**
@@ -209,7 +225,8 @@ public abstract class O2StationarySpell implements Serializable {
     }
 
     /**
-     * Set the center location of this stationary spell
+     * Set the center location of this stationary spell. This should only be used at start up to set up the saved
+     * stationary spells.
      *
      * @param location the spell location
      */
@@ -218,7 +235,8 @@ public abstract class O2StationarySpell implements Serializable {
     }
 
     /**
-     * Set the ID of the player who cast this spell
+     * Set the ID of the player who cast this spell. This should only be used at start up to set up the saved
+     * stationary spells.
      *
      * @param pid the player ID
      */
@@ -293,6 +311,9 @@ public abstract class O2StationarySpell implements Serializable {
     public void kill() {
         flair(20);
         kill = true;
+
+        // clean up for the spell, if relevant
+        doCleanUp();
 
         Player caster = p.getServer().getPlayer(playerUUID);
         if (caster != null)
@@ -541,7 +562,7 @@ public abstract class O2StationarySpell implements Serializable {
     }
 
     /**
-     * Handle apparate by coord event
+     * Handle apparate by coordinate event
      *
      * @param event the event
      */
@@ -579,4 +600,17 @@ public abstract class O2StationarySpell implements Serializable {
      */
     void doOnSpellProjectileMoveEvent(@NotNull OllivandersSpellProjectileMoveEvent event) {
     }
+
+    /**
+     * Handle player join events
+     *
+     * @param event the player join event
+     */
+    void doOnPlayerJoinEvent(@NotNull PlayerJoinEvent event) {
+    }
+
+    /**
+     * Clean up needed for this spell when it ends.
+     */
+    abstract void doCleanUp();
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpells.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpells.java
@@ -29,6 +29,7 @@ import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.entity.EntityTeleportEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.jetbrains.annotations.Nullable;
@@ -126,7 +127,7 @@ public class O2StationarySpells implements Listener {
     /**
      * Handle when entities target
      *
-     * @param event the pevent
+     * @param event the event
      */
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onEntityTargetEvent(@NotNull EntityTargetEvent event) {
@@ -306,12 +307,25 @@ public class O2StationarySpells implements Listener {
     }
 
     /**
+     * Handle player join events
+     *
+     * @param event the event
+     */
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerJoinEvent(@NotNull PlayerJoinEvent event) {
+        for (O2StationarySpell stationary : O2StationarySpells) {
+            if (stationary.isActive())
+                stationary.doOnPlayerJoinEvent(event);
+        }
+    }
+
+    /**
      * Add a stationary spell
      *
      * @param spell the stationary spell to add
      */
     public void addStationarySpell(@NotNull O2StationarySpell spell) {
-        common.printDebugMessage("O2StationarySpells.addStationarySpell: adding " + spell.getSpellType().toString() + " with duration " + spell.duration + " and radius of " + spell.radius, null, null, false);
+        common.printDebugMessage("O2StationarySpells.addStationarySpell: adding " + spell.getSpellType() + " with duration " + spell.duration + " and radius of " + spell.radius, null, null, false);
         O2StationarySpells.add(spell);
     }
 
@@ -322,7 +336,7 @@ public class O2StationarySpells implements Listener {
      * @param spell the stationary spell to remove
      */
     public void removeStationarySpell(@NotNull O2StationarySpell spell) {
-        common.printDebugMessage("O2StationarySpells.removeStationarySpell: removing " + spell.getSpellType().toString(), null, null, false);
+        common.printDebugMessage("O2StationarySpells.removeStationarySpell: removing " + spell.getSpellType(), null, null, false);
         spell.kill();
     }
 
@@ -426,7 +440,7 @@ public class O2StationarySpells implements Listener {
             statSpell.checkEffect();
 
             if (statSpell.kill) {
-                common.printDebugMessage("O2StationarySpells.upkeep: removing " + statSpell.getSpellType().toString(), null, null, false);
+                common.printDebugMessage("O2StationarySpells.upkeep: removing " + statSpell.getSpellType(), null, null, false);
 
                 O2StationarySpells.remove(statSpell);
             }
@@ -462,7 +476,7 @@ public class O2StationarySpells implements Listener {
     /**
      * Serialize stationary spells for saving
      *
-     * @return a map of the serialized stationary spell data
+     * @return a list of the serialized stationary spell data
      */
     @NotNull
     private List<Map<String, String>> serializeO2StationarySpells() {
@@ -488,9 +502,7 @@ public class O2StationarySpells implements Listener {
             //
             Map<String, String> locData = Ollivanders2API.common.serializeLocation(spell.location, spellLocLabel);
             if (locData != null) {
-                for (Entry<String, String> e : locData.entrySet()) {
-                    spellData.put(e.getKey(), e.getValue());
-                }
+                spellData.putAll(locData);
             }
 
             //
@@ -509,9 +521,7 @@ public class O2StationarySpells implements Listener {
             // get spell-specific data
             //
             Map<String, String> uniqueData = spell.serializeSpellData();
-            for (Entry<String, String> e : uniqueData.entrySet()) {
-                spellData.put(e.getKey(), e.getValue());
-            }
+            spellData.putAll(uniqueData);
         }
 
         return serializedList;
@@ -604,7 +614,7 @@ public class O2StationarySpells implements Listener {
             statSpell = (O2StationarySpell) spellClass.getConstructor(Ollivanders2.class).newInstance(p);
         }
         catch (Exception e) {
-            common.printDebugMessage("Exception trying to create new instance of " + spellType.toString(), e, null, true);
+            common.printDebugMessage("Exception trying to create new instance of " + spellType, e, null, true);
             return null;
         }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO.java
@@ -65,7 +65,7 @@ public class PROTEGO extends ShieldSpell {
      * @param duration the duration of the spell
      */
     public PROTEGO(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
-        super(plugin);
+        super(plugin, pid, location);
         spellType = O2StationarySpellType.PROTEGO;
 
         minRadius = minRadiusConfig;
@@ -73,8 +73,6 @@ public class PROTEGO extends ShieldSpell {
         minDuration = minDurationConfig;
         maxDuration = maxDurationConfig;
 
-        setPlayerID(pid);
-        setLocation(location);
         setRadius(radius);
         setDuration(duration);
 
@@ -165,4 +163,7 @@ public class PROTEGO extends ShieldSpell {
     @Override
     public void deserializeSpellData(@NotNull Map<String, String> spellData) {
     }
+
+    @Override
+    void doCleanUp() {}
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO_HORRIBILIS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO_HORRIBILIS.java
@@ -59,15 +59,13 @@ public class PROTEGO_HORRIBILIS extends ShieldSpell {
      * @param duration the duration of the spell
      */
     public PROTEGO_HORRIBILIS(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
-        super(plugin);
+        super(plugin, pid, location);
         spellType = O2StationarySpellType.PROTEGO_HORRIBILIS;
         minRadius = minRadiusConfig;
         maxRadius = maxRadiusConfig;
         minDuration = minDurationConfig;
         maxDuration = maxDurationConfig;
 
-        setPlayerID(pid);
-        setLocation(location);
         setRadius(radius);
         setDuration(duration);
 
@@ -105,4 +103,7 @@ public class PROTEGO_HORRIBILIS extends ShieldSpell {
     @Override
     public void deserializeSpellData(@NotNull Map<String, String> spellData) {
     }
+
+    @Override
+    void doCleanUp() {}
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO_MAXIMA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO_MAXIMA.java
@@ -90,15 +90,13 @@ public class PROTEGO_MAXIMA extends ShieldSpell
      */
     public PROTEGO_MAXIMA(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration, double damage)
     {
-        super(plugin);
+        super(plugin, pid, location);
         spellType = O2StationarySpellType.PROTEGO_MAXIMA;
         minRadius = minRadiusConfig;
         maxRadius = maxRadiusConfig;
         minDuration = minDurationConfig;
         maxDuration = maxDurationConfig;
 
-        setPlayerID(pid);
-        setLocation(location);
         setRadius(radius);
         setDuration(duration);
         setDamage(damage);
@@ -190,4 +188,7 @@ public class PROTEGO_MAXIMA extends ShieldSpell
 
         this.damage = damage;
     }
+
+    @Override
+    void doCleanUp() {}
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO_TOTALUM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO_TOTALUM.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 /**
  * Doesn't let entities pass into the protected area.
  *
- * <a href = "https://harrypotter.fandom.com/wiki/Protego_totalum">https://harrypotter.fandom.com/wiki/Protego_totalum</a>
+ * @see <a href = "https://harrypotter.fandom.com/wiki/Protego_totalum">https://harrypotter.fandom.com/wiki/Protego_totalum</a>
  * {@link net.pottercraft.ollivanders2.spell.PROTEGO_TOTALUM}
  */
 public class PROTEGO_TOTALUM extends ShieldSpell
@@ -64,7 +64,7 @@ public class PROTEGO_TOTALUM extends ShieldSpell
      */
     public PROTEGO_TOTALUM(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration)
     {
-        super(plugin);
+        super(plugin, pid, location);
         spellType = O2StationarySpellType.PROTEGO_TOTALUM;
 
         minRadius = minRadiusConfig;
@@ -72,8 +72,6 @@ public class PROTEGO_TOTALUM extends ShieldSpell
         minDuration = minDurationConfig;
         maxDuration = maxDurationConfig;
 
-        setPlayerID(pid);
-        setLocation(location);
         setRadius(radius);
         setDuration(duration);
 
@@ -197,7 +195,8 @@ public class PROTEGO_TOTALUM extends ShieldSpell
      * @param spellData a map of the saved spell data
      */
     @Override
-    public void deserializeSpellData(@NotNull Map<String, String> spellData)
-    {
-    }
+    public void deserializeSpellData(@NotNull Map<String, String> spellData) {}
+
+    @Override
+    void doCleanUp() {}
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/REPELLO_MUGGLETON.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/REPELLO_MUGGLETON.java
@@ -3,24 +3,28 @@ package net.pottercraft.ollivanders2.stationaryspell;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.common.EntityCommon;
 import net.pottercraft.ollivanders2.common.Ollivanders2Common;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.block.data.BlockData;
+import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityTargetEvent;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 /**
- * Hides all players within its area. The code to hide players is located in OllivandersSchedule.invisPlayer()
+ * Hides all players within its area.
  *
- * @see net.pottercraft.ollivanders2.spell.REPELLO_MUGGLETON
+ * {@link net.pottercraft.ollivanders2.spell.REPELLO_MUGGLETON}
  */
 public class REPELLO_MUGGLETON extends ShieldSpell {
     /**
@@ -39,6 +43,14 @@ public class REPELLO_MUGGLETON extends ShieldSpell {
      * max duration for this spell
      */
     public static final int maxDurationConfig = Ollivanders2Common.ticksPerMinute * 30;
+
+    public ArrayList<String> messages = new ArrayList<>() {{
+        add("You just remembered you need to do something someplace else.");
+        add("You just recalled an important appointment you need to get to somewhere else.");
+        add("Why were you going that way? You want to go a different way.");
+        add("You realize you don't actually want to go that way.");
+        add("You hear someone behind you calling your name.");
+    }};
 
     /**
      * Simple constructor used for deserializing saved stationary spells at server start. Do not use to cast spell.
@@ -61,34 +73,72 @@ public class REPELLO_MUGGLETON extends ShieldSpell {
      * @param duration the duration of the spell
      */
     public REPELLO_MUGGLETON(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
-        super(plugin);
+        super(plugin, pid, location);
+
+        setRadius(radius);
+        setDuration(duration);
 
         spellType = O2StationarySpellType.REPELLO_MUGGLETON;
+
+        hidePlayersInSpellArea();
     }
 
     /**
-     * Upkeep
+     * Hide the players in the spell area
      */
-    @Override
-    public void checkEffect() {
-        age();
+    private void hidePlayersInSpellArea() {
+        World world = location.getWorld();
+        if (world == null) {
+            common.printDebugMessage("StationarySpell.REPELLO_MUGGLETON: world is null", null, null, true);
+            return;
+        }
 
-        if (duration <= 1) {
-            for (Player player : getBlock().getWorld().getPlayers()) {
-                for (Entity target : EntityCommon.getNearbyEntitiesByType(location, radius, EntityType.PLAYER)) {
-                    Location targetLoc = target.getLocation();
-
-                    // change the player location block and the one above it - this is going to be weird if the player is currently shape shifted to a 1-block sized create with Animagus but acceptable
-                    BlockData fakeData = Bukkit.createBlockData(Material.AIR);
-                    player.sendBlockChange(targetLoc, fakeData);
-                    player.sendBlockChange(targetLoc.add(0, 1, 0), fakeData);
+        for (Entity player : EntityCommon.getNearbyEntitiesByType(location, radius, EntityType.PLAYER)) {
+            if (isLocationInside(player.getLocation())) {
+                for (Player viewer : world.getPlayers()) {
+                    hidePlayer((Player)player, viewer);
                 }
             }
         }
     }
 
     /**
-     * Do not allow targeting if the target is inside the radius and the targeter is not
+     * Hide a player inside this stationary spell if the viewer is a muggle
+     *
+     * @param player the player to hide
+     * @param viewer the viewer
+     */
+    private void hidePlayer (Player player, Player viewer) {
+        if (p.getO2Player(viewer).isMuggle()) {
+            viewer.hidePlayer(p, player);
+            common.printDebugMessage("StationarySpell.REPELLO_MUGGLETON: hid " + player.getName() + " from " + viewer.getName(), null, null, false);
+        }
+    }
+
+    /**
+     * Unhides the player from other players - for use in spell clean up and when players leave the spell area
+     *
+     * @param player the player to unhide
+     * @param viewer the viewer
+     */
+    private void showPlayer (Player player, Player viewer) {
+        viewer.showPlayer(p, player);
+        common.printDebugMessage("REPELLO_MUGGLETON: unhid " + player.getName() + " from " + viewer.getName(), null, null, false);
+    }
+
+    /**
+     * Upkeep - age the spell
+     */
+    @Override
+    public void checkEffect() {
+        age();
+
+        if (duration <= 1)
+            kill();
+    }
+
+    /**
+     * Prevent muggle players targeting a player inside the area.
      *
      * @param event the event
      */
@@ -97,12 +147,139 @@ public class REPELLO_MUGGLETON extends ShieldSpell {
         Entity target = event.getTarget();
         Entity entity = event.getEntity(); // will never be null
 
-        if (target == null)
+        if (!(target instanceof Player))
             return;
 
         if (isLocationInside(target.getLocation()) && !isLocationInside(entity.getLocation())) {
             event.setCancelled(true);
-            common.printDebugMessage("REPELLO_MUGGLETON: canceled EntityTargetEvent", null, null, false);
+            common.printDebugMessage("REPELLO_MUGGLETON: canceled target of " + target.getName() + " by " + entity.getName(),  null, null, false);
+        }
+    }
+
+    /**
+     * Hide the player from muggles if they go into the spell area
+     *
+     * @see <a href = "https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Player.html#hidePlayer(org.bukkit.plugin.Plugin,org.bukkit.entity.Player)">https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Player.html#hidePlayer(org.bukkit.plugin.Plugin,org.bukkit.entity.Player)</a>
+     * @param event the event
+     */
+    @Override
+    void doOnPlayerMoveEvent(@NotNull PlayerMoveEvent event) {
+        Location toLocation = event.getTo();
+        Location fromLocation = event.getFrom();
+        Player player = event.getPlayer();
+
+        if (event.isCancelled() || toLocation == null)
+            return;
+
+        if (p.getO2Player(player).isMuggle()) {
+            // do not let muggles enter the spell area if they are outside of it
+            if (isLocationInside(toLocation) && !(isLocationInside(fromLocation))) {
+                event.setCancelled(true);
+                player.sendMessage(Ollivanders2.chatColor + getMessage());
+                common.printDebugMessage("REPELLO_MUGGLETON: prevented " + player.getName() + " entering area.", null, null, false);
+                return; // return because they never entered the area so we don't need to do the rest of the steps in this function
+            }
+
+            // if they were inside the area and move out, hide the players inside the spell area from them
+            else if (!(isLocationInside(toLocation)) && isLocationInside(fromLocation)) {
+                for (Entity hiddenPlayer : EntityCommon.getNearbyEntitiesByType(location, radius, EntityType.PLAYER)) {
+                    hidePlayer((Player)hiddenPlayer, player);
+                }
+            }
+        }
+
+        // handle toggling visibility for this player with muggles if they cross the spell area boundary
+        handleVisibility(toLocation, fromLocation, player);
+    }
+
+    /**
+     * Get a random message to show muggles when they try to walk in to the spell area.
+     *
+     * @return one of the messages at random
+     */
+    private String getMessage() {
+        return messages.get(Math.abs(Ollivanders2Common.random.nextInt()) % messages.size());
+    }
+
+    /**
+     * Handle hiding or unhiding the player from muggles if the player crosses the spell area boundary
+     *
+     * @param toLocation the location the player is moving to
+     * @param fromLocation the location the player is moving from
+     * @param player the player moving
+     */
+    private void handleVisibility(Location toLocation, Location fromLocation, Player player) {
+        // if they move from outside the spell area to inside of it, hide them from muggles
+        if (isLocationInside(toLocation) && !(isLocationInside(fromLocation))) {
+            for (Player viewer : p.getServer().getOnlinePlayers()) {
+                hidePlayer(player, viewer);
+            }
+        }
+        // if they move from inside the spell area to outside of it, unhide them from all players
+        else if (!(isLocationInside(toLocation)) && isLocationInside(fromLocation)) {
+            for (Player viewer : p.getServer().getOnlinePlayers()) {
+                showPlayer(player, viewer);
+            }
+        }
+    }
+
+    /**
+     * Remove muggles from the recipients of any chats by players in the spell area
+     *
+     * @param event the event
+     */
+    @Override
+    void doOnAsyncPlayerChatEvent(@NotNull AsyncPlayerChatEvent event) {
+        Player speaker = event.getPlayer();
+
+        if (!isLocationInside(speaker.getLocation()))
+            return;
+
+        Set<Player> recipients = new HashSet<>(event.getRecipients());
+        for (Player player : recipients) {
+            if (p.getO2Player(player).isMuggle()) {
+                event.getRecipients().remove(player);
+                common.printDebugMessage("REPELLO_MUGGLETON: removed " + player.getName() + " from chat recipients", null, null, false);
+            }
+        }
+    }
+
+    /**
+     * Unhide all players that were in the spell area
+     */
+    @Override
+    void doCleanUp() {
+        World world = location.getWorld();
+        if (world == null) {
+            common.printDebugMessage("StationarySpell.REPELLO_MUGGLETON: world is null", null, null, true);
+            return;
+        }
+
+        for (Player player : world.getPlayers()) {
+            if (isLocationInside(player.getLocation())) {
+                for (Player viewer : location.getWorld().getPlayers()) {
+                    showPlayer(player, viewer);
+                }
+            }
+        }
+    }
+
+    /**
+     * When players join, hide any players in this repello muggleton from them.
+     *
+     * @param event the player join event
+     */
+    @Override
+    void doOnPlayerJoinEvent(@NotNull PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        if (!p.getO2Player(player).isMuggle())
+            return;
+
+        // hide any players inside this spell area from this player if they are a muggle
+        for (Entity hiddenPlayer : EntityCommon.getNearbyEntitiesByType(location, radius, EntityType.PLAYER)) {
+            if (hiddenPlayer instanceof Player) {
+                hidePlayer((Player) hiddenPlayer, player);
+            }
         }
     }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/ShieldSpell.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/ShieldSpell.java
@@ -1,7 +1,10 @@
 package net.pottercraft.ollivanders2.stationaryspell;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
+import org.bukkit.Location;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
 
 /**
  * Super class for all shield spells
@@ -14,5 +17,16 @@ public abstract class ShieldSpell extends O2StationarySpell {
      */
     public ShieldSpell(@NotNull Ollivanders2 plugin) {
         super(plugin);
+    }
+
+    /**
+     * Simple constructor used for deserializing saved stationary spells at server start. Do not use to cast spell.
+     *
+     * @param plugin   a callback to the MC plugin
+     * @param pid      the player who cast the spell
+     * @param location the center location of the spell
+     */
+    public ShieldSpell(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location) {
+        super(plugin, pid, location);
     }
 }


### PR DESCRIPTION
- refactored invis schedule to just handle invisibility cloaks
- cleaned up how invis is handled, which was unnecessary complicated
- moved handling visiblity for repello muggleton in to the stationary spell with listeners
- added chat blocking for repello muggleton
- added preventing muggles entering the area
- clean up on the O2Player muggle code which I am pretty sure was not working
- added a better constructor for stationary spells
- added a cleanup method for stationary spells
- fixed bug in how the block allow list was being checked for spells
- added handling for null in flair since sometimes it happens

https://github.com/Azami7/Ollivanders2/issues/132