### PR TITLE
Horcrux rewrite

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/ItemEnchant.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/ItemEnchant.java
@@ -115,15 +115,11 @@ public abstract class ItemEnchant extends O2Spell {
                 continue;
 
             // if this enchantment has an allowed list, check it
-            if (itemTypeAllowlist.size() > 0) {
+            if (!itemTypeAllowlist.isEmpty()) {
                 O2ItemType itemType = O2Item.getItemType(item.getItemStack());
                 if (itemType == null || !(itemTypeAllowlist.contains(itemType)))
                     continue;
             }
-
-            // if this item is already enchanted, skip it
-            if (Ollivanders2API.getItems().enchantedItems.isEnchanted(item))
-                continue;
 
             Item enchantedItem = enchantItem(item);
             Ollivanders2API.getItems().enchantedItems.addEnchantedItem(enchantedItem, enchantmentType, magnitude, args);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpell.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpell.java
@@ -24,8 +24,12 @@ import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityCombustEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityInteractEvent;
+import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.entity.EntityTeleportEvent;
+import org.bukkit.event.entity.ItemDespawnEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.InventoryPickupItemEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -602,15 +606,42 @@ public abstract class O2StationarySpell implements Serializable {
     }
 
     /**
-     * Handle player join events
-     *
-     * @param event the player join event
-     */
-    void doOnPlayerJoinEvent(@NotNull PlayerJoinEvent event) {
-    }
-
-    /**
      * Clean up needed for this spell when it ends.
      */
     abstract void doCleanUp();
+
+    /**
+     * Handle spell world load events
+     *
+     * @param event the world load event
+     */
+    void doOnPlayerJoinEvent(@NotNull PlayerJoinEvent event) { }
+
+    /**
+     * Handle item despawn events
+     *
+     * @param event the item despawn event
+     */
+    void doOnItemDespawnEvent(@NotNull ItemDespawnEvent event) {}
+
+    /**
+     * Handle items being picked up by entities
+     *
+     * @param event the event
+     */
+    void doOnEntityPickupItemEvent(@NotNull EntityPickupItemEvent event) {}
+
+    /**
+     * Handle items being picked up by things like hoppers
+     *
+     * @param event the event
+     */
+    void doOnInventoryItemPickupEvent(@NotNull InventoryPickupItemEvent event ) {}
+
+    /**
+     * Handle player death event
+     *
+     * @param event the event
+     */
+    void doOnPlayerDeathEvent(@NotNull PlayerDeathEvent event) {}
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpells.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpells.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.UUID;
 
 import net.pottercraft.ollivanders2.GsonDAO;
@@ -25,8 +24,12 @@ import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityCombustEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityInteractEvent;
+import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.entity.EntityTeleportEvent;
+import org.bukkit.event.entity.ItemDespawnEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.InventoryPickupItemEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -307,7 +310,7 @@ public class O2StationarySpells implements Listener {
     }
 
     /**
-     * Handle player join events
+     * Handle world load events
      *
      * @param event the event
      */
@@ -316,6 +319,53 @@ public class O2StationarySpells implements Listener {
         for (O2StationarySpell stationary : O2StationarySpells) {
             if (stationary.isActive())
                 stationary.doOnPlayerJoinEvent(event);
+        }
+    }
+
+    /**
+     * Handle item despawn events
+     *
+     * @param event the item despawn event
+     */
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onItemDespawnEvent(@NotNull ItemDespawnEvent event) {
+        for (O2StationarySpell stationary : O2StationarySpells) {
+            if (stationary.isActive())
+                stationary.doOnItemDespawnEvent(event);
+        }
+    }
+
+    /**
+     * Handle items being picked up by entities
+     *
+     * @param event the event
+     */
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onEntityPickupItemEvent(@NotNull EntityPickupItemEvent event) {
+        for (O2StationarySpell stationary : O2StationarySpells) {
+            if (stationary.isActive())
+                stationary.doOnEntityPickupItemEvent(event);
+        }
+    }
+
+    /**
+     * Handle items being picked up by things like hoppers
+     *
+     * @param event the event
+     */
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onInventoryItemPickupEvent(@NotNull InventoryPickupItemEvent event) {
+        for (O2StationarySpell stationary : O2StationarySpells) {
+            if (stationary.isActive())
+                stationary.doOnInventoryItemPickupEvent(event);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onPlayerDeathEvent(@NotNull PlayerDeathEvent event) {
+        for (O2StationarySpell stationary : O2StationarySpells) {
+            if (stationary.isActive())
+                stationary.doOnPlayerDeathEvent(event);
         }
     }
 


### PR DESCRIPTION
- changed horcrux preserve the item in the location (no despawn)
- restore item on restart
- do not allow item pick up because if a player picks it up and moves it the spell location wont be right anymore
- on player death, preserve inventory, experience, level
- only allow 1 horcrux at a time
- fixed a duplicate isEnchanted check in ItemEnchant

https://github.com/Azami7/Ollivanders2/issues/183