### PR TITLE
horcrux start up fix

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HORCRUX.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HORCRUX.java
@@ -277,6 +277,9 @@ public class HORCRUX extends O2StationarySpell {
      */
     @Override
     void doOnItemDespawnEvent(@NotNull ItemDespawnEvent event) {
+        if (horcruxItem == null) //this can happen on restart when things are not fully loaded yet
+            return;
+
         Item eventItem = event.getEntity();
 
         if (eventItem.getUniqueId() == horcruxItem.getUniqueId())


### PR DESCRIPTION
fix to handle item despawn events happening at server start before the stationary spells have been completely set up