### PR TITLE
Cave Inimicum and Repello Muggleton

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
@@ -54,6 +54,8 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Ollivanders2 plugin
+ *
+ * @author Azami7
  */
 public class Ollivanders2 extends JavaPlugin {
     /**
@@ -70,7 +72,7 @@ public class Ollivanders2 extends JavaPlugin {
     /**
      * All pending teleport events
      */
-    private Ollivanders2TeleportEvents teleportEvents;
+    private Ollivanders2TeleportActions teleportActions;
 
     /**
      * Spells
@@ -343,7 +345,7 @@ public class Ollivanders2 extends JavaPlugin {
         books.onEnable();
 
         // teleport events
-        teleportEvents = new Ollivanders2TeleportEvents(this);
+        teleportActions = new Ollivanders2TeleportActions(this);
 
         getLogger().info(this + " is now enabled!");
     }
@@ -876,7 +878,7 @@ public class Ollivanders2 extends JavaPlugin {
         if (debug)
             getLogger().info("Running house sort");
 
-        if (targetPlayer.length() < 1 || targetHouse.length() < 1) {
+        if (targetPlayer.isEmpty() || targetHouse.isEmpty()) {
             usageMessageHouseSort(sender);
             return (true);
         }
@@ -1236,43 +1238,43 @@ public class Ollivanders2 extends JavaPlugin {
     }
 
     /**
-     * Get all pending teleport events.
+     * Get all pending teleport actions.
      *
-     * @return an array of teleport events
+     * @return a list of teleport actions
      */
     @NotNull
-    public List<Ollivanders2TeleportEvents.O2TeleportEvent> getTeleportEvents() {
-        return teleportEvents.getTeleportEvents();
+    public List<Ollivanders2TeleportActions.O2TeleportAction> getTeleportActions() {
+        return teleportActions.getTeleportActions();
     }
 
     /**
-     * Add a teleport event to the queue
+     * Add a teleport action to the queue
      *
      * @param p  the player to teleport
      * @param to teleport destination
      */
-    public void addTeleportEvent(@NotNull Player p, @NotNull Location to) {
-        addTeleportEvent(p, to, false);
+    public void addTeleportAction(@NotNull Player p, @NotNull Location to) {
+        addTeleportAction(p, to, false);
     }
 
     /**
-     * Add a teleport event with an explosion effect
+     * Add a teleport action with an explosion effect
      *
      * @param p                   the player to teleport
      * @param to                  teleport destination
      * @param explosionOnTeleport whether to do an explosion effect
      */
-    public void addTeleportEvent(@NotNull Player p, @NotNull Location to, boolean explosionOnTeleport) {
-        teleportEvents.addTeleportEvent(p, p.getLocation(), to, explosionOnTeleport);
+    public void addTeleportAction(@NotNull Player p, @NotNull Location to, boolean explosionOnTeleport) {
+        teleportActions.addTeleportEvent(p, p.getLocation(), to, explosionOnTeleport);
     }
 
     /**
-     * Remove a teleport event.
+     * Remove a teleport action.
      *
-     * @param event the event to remove
+     * @param action the action to remove
      */
-    public void removeTeleportEvent(@NotNull Ollivanders2TeleportEvents.O2TeleportEvent event) {
-        teleportEvents.removeTeleportEvent(event);
+    public void removeTeleportAction(@NotNull Ollivanders2TeleportActions.O2TeleportAction action) {
+        teleportActions.removeTeleportEvent(action);
     }
 
     /**
@@ -1692,7 +1694,7 @@ public class Ollivanders2 extends JavaPlugin {
         StringBuilder output = new StringBuilder();
         List<String> allProphecies = prophecies.getProphecies();
 
-        if (allProphecies.size() > 0) {
+        if (!allProphecies.isEmpty()) {
             output.append("Prophecies:\n");
 
             for (String prophecy : allProphecies) {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2TeleportActions.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2TeleportActions.java
@@ -15,19 +15,19 @@ import java.util.List;
  * @author Azami7
  * @since 2.4
  */
-public class Ollivanders2TeleportEvents {
+public class Ollivanders2TeleportActions {
     final private Ollivanders2 p;
     final private Ollivanders2Common common;
 
     /**
-     * The list of all queued teleport events
+     * The list of all queued teleport actions
      */
-    final private List<O2TeleportEvent> teleportEvents = new ArrayList<>();
+    final private List<O2TeleportAction> teleportActions = new ArrayList<>();
 
     /**
-     * A teleport event
+     * A teleport action
      */
-    static public class O2TeleportEvent {
+    static public class O2TeleportAction {
         /**
          * The player to teleport
          */
@@ -55,7 +55,7 @@ public class Ollivanders2TeleportEvents {
          * @param from the location they are teleporting from
          * @param to   the location they are teleporting to
          */
-        O2TeleportEvent(@NotNull Player p, @NotNull Location from, @NotNull Location to) {
+        O2TeleportAction(@NotNull Player p, @NotNull Location from, @NotNull Location to) {
             player = p;
             fromLocation = from;
             toLocation = to;
@@ -68,7 +68,7 @@ public class Ollivanders2TeleportEvents {
          * @param to        the location they are teleporting to
          * @param explosion should this teleport create an explosion effect when it happens
          */
-        O2TeleportEvent(@NotNull Player p, @NotNull Location from, @NotNull Location to, boolean explosion) {
+        O2TeleportAction(@NotNull Player p, @NotNull Location from, @NotNull Location to, boolean explosion) {
             player = p;
             fromLocation = from;
             toLocation = to;
@@ -121,7 +121,7 @@ public class Ollivanders2TeleportEvents {
      *
      * @param plugin a callback to the MC plugin
      */
-    public Ollivanders2TeleportEvents(@NotNull Ollivanders2 plugin) {
+    public Ollivanders2TeleportActions(@NotNull Ollivanders2 plugin) {
         p = plugin;
         common = new Ollivanders2Common(p);
     }
@@ -132,12 +132,12 @@ public class Ollivanders2TeleportEvents {
      * @return a list of the pending teleport events
      */
     @NotNull
-    public List<O2TeleportEvent> getTeleportEvents() {
-        return new ArrayList<>(teleportEvents);
+    public List<O2TeleportAction> getTeleportActions() {
+        return new ArrayList<>(teleportActions);
     }
 
     /**
-     * Add a teleport event to the list.
+     * Add a teleport action to the list.
      *
      * @param player the player teleporting
      * @param from   the location they are teleporting from
@@ -148,7 +148,7 @@ public class Ollivanders2TeleportEvents {
     }
 
     /**
-     * Add a teleport event to the list.
+     * Add a teleport action to the list.
      *
      * @param player              the player teleporting
      * @param from                the location they are teleporting from
@@ -156,26 +156,26 @@ public class Ollivanders2TeleportEvents {
      * @param explosionOnTeleport should there be an explosion effect on teleport
      */
     public void addTeleportEvent(@NotNull Player player, @NotNull Location from, @NotNull Location to, boolean explosionOnTeleport) {
-        O2TeleportEvent teleportEvent = new O2TeleportEvent(player, from, to, explosionOnTeleport);
+        O2TeleportAction teleportEvent = new O2TeleportAction(player, from, to, explosionOnTeleport);
 
-        common.printDebugMessage("Created teleport event: " + player.getName() + " from " + from + " to " + to, null, null, false);
-        teleportEvents.add(teleportEvent);
+        common.printDebugMessage("Created teleport action: " + player.getName() + " from " + from + " to " + to, null, null, false);
+        teleportActions.add(teleportEvent);
 
         to.getChunk().load();
     }
 
     /**
-     * Remove a teleport event from the list.
+     * Remove a teleport action from the list.
      *
-     * @param event the teleport event to remove
+     * @param teleportAction the teleport action to remove
      */
-    public void removeTeleportEvent(@NotNull O2TeleportEvent event) {
-        if (teleportEvents.contains(event)) {
-            common.printDebugMessage("Removing teleport event for " + event.getPlayer().getName(), null, null, false);
-            teleportEvents.remove(event);
+    public void removeTeleportEvent(@NotNull Ollivanders2TeleportActions.O2TeleportAction teleportAction) {
+        if (teleportActions.contains(teleportAction)) {
+            common.printDebugMessage("Removing teleport action for " + teleportAction.getPlayer().getName(), null, null, false);
+            teleportActions.remove(teleportAction);
         }
         else {
-            common.printDebugMessage("Unable to remove teleport event, not found.", null, null, false);
+            common.printDebugMessage("Unable to remove teleport action, not found.", null, null, false);
         }
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/CONFRONTING_THE_FACELESS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/CONFRONTING_THE_FACELESS.java
@@ -16,10 +16,11 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.LIBERACORPUS}<br>
  * {@link net.pottercraft.ollivanders2.spell.OPPUGNO}<br>
  * {@link net.pottercraft.ollivanders2.spell.VERDIMILLIOUS_TRIA}
+ * {@link net.pottercraft.ollivanders2.spell.CAVE_INIMICUM}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Confronting_the_Faceless">https://harrypotter.fandom.com/wiki/Confronting_the_Faceless</a>
  * @author Azami7
+ * @see <a href = "https://harrypotter.fandom.com/wiki/Confronting_the_Faceless">https://harrypotter.fandom.com/wiki/Confronting_the_Faceless</a>
  * @since 2.2.4
  */
 public class CONFRONTING_THE_FACELESS extends O2Book {
@@ -44,5 +45,6 @@ public class CONFRONTING_THE_FACELESS extends O2Book {
         // todo mov fotia rework - purple sparks + pacify
         // todo hex breaker
         spells.add(O2SpellType.VERDIMILLIOUS_TRIA);
+        spells.add(O2SpellType.CAVE_INIMICUM);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/common/EntityCommon.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/common/EntityCommon.java
@@ -231,6 +231,7 @@ public class EntityCommon {
     @NotNull
     static public List<LivingEntity> getLivingEntitiesInRadius(@NotNull Location location, double radius) {
         Collection<Entity> entities = getEntitiesInRadius(location, radius);
+
         List<LivingEntity> close = new ArrayList<>();
 
         for (Entity e : entities) {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/common/EntityCommon.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/common/EntityCommon.java
@@ -6,7 +6,9 @@ import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.entity.Bee;
 import org.bukkit.entity.Cat;
+import org.bukkit.entity.Enemy;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Horse;
@@ -14,7 +16,9 @@ import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Llama;
 import org.bukkit.entity.Parrot;
+import org.bukkit.entity.PigZombie;
 import org.bukkit.entity.Rabbit;
+import org.bukkit.entity.Wolf;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
@@ -261,9 +265,9 @@ public class EntityCommon {
      * Gets item entities within bounding box of the projectile
      *
      * @param location the location to check
-     * @param x the x-limit to check
-     * @param y the y-limit to check
-     * @param z the z-limit to check
+     * @param x        the x-limit to check
+     * @param y        the y-limit to check
+     * @param z        the z-limit to check
      * @return List of item entities within bounding box of projectile
      */
     @NotNull
@@ -283,7 +287,7 @@ public class EntityCommon {
      * Gets item entities within radius of the projectile
      *
      * @param location the location to check
-     * @param radius the radius to check around the location
+     * @param radius   the radius to check around the location
      * @return List of item entities within radius of projectile
      */
     @NotNull
@@ -295,7 +299,7 @@ public class EntityCommon {
      * Gets item entities within radius of the projectile
      *
      * @param location the location to check
-     * @param radius radius within which to get entities
+     * @param radius   radius within which to get entities
      * @return List of item entities within one block of projectile
      */
     @NotNull
@@ -326,7 +330,7 @@ public class EntityCommon {
     /**
      * Get an item by material
      *
-     * @param location the location to check
+     * @param location  the location to check
      * @param materials the list of materials to look for
      * @param radius    the radius to look in
      * @return an item if found, null otherwise
@@ -680,5 +684,31 @@ public class EntityCommon {
             return potionEffectLevels.get(potionEffectType);
         else
             return MagicLevel.OWL;
+    }
+
+    /**
+     * Is this living entity a hostile? This assumes Player entities are not hostile.
+     *
+     * @return true if it is a hostile or angry mob, false otherwise
+     * @see <a href = "https://minecraft.fandom.com/wiki/Mob#Hostile_mobs">https://minecraft.fandom.com/wiki/Mob#Hostile_mobs</a>
+     */
+    static public boolean isHostile(@NotNull LivingEntity livingEntity) {
+        // are they an inherently hostile mob?
+        if (livingEntity instanceof Enemy)
+            return true;
+
+        // are they an angry bee?
+        if (livingEntity instanceof Bee && ((Bee) livingEntity).getAnger() > 0)
+            return true;
+
+        // are they an angry wolf?
+        if (livingEntity instanceof Wolf && ((Wolf) livingEntity).isAngry())
+            return true;
+
+        // are they an angry zombie piglin?
+        if (livingEntity instanceof PigZombie && ((PigZombie) livingEntity).isAngry())
+            return true;
+
+        return false;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2DivinationType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2DivinationType.java
@@ -64,7 +64,8 @@ public enum O2DivinationType {
 
     /**
      * get the classname for this divination type
-     * @return
+     *
+     * @return the class for this divination
      */
     @NotNull
     public Class<?> getClassName() {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/item/enchantment/PORTUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/item/enchantment/PORTUS.java
@@ -142,10 +142,10 @@ public class PORTUS extends Enchantment {
         Location portkeyReturn = event.getItem().getLocation();
 
         // teleport the player and any other player in the radius
-        p.addTeleportEvent((Player)entity, destination, true);
+        p.addTeleportAction((Player)entity, destination, true);
         for (LivingEntity livingEntity : EntityCommon.getLivingEntitiesInRadius(location, radius)) {
             if (livingEntity instanceof Player) {
-                p.addTeleportEvent((Player)livingEntity, destination, true);
+                p.addTeleportAction((Player)livingEntity, destination, true);
             }
             else {
                 livingEntity.teleport(destination);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/player/O2PlayerCommon.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/player/O2PlayerCommon.java
@@ -271,16 +271,46 @@ public final class O2PlayerCommon {
     /**
      * Does a player have a particular potion effect?
      *
-     * @param player the player to check
+     * @param player     the player to check
      * @param effectType the potion effect type to check for
-     * @return
+     * @return true if the player has this potion effect, false otherwise
      */
     static public boolean hasPotionEffect(@NotNull Player player, @NotNull PotionEffectType effectType) {
-        for (PotionEffect effect: player.getActivePotionEffects()) {
+        for (PotionEffect effect : player.getActivePotionEffects()) {
             if (effect.getType() == effectType) {
                 return true;
             }
         }
+
+        return false;
+    }
+
+    /**
+     * Does the player have the Cloak of Invisibility
+     *
+     * @param player player to be checked
+     * @return true if yes, false if no
+     */
+    public static boolean wearingInvisibilityCloak(@NotNull Player player) {
+        ItemStack chestPlate = player.getInventory().getChestplate();
+        if (chestPlate != null) {
+            return O2ItemType.INVISIBILITY_CLOAK.isItemThisType(chestPlate);
+        }
+        return false;
+    }
+
+    /**
+     * Is this player invisible?
+     *
+     * @param player the player to check
+     * @return true if they are either wearing an invisibility cloak or have an invisibility potion effect, false otherwise
+     */
+    public static boolean isInvisible(@NotNull Player player) {
+        if (wearingInvisibilityCloak(player))
+            return true;
+
+        if (O2PlayerCommon.hasPotionEffect(player, PotionEffectType.INVISIBILITY))
+            return true;
 
         return false;
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Players.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Players.java
@@ -108,6 +108,7 @@ public class O2Players {
      * @param name the effectType of this player
      */
     public void addPlayer(@NotNull UUID pid, @NotNull String name) {
+        // todo make this return o2p so that Ollivanders2.getO2Player can guarantee NotNull
         O2Player o2p = new O2Player(pid, name, p);
 
         updatePlayer(pid, o2p);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2PotionType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2PotionType.java
@@ -7,6 +7,8 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * All potions types
+ *
+ * @author Azami7
  */
 public enum O2PotionType {
     /**
@@ -105,6 +107,11 @@ public enum O2PotionType {
         return className;
     }
 
+    /**
+     * Get the magic level of this potion
+     *
+     * @return the magic level
+     */
     @NotNull
     public MagicLevel getLevel() {
         return level;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/APPARATE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/APPARATE.java
@@ -170,7 +170,7 @@ public final class APPARATE extends O2Spell {
     private void doApparate() {
         if (!apparateEvent.isCancelled()) {
             p.getServer().getLogger().info("adding teleport event");
-            p.addTeleportEvent(player, destination, true);
+            p.addTeleportAction(player, destination, true);
         }
     }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/BAO_ZHONG_CHA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/BAO_ZHONG_CHA.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 /**
  * Tasseomancy is the art of reading tea leaves to predict events in the future.
  *
- * @see <a = href="http://harrypotter.wikia.com/wiki/Tessomancy">http://harrypotter.wikia.com/wiki/Tessomancy</a>
+ * @see <a href="http://harrypotter.wikia.com/wiki/Tessomancy">http://harrypotter.wikia.com/wiki/Tessomancy</a>
  * @author Azami7
  * @since 2.2.9
  */

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/CAVE_INIMICUM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/CAVE_INIMICUM.java
@@ -1,43 +1,42 @@
 package net.pottercraft.ollivanders2.spell;
 
 import net.pottercraft.ollivanders2.O2MagicBranch;
+import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpell;
 import org.bukkit.entity.Player;
-
-import net.pottercraft.ollivanders2.Ollivanders2;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 
 /**
- * The Muggle-Repelling -Repello Muggletum - is a charm that prevents Muggles from seeing or entering an area. Any
- * non-magic person gets close to the vicinity of the enchantment remembers something urgent to do and leave.
+ * Cave Inimicum produces a boundary that keeps the caster hidden from view. Those who were on the other side of the
+ * shield are not able to see, hear, or (if the spell was well cast) smell them.
  * <p>
- * {@link net.pottercraft.ollivanders2.stationaryspell.ShieldSpell}
+ * {@link net.pottercraft.ollivanders2.stationaryspell.CAVE_INIMICUM}
  *
  * @author Azami7
- * @version Ollivanders2
- * @see <a href = "https://harrypotter.fandom.com/wiki/Muggle-Repelling_Charm">https://harrypotter.fandom.com/wiki/Muggle-Repelling_Charm</a>
+ * @see <a href = "https://harrypotter.fandom.com/wiki/Cave_inimicum">https://harrypotter.fandom.com/wiki/Cave_inimicum</a>
  * @since 2.21
  */
-public final class REPELLO_MUGGLETON extends StationarySpell {
+public class CAVE_INIMICUM extends StationarySpell {
     /**
      * Default constructor for use in generating spell text. Do not use to cast the spell.
      *
      * @param plugin the Ollivanders2 plugin
      */
-    public REPELLO_MUGGLETON(Ollivanders2 plugin) {
+    public CAVE_INIMICUM(Ollivanders2 plugin) {
         super(plugin);
 
-        spellType = O2SpellType.REPELLO_MUGGLETON;
+        spellType = O2SpellType.CAVE_INIMICUM;
         branch = O2MagicBranch.CHARMS;
 
         flavorText = new ArrayList<>() {{
-            add("Muggle-Repelling Charms on every inch of it. Every time Muggles have got anywhere near here all year, they've suddenly remembered urgent appointments and had to dash away again.");
+            add("\"That's as much as I can do. At the very least, we should know they're coming, I can't guarantee it will keep out Vol—\" -Hermione Granger");
+            add("The Concealment Shield");
         }};
 
-        text = "Repello Muggleton will conceal players inside of it from Muggles and prevent them entering the area.";
+        text = "Cave Inimicum will hide players inside of it from players and hostile mobs outside the shield. It will also sound a proximity alarm if they get close to the shield area";
     }
 
     /**
@@ -47,10 +46,10 @@ public final class REPELLO_MUGGLETON extends StationarySpell {
      * @param player    the player who cast this spell
      * @param rightWand which wand the player was using
      */
-    public REPELLO_MUGGLETON(@NotNull Ollivanders2 plugin, @NotNull Player player, @NotNull Double rightWand) {
+    public CAVE_INIMICUM(@NotNull Ollivanders2 plugin, @NotNull Player player, @NotNull Double rightWand) {
         super(plugin, player, rightWand);
 
-        spellType = O2SpellType.REPELLO_MUGGLETON;
+        spellType = O2SpellType.CAVE_INIMICUM;
         branch = O2MagicBranch.CHARMS;
 
         durationModifierInSeconds = 15;
@@ -67,6 +66,8 @@ public final class REPELLO_MUGGLETON extends StationarySpell {
 
     @Override
     protected O2StationarySpell createStationarySpell() {
-        return new net.pottercraft.ollivanders2.stationaryspell.REPELLO_MUGGLETON(p, player.getUniqueId(), location, radius, duration);
+        return new net.pottercraft.ollivanders2.stationaryspell.CAVE_INIMICUM(p, player.getUniqueId(), location, radius, duration);
     }
 }
+
+

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/CELATUM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/CELATUM.java
@@ -19,9 +19,14 @@ import java.util.ArrayList;
  * <p>
  * {@link net.pottercraft.ollivanders2.item.enchantment.CELATUM}
  *
+ * @author Azami7
  * @see <a href = "https://harrypotter.fandom.com/wiki/Concealing_charms">https://harrypotter.fandom.com/wiki/Concealing_charms</a>
+ * @since 2.21
  */
 public final class CELATUM extends ItemEnchant {
+    /**
+     * The page delimiter used when the books pages get compressed to one string
+     */
     public static String pageDelimiter = "##PAGE##";
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/ItemEnchant.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/ItemEnchant.java
@@ -128,7 +128,7 @@ public abstract class ItemEnchant extends O2Spell {
     /**
      * Enchants the item held in the player's off-hand
      */
-    protected void enchantHeldItem () {
+    protected void enchantHeldItem() {
         ItemStack targetItem = player.getInventory().getItemInOffHand();
 
         // make sure they are actually holding something and that it can be enchanted
@@ -251,20 +251,27 @@ public abstract class ItemEnchant extends O2Spell {
      *
      * @param itemStack the item being enchanted
      */
-    protected void initEnchantmentArgs(ItemStack itemStack) { }
+    protected void initEnchantmentArgs(ItemStack itemStack) {
+    }
 
     /**
      * Do any after effects on the item. This needs to be overridden by the classes that need it.
      *
      * @param item the item to affect
+     * @return the altered item
      */
     @Nullable
-    protected Item alterItem(Item item) { return item; }
+    protected Item alterItem(Item item) {
+        return item;
+    }
 
     /**
      * Do any after effects on the item. This needs to be overridden by the classes that need it.
      *
      * @param itemStack the item to affect
+     * @return the altered item
      */
-    protected ItemStack alterItem(ItemStack itemStack) { return itemStack; }
+    protected ItemStack alterItem(ItemStack itemStack) {
+        return itemStack;
+    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2SpellType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2SpellType.java
@@ -7,6 +7,8 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * All supported spells.
+ *
+ * @author Azami7
  */
 public enum O2SpellType {
     /**
@@ -125,6 +127,10 @@ public enum O2SpellType {
      * {@link CARTOMANCIE}
      */
     CARTOMANCIE(CARTOMANCIE.class, MagicLevel.OWL),
+    /**
+     * {@link CAVE_INIMICUM}
+     */
+    CAVE_INIMICUM(CAVE_INIMICUM.class, MagicLevel.NEWT),
     /**
      * {@link CELATUM}
      */
@@ -720,7 +726,7 @@ public enum O2SpellType {
     /**
      * Get the class name associated with this spell type
      *
-     * @return the classname for this spell type
+     * @return the class name for this spell type
      */
     @NotNull
     public Class<?> getClassName() {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/ALIQUAM_FLOO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/ALIQUAM_FLOO.java
@@ -30,9 +30,11 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Makes a "fireplace" a floo network location
- *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Floo_Network">https://harrypotter.fandom.com/wiki/Floo_Network</a>
+ * <p>
  * {@link net.pottercraft.ollivanders2.spell.ALIQUAM_FLOO}
+ *
+ * @author Azami7
+ * @see <a href = "https://harrypotter.fandom.com/wiki/Floo_Network">https://harrypotter.fandom.com/wiki/Floo_Network</a>
  */
 public class ALIQUAM_FLOO extends O2StationarySpell {
     /**
@@ -139,7 +141,7 @@ public class ALIQUAM_FLOO extends O2StationarySpell {
      * Check for players activating the floo
      */
     @Override
-    public void checkEffect() {
+    public void upkeep() {
         // if this fireplace is already active,
         if (isWorking()) {
             cooldown = cooldown - 1;
@@ -330,7 +332,7 @@ public class ALIQUAM_FLOO extends O2StationarySpell {
                     return;
 
                 if (!flooNetworkEvent.isCancelled()) {
-                    p.addTeleportEvent(player, flooNetworkEvent.getDestination());
+                    p.addTeleportAction(player, flooNetworkEvent.getDestination());
                     player.sendMessage(Ollivanders2.chatColor + "Fire swirls around you.");
                 }
                 else

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/CAVE_INIMICUM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/CAVE_INIMICUM.java
@@ -1,34 +1,36 @@
 package net.pottercraft.ollivanders2.stationaryspell;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.common.EntityCommon;
 import org.bukkit.Location;
+import org.bukkit.Sound;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
 /**
- * The Muggle-Repelling -Repello Muggletum - is a charm that prevents Muggles from seeing or entering an area. Any
- * non-magic person gets close to the vicinity of the enchantment remembers something urgent to do and leave.
+ * Cave Inimicum produces a boundary that keeps the caster hidden from view. Those who were on the other side of the
+ * shield are not able to see, hear, or (if the spell was well cast) smell them.
  * <p>
- * {@link net.pottercraft.ollivanders2.spell.REPELLO_MUGGLETON}
+ * {@link net.pottercraft.ollivanders2.spell.CAVE_INIMICUM}
  *
  * @author Azami7
- * @version Ollivanders2
- * @See <a href = "https://harrypotter.fandom.com/wiki/Muggle-Repelling_Charm">https://harrypotter.fandom.com/wiki/Muggle-Repelling_Charm</a>
+ * @see <a href = "https://harrypotter.fandom.com/wiki/Cave_inimicum">https://harrypotter.fandom.com/wiki/Cave_inimicum</a>
  * @since 2.21
  */
-public class REPELLO_MUGGLETON extends ConcealmentShieldSpell {
+public class CAVE_INIMICUM extends ConcealmentShieldSpell {
     /**
      * Simple constructor used for deserializing saved stationary spells at server start. Do not use to cast spell.
      *
      * @param plugin a callback to the MC plugin
      */
-    public REPELLO_MUGGLETON(@NotNull Ollivanders2 plugin) {
+    public CAVE_INIMICUM(@NotNull Ollivanders2 plugin) {
         super(plugin);
 
-        spellType = O2StationarySpellType.REPELLO_MUGGLETON;
+        spellType = O2StationarySpellType.CAVE_INIMICUM;
     }
 
     /**
@@ -40,50 +42,32 @@ public class REPELLO_MUGGLETON extends ConcealmentShieldSpell {
      * @param radius   the radius for this spell
      * @param duration the duration of the spell
      */
-    public REPELLO_MUGGLETON(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
+    public CAVE_INIMICUM(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
         super(plugin, pid, location);
 
         setRadius(radius);
         setDuration(duration);
+        alarmOnProximity = true;
+        proximityRadiusModifier = 5; // alarm if a player or hostile entity gets within 5 blocks of the spell area
 
-        spellType = O2StationarySpellType.REPELLO_MUGGLETON;
-
-        messages.add("You just remembered you need to do something someplace else.");
-        messages.add("You just recalled an important appointment you need to get to somewhere else.");
-        messages.add("Why were you going that way? You want to go a different way.");
-        messages.add("You realize you don't actually want to go that way.");
-        messages.add("You hear someone behind you calling your name.");
-    }
-
-    /**
-     * Is this entity a player and are they a Muggle?
-     *
-     * @param entity the entity to check
-     * @return true if they are a muggle, false otherwise
-     */
-    private boolean isMuggle(Entity entity) {
-        if (entity instanceof Player) {
-            return p.getO2Player((Player) entity).isMuggle();
-        }
-
-        return false;
+        spellType = O2StationarySpellType.CAVE_INIMICUM;
     }
 
     /**
      * Can this entity see players inside the spell area? Assumes the entity being checked is outside the spell area.
      *
      * @param entity the entity looking inside the area
-     * @return true if the entity is not a Muggle, false otherwise
+     * @return false, this spell conceals players in the area from everyone
      */
     protected boolean canSee(@NotNull Entity entity) {
-        return !isMuggle(entity);
+        return false;
     }
 
     /**
      * Can this entity target players inside the spell area? Assumes the entity being checked is outside the spell area.
      *
      * @param entity the entity targeting inside the area
-     * @return true, this spell does not prevent targeting
+     * @return true, this spell does not affect targeting
      */
     @Override
     protected boolean canTarget(@NotNull Entity entity) {
@@ -94,34 +78,48 @@ public class REPELLO_MUGGLETON extends ConcealmentShieldSpell {
      * Can this entity enter the spell area? Assumes the entity being checked is outside the spell area.
      *
      * @param entity the entity entering the area
-     * @return true if the entity is not a Muggle, false otherwise
+     * @return true, this spell does not block entry in to the spell area
      */
     protected boolean canEnter(@NotNull Entity entity) {
-        return !isMuggle(entity);
+        return true;
     }
 
     /**
      * Can this entity "hear" sounds from inside the spell area? Assumes the entity being checked is outside the spell area.
      *
      * @param entity the entity entering the area
-     * @return true if the entity is not a Muggle, false otherwise
+     * @return false, this spell conceals players in the area from everyone
      */
     protected boolean canHear(@NotNull Entity entity) {
-        return !isMuggle(entity);
+        return false;
     }
 
     /**
-     * Check the proximity alarm conditions at the location.
-     * Repello Muggleton does not have a proximity alarm.
+     * Activate the proximity alarm if there is a player or hostile mob at the location. Assumes that a check to determine
+     * that a proximity alarm should go off for this location has happened and called this.
      */
     protected boolean checkAlarm(@NotNull Location alertLocation) {
+        // get all the entities at the location
+        for (LivingEntity livingEntity : EntityCommon.getLivingEntitiesInRadius(location, 1)) {
+            if (livingEntity instanceof Player || EntityCommon.isHostile(livingEntity)) {
+                return true;
+            }
+        }
+
         return false;
     }
 
     /**
      * Do the proximity alarm action for this spell.
-     * Repello Muggleton does not have a proximity alarm.
      */
     protected void proximityAlarm() {
+        if (proximityCooldownTimer > 0)
+            return;
+
+        for (Player player : getPlayersInsideSpellRadius()) {
+            player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BELL_RESONATE, 1, 1);
+        }
+
+        proximityCooldownTimer = proximityCooldownLimit;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/CAVE_INIMICUM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/CAVE_INIMICUM.java
@@ -2,9 +2,8 @@ package net.pottercraft.ollivanders2.stationaryspell;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.common.EntityCommon;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Location;
-import org.bukkit.Sound;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -23,6 +22,23 @@ import java.util.UUID;
  */
 public class CAVE_INIMICUM extends ConcealmentShieldSpell {
     /**
+     * the min radius for this spell
+     */
+    public static final int minRadiusConfig = 5;
+    /**
+     * the max radius for this spell
+     */
+    public static final int maxRadiusConfig = 20;
+    /**
+     * the min duration for this spell
+     */
+    public static final int minDurationConfig = Ollivanders2Common.ticksPerSecond * 30;
+    /**
+     * the max duration for this spell
+     */
+    public static final int maxDurationConfig = Ollivanders2Common.ticksPerMinute * 30;
+
+    /**
      * Simple constructor used for deserializing saved stationary spells at server start. Do not use to cast spell.
      *
      * @param plugin a callback to the MC plugin
@@ -31,6 +47,11 @@ public class CAVE_INIMICUM extends ConcealmentShieldSpell {
         super(plugin);
 
         spellType = O2StationarySpellType.CAVE_INIMICUM;
+
+        minRadius = minRadiusConfig;
+        maxRadius = maxRadiusConfig;
+        minDuration = minDurationConfig;
+        maxDuration = maxDurationConfig;
     }
 
     /**
@@ -49,6 +70,11 @@ public class CAVE_INIMICUM extends ConcealmentShieldSpell {
         proximityRadiusModifier = 5; // alarm if a player or hostile entity gets within 5 blocks of the spell area
 
         spellType = O2StationarySpellType.CAVE_INIMICUM;
+
+        minRadius = minRadiusConfig;
+        maxRadius = maxRadiusConfig;
+        minDuration = minDurationConfig;
+        maxDuration = maxDurationConfig;
     }
 
     /**
@@ -57,8 +83,11 @@ public class CAVE_INIMICUM extends ConcealmentShieldSpell {
      * @param entity the entity looking inside the area
      * @return false, this spell conceals players in the area from everyone
      */
-    protected boolean canSee(@NotNull Entity entity) {
-        return false;
+    protected boolean canSee(@NotNull LivingEntity entity) {
+        if (isLocationInside(entity.getLocation()))
+            return true;
+        else
+            return false;
     }
 
     /**
@@ -68,7 +97,7 @@ public class CAVE_INIMICUM extends ConcealmentShieldSpell {
      * @return true, this spell does not affect targeting
      */
     @Override
-    protected boolean canTarget(@NotNull Entity entity) {
+    protected boolean canTarget(@NotNull LivingEntity entity) {
         return true;
     }
 
@@ -78,7 +107,7 @@ public class CAVE_INIMICUM extends ConcealmentShieldSpell {
      * @param entity the entity entering the area
      * @return true, this spell does not block entry in to the spell area
      */
-    protected boolean canEnter(@NotNull Entity entity) {
+    protected boolean canEnter(@NotNull LivingEntity entity) {
         return true;
     }
 
@@ -88,20 +117,29 @@ public class CAVE_INIMICUM extends ConcealmentShieldSpell {
      * @param entity the entity entering the area
      * @return false, this spell conceals players in the area from everyone
      */
-    protected boolean canHear(@NotNull Entity entity) {
+    protected boolean canHear(@NotNull LivingEntity entity) {
         return false;
+    }
+
+    /**
+     * Activate the proximity alarm if there is a player at the location. Assumes that a check to determine
+     * that a proximity alarm should go off for this location has happened and called this.
+     *
+     * @param player the player that triggered the alarm
+     */
+    protected boolean checkAlarm(@NotNull Player player) {
+        return true;
     }
 
     /**
      * Activate the proximity alarm if there is a player or hostile mob at the location. Assumes that a check to determine
      * that a proximity alarm should go off for this location has happened and called this.
+     *
+     * @param entity the entity that triggered the alarm
      */
-    protected boolean checkAlarm(@NotNull Location alertLocation) {
-        // get all the entities at the location
-        for (LivingEntity livingEntity : EntityCommon.getLivingEntitiesInRadius(location, 1)) {
-            if (livingEntity instanceof Player || EntityCommon.isHostile(livingEntity)) {
-                return true;
-            }
+    protected boolean checkAlarm(@NotNull LivingEntity entity) {
+        if (EntityCommon.isHostile(entity)) {
+            return true;
         }
 
         return false;
@@ -115,7 +153,7 @@ public class CAVE_INIMICUM extends ConcealmentShieldSpell {
             return;
 
         for (Player player : getPlayersInsideSpellRadius()) {
-            player.getWorld().playSound(player.getLocation(), Sound.BLOCK_BELL_RESONATE, 1, 1);
+            player.sendMessage(Ollivanders2.chatColor + "A hostile entity approaches.");
         }
 
         proximityCooldownTimer = proximityCooldownLimit;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/CAVE_INIMICUM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/CAVE_INIMICUM.java
@@ -43,10 +43,8 @@ public class CAVE_INIMICUM extends ConcealmentShieldSpell {
      * @param duration the duration of the spell
      */
     public CAVE_INIMICUM(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
-        super(plugin, pid, location);
+        super(plugin, pid, location, radius, duration);
 
-        setRadius(radius);
-        setDuration(duration);
         alarmOnProximity = true;
         proximityRadiusModifier = 5; // alarm if a player or hostile entity gets within 5 blocks of the spell area
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/COLLOPORTUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/COLLOPORTUS.java
@@ -19,6 +19,10 @@ import java.util.UUID;
  * Prevents opening of target door, trapdoor, or chest.
  * <p>
  * {@link net.pottercraft.ollivanders2.spell.COLLOPORTUS}
+ *
+ * @author Azami7
+ * @see <a href = "https://harrypotter.fandom.com/wiki/Locking_Spell">https://harrypotter.fandom.com/wiki/Locking_Spell</a>
+ * @since 2.21
  */
 public class COLLOPORTUS extends O2StationarySpell {
     /**
@@ -69,7 +73,7 @@ public class COLLOPORTUS extends O2StationarySpell {
      * No upkeep for this spell
      */
     @Override
-    public void checkEffect() {
+    public void upkeep() {
     }
 
     /**
@@ -160,5 +164,6 @@ public class COLLOPORTUS extends O2StationarySpell {
     }
 
     @Override
-    void doCleanUp() {}
+    void doCleanUp() {
+    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/ConcealmentShieldSpell.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/ConcealmentShieldSpell.java
@@ -1,0 +1,343 @@
+package net.pottercraft.ollivanders2.stationaryspell;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.common.EntityCommon;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
+import net.pottercraft.ollivanders2.player.O2PlayerCommon;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntityTargetEvent;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Parent class for all concealment shield spells.
+ *
+ * @since 2.21
+ * @author Azami7
+ */
+public abstract class ConcealmentShieldSpell extends ShieldSpell {
+    /**
+     * Does this spell alarm to the players inside it on an entity within proximity
+     */
+    protected boolean alarmOnProximity = false;
+
+    /**
+     * The distance away from the edge of this spell that a proximity alarm will trigger
+     */
+    protected int proximityRadiusModifier = 3;
+
+    /**
+     * The proximity alarm cooldown - so that this doesn't go off all the time
+     */
+    protected int proximityCooldownTimer;
+
+    /**
+     * The duration of the proximity alarm cooldown
+     */
+    protected final int proximityCooldownLimit = Ollivanders2Common.ticksPerMinute;
+
+    /**
+     * The messages that a player gets when they try to enter the area and they are not allowed
+     */
+    public ArrayList<String> messages = new ArrayList<>();
+
+    /**
+     * Simple constructor used for deserializing saved stationary spells at server start. Do not use to cast spell.
+     *
+     * @param plugin a callback to the MC plugin
+     */
+    public ConcealmentShieldSpell(@NotNull Ollivanders2 plugin) {
+        super(plugin);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param plugin   a callback to the MC plugin
+     * @param pid      the player who cast the spell
+     * @param location the center location of the spell
+     */
+    public ConcealmentShieldSpell(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location) {
+        super(plugin, pid, location);
+
+        hidePlayersInSpellArea();
+    }
+
+    /**
+     * Upkeep - age the spell
+     */
+    @Override
+    public void upkeep() {
+        // age the spell
+        age();
+
+        // decrement the proximity timer if it is running
+        if (proximityCooldownTimer > 0)
+            proximityCooldownTimer = proximityCooldownTimer - 1;
+
+        // kill the spell if the age limit is reached
+        if (duration <= 1)
+            kill();
+    }
+
+    /**
+     * Hide the players in the spell area
+     */
+    protected void hidePlayersInSpellArea() {
+        for (Player player : getPlayersInsideSpellRadius()) {
+            hidePlayer(player);
+        }
+    }
+
+    /**
+     * Hide a player in this spell area from those who cannot see in the spell area.
+     *
+     * @param player the player to hide
+     * @see <a href = "https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Player.html#hidePlayer(org.bukkit.plugin.Plugin,org.bukkit.entity.Player)">https://hub.spigotmc.org/javadocs/spigot/org/bukkit/entity/Player.html#hidePlayer(org.bukkit.plugin.Plugin,org.bukkit.entity.Player)</a>
+     */
+    protected void hidePlayer(@NotNull Player player) {
+        // do not do anything if they are not inside the spell area or are otherwise invisible already
+        if (!isLocationInside(player.getLocation()) || O2PlayerCommon.isInvisible(player))
+            return;
+
+        for (Player viewer : p.getServer().getOnlinePlayers()) {
+            // if the viewer cannot see players in this spell area, hide the player from them
+            if (!canSee(player)) {
+                viewer.hidePlayer(p, player);
+                common.printDebugMessage("StationarySpell.ConcealmentShieldSpell: hid " + player.getName() + " from " + viewer.getName(), null, null, false);
+            }
+        }
+    }
+
+    /**
+     * Unhide the players in the spell area
+     */
+    protected void unhidePlayersInSpellArea() {
+        for (Player player : getPlayersInsideSpellRadius()) {
+            unhidePlayer(player);
+        }
+    }
+
+    /**
+     * Show this player because they are outside the spell area
+     *
+     * @param player the player to unhide
+     */
+    protected void unhidePlayer(@NotNull Player player) {
+        // do not do anything if they are inside the spell area or are invisible for other reasons
+        if (isLocationInside(player.getLocation()) || O2PlayerCommon.isInvisible(player))
+            return;
+
+        for (Player viewer : p.getServer().getOnlinePlayers()) {
+            viewer.showPlayer(p, player);
+            common.printDebugMessage("StationarySpell.ConcealmentShieldSpell: unhid " + player.getName() + " from " + viewer.getName(), null, null, false);
+        }
+    }
+
+    /**
+     * The message shown to players if they try to enter this area and cannot
+     *
+     * @return a message or null if this spell does not have one
+     */
+    @Nullable
+    protected String getAreaEntryDenialMessage() {
+        if (messages.isEmpty())
+            return null;
+        else
+            return messages.get(Math.abs(Ollivanders2Common.random.nextInt()) % messages.size());
+    }
+
+    /**
+     * Do a proximity alarm if the alertLocation is within the proximity area of this spell
+     */
+    protected void doProximityCheck(@NotNull Location alertLocation) {
+        // do not run the proximity alarm if it is in cooldown
+        if (proximityCooldownTimer > 0)
+            return;
+
+        if (Ollivanders2Common.isInside(location, alertLocation, radius + proximityRadiusModifier))
+            if (checkAlarm(alertLocation)) {
+                proximityAlarm();
+            }
+    }
+
+    //
+    // Event handlers
+    //
+
+    /**
+     * Prevent entities targeting a player inside the area.
+     *
+     * @param event the event
+     */
+    @Override
+    void doOnEntityTargetEvent(@NotNull EntityTargetEvent event) {
+        Entity target = event.getTarget();
+        Entity entity = event.getEntity(); // will never be null
+
+        if (!(target instanceof Player))
+            return;
+
+        if (isLocationInside(target.getLocation()) && !isLocationInside(entity.getLocation()) && !canTarget(entity)) {
+            event.setCancelled(true);
+            common.printDebugMessage("StationarySpell.ConcealmentShieldSpell: canceled target of " + target.getName() + " by " + entity.getName(), null, null, false);
+        }
+    }
+
+    /**
+     * Hide the player if they go into the spell area
+     *
+     * @param event the event
+     */
+    @Override
+    void doOnPlayerMoveEvent(@NotNull PlayerMoveEvent event) {
+        Location toLocation = event.getTo();
+        Location fromLocation = event.getFrom();
+        Player player = event.getPlayer();
+
+        if (event.isCancelled() || toLocation == null)
+            return;
+
+        // player moving in to the spell area when they were outside it
+        if (isLocationInside(toLocation) && !isLocationInside(fromLocation)) {
+            // if they can enter the area, hide them
+            if (canEnter(player)) {
+                hidePlayer(player);
+            }
+            // if they cannot enter the area, cancel the move event
+            else {
+                event.setCancelled(true);
+
+                String areaEntryDenyMessage = getAreaEntryDenialMessage();
+                if (areaEntryDenyMessage != null)
+                    player.sendMessage(Ollivanders2.chatColor + areaEntryDenyMessage);
+
+                common.printDebugMessage("StationarySpell.ConcealmentShieldSpell: prevented " + player.getName() + " entering area.", null, null, false);
+            }
+        }
+        // player moving out of the spell area from inside it, unhide them
+        else if (!isLocationInside(toLocation) && isLocationInside(fromLocation)) {
+            unhidePlayer(player);
+        }
+        // player is moving around outside the spell area
+        else if (!isLocationInside(toLocation) && !isLocationInside(fromLocation)) {
+            if (alarmOnProximity)
+                doProximityCheck(toLocation);
+        }
+        // else the player is moving around inside the spell area
+    }
+
+    /**
+     * Remove muggles from the recipients of any chats by players in the spell area
+     *
+     * @param event the event
+     */
+    @Override
+    void doOnAsyncPlayerChatEvent(@NotNull AsyncPlayerChatEvent event) {
+        Player speaker = event.getPlayer();
+
+        if (!isLocationInside(speaker.getLocation()))
+            return;
+
+        Set<Player> recipients = new HashSet<>(event.getRecipients());
+        for (Player player : recipients) {
+            if (!canHear(player)) {
+                event.getRecipients().remove(player);
+                common.printDebugMessage("StationarySpell.ConcealmentShieldSpell: removed " + player.getName() + " from chat recipients", null, null, false);
+            }
+        }
+    }
+
+    /**
+     * When players join, hide any players in this concealment spell area from them.
+     *
+     * @param event the player join event
+     */
+    @Override
+    void doOnPlayerJoinEvent(@NotNull PlayerJoinEvent event) {
+        // re-evaluate all hidden players in the spell area
+        hidePlayersInSpellArea();
+    }
+
+    /**
+     * Unhide all players that were in the spell area
+     */
+    @Override
+    void doCleanUp() {
+        unhidePlayersInSpellArea();
+    }
+
+    //
+    // serialize/deserialize functions
+    //
+
+    @Override
+    @NotNull
+    public Map<String, String> serializeSpellData() {
+        return new HashMap<>();
+    }
+
+    @Override
+    public void deserializeSpellData(@NotNull Map<String, String> spellData) {
+    }
+
+    //
+    // Abstract functions that need to be overridden
+    //
+
+    /**
+     * Can this entity "hear" sounds from inside the spell area? Assumes the entity being checked is outside the spell area.
+     *
+     * @param entity the entity entering the area
+     * @return true if the entity can hear inside the area, false otherwise
+     */
+    protected abstract boolean canHear(@NotNull Entity entity);
+
+    /**
+     * Can this entity see players inside the spell area? Assumes the entity being checked is outside the spell area.
+     *
+     * @param entity the entity looking inside the area
+     * @return true if the entity can target inside the area, false otherwise
+     */
+    protected abstract boolean canSee(@NotNull Entity entity);
+
+    /**
+     * Can this entity target players inside the spell area? Assumes the entity being checked is outside the spell area.
+     *
+     * @param entity the entity targeting inside the area
+     * @return true if the entity can target inside the area, false otherwise
+     */
+    protected abstract boolean canTarget(@NotNull Entity entity);
+
+    /**
+     * Can this entity enter the spell area? Assumes the entity being checked is outside the spell area.
+     *
+     * @param entity the entity entering the area
+     * @return true if the entity can enter the area, false otherwise
+     */
+    protected abstract boolean canEnter(@NotNull Entity entity);
+
+    /**
+     * Check the proximity alarm conditions at the location. Assumes that a check to determine that a proximity alarm
+     * should go off for this location has happened and called this.
+     */
+    protected abstract boolean checkAlarm(@NotNull Location alertLocation);
+
+    /**
+     * Do the proximity alarm action for this spell.
+     */
+    protected abstract void proximityAlarm();
+}

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HARMONIA_NECTERE_PASSUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HARMONIA_NECTERE_PASSUS.java
@@ -19,9 +19,12 @@ import java.util.UUID;
 
 /**
  * Checks for entities going into a vanishing cabinet
- *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Vanishing_Cabinet">https://harrypotter.fandom.com/wiki/Vanishing_Cabinet</a>
+ * <p>
  * {@link net.pottercraft.ollivanders2.spell.HARMONIA_NECTERE_PASSUS}
+ *
+ * @author Azami7
+ * @version Ollivanders2
+ * @see <a href = "https://harrypotter.fandom.com/wiki/Vanishing_Cabinet">https://harrypotter.fandom.com/wiki/Vanishing_Cabinet</a>
  */
 public class HARMONIA_NECTERE_PASSUS extends O2StationarySpell {
     /**
@@ -79,8 +82,6 @@ public class HARMONIA_NECTERE_PASSUS extends O2StationarySpell {
         super(plugin, pid, location);
 
         spellType = O2StationarySpellType.HARMONIA_NECTERE_PASSUS;
-        minRadius = minRadiusConfig;
-        maxRadius = maxRadiusConfig;
         permanent = true;
 
         radius = minRadius = maxRadius = minRadiusConfig;
@@ -93,7 +94,7 @@ public class HARMONIA_NECTERE_PASSUS extends O2StationarySpell {
      * Disable the spell if the twin is broken
      */
     @Override
-    public void checkEffect() {
+    public void upkeep() {
         World world = location.getWorld();
         if (world == null) {
             common.printDebugMessage("HARMONIA_NECTERE_PASSUS.checkEffect: world is null", null, null, false);
@@ -155,10 +156,7 @@ public class HARMONIA_NECTERE_PASSUS extends O2StationarySpell {
      * @return true if this player is using this cabinet, false otherwise
      */
     public boolean isUsing(Player player) {
-        if (inUseBy.containsKey(player))
-            return true;
-
-        return false;
+        return inUseBy.containsKey(player);
     }
 
     /**
@@ -243,7 +241,7 @@ public class HARMONIA_NECTERE_PASSUS extends O2StationarySpell {
                 @Override
                 public void run() {
                     if (!event.isCancelled()) {
-                        p.addTeleportEvent(player, twinCabinetLocation, true);
+                        p.addTeleportAction(player, twinCabinetLocation, true);
                     }
                 }
             }.runTaskLater(p, Ollivanders2Common.ticksPerSecond);
@@ -251,5 +249,6 @@ public class HARMONIA_NECTERE_PASSUS extends O2StationarySpell {
     }
 
     @Override
-    void doCleanUp() {}
+    void doCleanUp() {
+    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HORCRUX.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HORCRUX.java
@@ -26,9 +26,13 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Player will spawn here when killed, with all of their spell levels intact. Only fiendfyre can destroy it.
- *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Horcrux-making_spell">https://harrypotter.fandom.com/wiki/Horcrux-making_spell</a>
+ * <p>
  * {@link net.pottercraft.ollivanders2.spell.ET_INTERFICIAM_ANIMAM_LIGAVERIS}
+ *
+ * @author Azami7
+ * @version Ollivanders2
+ * @see <a href = "https://harrypotter.fandom.com/wiki/Horcrux-making_spell">https://harrypotter.fandom.com/wiki/Horcrux-making_spell</a>
+ * @since 2.21
  */
 public class HORCRUX extends O2StationarySpell {
     /**
@@ -96,6 +100,7 @@ public class HORCRUX extends O2StationarySpell {
      * @param plugin   a callback to the MC plugin
      * @param pid      the player who cast the spell
      * @param location the center location of the spell
+     * @param item     the horcrux object
      */
     public HORCRUX(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, @NotNull Item item) {
         super(plugin);
@@ -120,7 +125,7 @@ public class HORCRUX extends O2StationarySpell {
      * Upkeep for the spell
      */
     @Override
-    public void checkEffect() {
+    public void upkeep() {
         // decrement all the affected cooldowns by a tick
         ArrayList<String> iterator = new ArrayList<>(affectedPlayers.keySet());
 
@@ -305,7 +310,7 @@ public class HORCRUX extends O2StationarySpell {
      * @param event the event
      */
     @Override
-    void doOnInventoryItemPickupEvent (@NotNull InventoryPickupItemEvent event ) {
+    void doOnInventoryItemPickupEvent(@NotNull InventoryPickupItemEvent event) {
         Item eventItem = event.getItem();
 
         if (eventItem.getUniqueId() == horcruxItem.getUniqueId())
@@ -313,5 +318,6 @@ public class HORCRUX extends O2StationarySpell {
     }
 
     @Override
-    void doCleanUp() { }
+    void doCleanUp() {
+    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/LUMOS_FERVENS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/LUMOS_FERVENS.java
@@ -254,10 +254,10 @@ public class LUMOS_FERVENS extends O2StationarySpell {
      * This is the stationary spell's effect. age() must be called in this if you want the spell to age and die eventually.
      */
     @Override
-    void checkEffect() {
+    void upkeep() {
         age();
     }
-    
+
     /**
      * Clean up needed for this spell when it ends.
      */

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/MOLLIARE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/MOLLIARE.java
@@ -14,9 +14,12 @@ import java.util.UUID;
 
 /**
  * Negates fall damage.
- *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Cushioning_Charm">https://harrypotter.fandom.com/wiki/Cushioning_Charm</a>
+ * <p>
  * {@link net.pottercraft.ollivanders2.spell.MOLLIARE}
+ *
+ * @author Azami7
+ * @version Ollivanders2
+ * @see <a href = "https://harrypotter.fandom.com/wiki/Cushioning_Charm">https://harrypotter.fandom.com/wiki/Cushioning_Charm</a>
  */
 public class MOLLIARE extends O2StationarySpell {
     /**
@@ -74,7 +77,7 @@ public class MOLLIARE extends O2StationarySpell {
      * Age the spell by a tick
      */
     @Override
-    public void checkEffect() {
+    public void upkeep() {
         age();
     }
 
@@ -107,5 +110,6 @@ public class MOLLIARE extends O2StationarySpell {
     }
 
     @Override
-    void doCleanUp() {}
+    void doCleanUp() {
+    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/MUFFLIATO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/MUFFLIATO.java
@@ -16,9 +16,12 @@ import java.util.UUID;
 
 /**
  * Only players within this can hear other conversation from other players within. Duration depending on spell's level.
- *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Muffliato_Charm">https://harrypotter.fandom.com/wiki/Muffliato_Charm</a>
+ * <p>
  * {@link net.pottercraft.ollivanders2.spell.MUFFLIATO}
+ *
+ * @author Azami7
+ * @version Ollivanders2
+ * @see <a href = "https://harrypotter.fandom.com/wiki/Muffliato_Charm">https://harrypotter.fandom.com/wiki/Muffliato_Charm</a>
  */
 public class MUFFLIATO extends ShieldSpell {
     /**
@@ -76,7 +79,7 @@ public class MUFFLIATO extends ShieldSpell {
      * Age the spell by 1 tick
      */
     @Override
-    public void checkEffect() {
+    public void upkeep() {
         age();
     }
 
@@ -111,5 +114,6 @@ public class MUFFLIATO extends ShieldSpell {
     }
 
     @Override
-    void doCleanUp() {}
+    void doCleanUp() {
+    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/NULLUM_APPAREBIT.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/NULLUM_APPAREBIT.java
@@ -19,9 +19,12 @@ import java.util.UUID;
 
 /**
  * Nullum apparebit creates a stationary spell which will not allow apparition into it.
- *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx">https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx</a>
+ * <p>
  * {@link net.pottercraft.ollivanders2.spell.NULLUM_APPAREBIT}
+ *
+ * @author Azami7
+ * @version Ollivanders2
+ * @see <a href = "https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx">https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx</a>
  */
 public class NULLUM_APPAREBIT extends O2StationarySpell {
     /**
@@ -80,7 +83,7 @@ public class NULLUM_APPAREBIT extends O2StationarySpell {
      * Age the spell by 1 tick
      */
     @Override
-    public void checkEffect() {
+    public void upkeep() {
         age();
     }
 
@@ -194,5 +197,6 @@ public class NULLUM_APPAREBIT extends O2StationarySpell {
     }
 
     @Override
-    void doCleanUp() {}
+    void doCleanUp() {
+    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/NULLUM_EVANESCUNT.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/NULLUM_EVANESCUNT.java
@@ -19,9 +19,12 @@ import java.util.UUID;
 
 /**
  * Nullum evanescunt creates a stationary spell which will not allow apparition out of it.
- *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx">https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx</a>
+ * <p>
  * {@link net.pottercraft.ollivanders2.spell.NULLUM_EVANESCUNT}
+ *
+ * @author Azami7
+ * @version Ollivanders2
+ * @see <a href = "https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx">https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx</a>
  */
 public class NULLUM_EVANESCUNT extends O2StationarySpell {
     /**
@@ -64,7 +67,7 @@ public class NULLUM_EVANESCUNT extends O2StationarySpell {
      * Age the spell by 1 tick
      */
     @Override
-    public void checkEffect() {
+    public void upkeep() {
         age();
     }
 
@@ -178,5 +181,6 @@ public class NULLUM_EVANESCUNT extends O2StationarySpell {
     }
 
     @Override
-    void doCleanUp() {}
+    void doCleanUp() {
+    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpell.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpell.java
@@ -39,6 +39,9 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Stationary spell object in Ollivanders2
+ *
+ * @author Azami7
+ * @version Ollivanders2
  */
 public abstract class O2StationarySpell implements Serializable {
     /**
@@ -364,6 +367,24 @@ public abstract class O2StationarySpell implements Serializable {
     }
 
     /**
+     * Get the players inside this spell radius. We use eye radius to handle entities bigger than 1 block.
+     *
+     * @return a list of the players with an eye location within the radius
+     */
+    public List<Player> getPlayersInsideSpellRadius() {
+        Collection<LivingEntity> entities = getEntitiesInsideSpellRadius();
+        List<Player> players = new ArrayList<>();
+
+        for (LivingEntity livingEntity : entities) {
+            if (livingEntity instanceof Player) {
+                players.add((Player) livingEntity);
+            }
+        }
+
+        return players;
+    }
+
+    /**
      * Makes a particle effect at all points along the radius of spell and at spell loc
      * <p>
      * {@link Ollivanders2Common}
@@ -458,9 +479,9 @@ public abstract class O2StationarySpell implements Serializable {
     }
 
     /**
-     * This is the stationary spell's effect. age() must be called in this if you want the spell to age and die eventually.
+     * This is the stationary spell's upkeep, age() must be called in this if you want the spell to age and die eventually.
      */
-    abstract void checkEffect();
+    abstract void upkeep();
 
     /**
      * Serialize all data specific to this spell so it can be saved.
@@ -615,33 +636,38 @@ public abstract class O2StationarySpell implements Serializable {
      *
      * @param event the world load event
      */
-    void doOnPlayerJoinEvent(@NotNull PlayerJoinEvent event) { }
+    void doOnPlayerJoinEvent(@NotNull PlayerJoinEvent event) {
+    }
 
     /**
      * Handle item despawn events
      *
      * @param event the item despawn event
      */
-    void doOnItemDespawnEvent(@NotNull ItemDespawnEvent event) {}
+    void doOnItemDespawnEvent(@NotNull ItemDespawnEvent event) {
+    }
 
     /**
      * Handle items being picked up by entities
      *
      * @param event the event
      */
-    void doOnEntityPickupItemEvent(@NotNull EntityPickupItemEvent event) {}
+    void doOnEntityPickupItemEvent(@NotNull EntityPickupItemEvent event) {
+    }
 
     /**
      * Handle items being picked up by things like hoppers
      *
      * @param event the event
      */
-    void doOnInventoryItemPickupEvent(@NotNull InventoryPickupItemEvent event ) {}
+    void doOnInventoryItemPickupEvent(@NotNull InventoryPickupItemEvent event) {
+    }
 
     /**
      * Handle player death event
      *
      * @param event the event
      */
-    void doOnPlayerDeathEvent(@NotNull PlayerDeathEvent event) {}
+    void doOnPlayerDeathEvent(@NotNull PlayerDeathEvent event) {
+    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpell.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpell.java
@@ -328,7 +328,7 @@ public abstract class O2StationarySpell implements Serializable {
     }
 
     /**
-     * Is the location specified inside the object's radius?
+     * Is the location specified inside the stationary spell's radius?
      *
      * @param loc the location specified.
      * @return true if the location is inside of this spell radius, false otherwise
@@ -355,6 +355,7 @@ public abstract class O2StationarySpell implements Serializable {
     @NotNull
     public List<LivingEntity> getEntitiesInsideSpellRadius() {
         Collection<LivingEntity> entities = EntityCommon.getLivingEntitiesInRadius(location, radius);
+
         List<LivingEntity> close = new ArrayList<>();
 
         /* only add living entities if their eye location is within the radius */
@@ -372,13 +373,12 @@ public abstract class O2StationarySpell implements Serializable {
      * @return a list of the players with an eye location within the radius
      */
     public List<Player> getPlayersInsideSpellRadius() {
-        Collection<LivingEntity> entities = getEntitiesInsideSpellRadius();
         List<Player> players = new ArrayList<>();
 
-        for (LivingEntity livingEntity : entities) {
-            if (livingEntity instanceof Player) {
-                players.add((Player) livingEntity);
-            }
+        for (Player player : p.getServer().getOnlinePlayers())
+        {
+            if (isLocationInside(player.getLocation()))
+                players.add(player);
         }
 
         return players;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpellType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpellType.java
@@ -10,12 +10,19 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents allowable stationary spells.
+ *
+ * @author Azami7
+ * @version Ollivanders2
  */
 public enum O2StationarySpellType {
     /**
      * {@link ALIQUAM_FLOO}
      */
     ALIQUAM_FLOO(ALIQUAM_FLOO.class, MagicLevel.EXPERT),
+    /**
+     * {@link CAVE_INIMICUM}
+     */
+    CAVE_INIMICUM(CAVE_INIMICUM.class, MagicLevel.NEWT),
     /**
      * {@link COLLOPORTUS}
      */
@@ -89,7 +96,7 @@ public enum O2StationarySpellType {
     /**
      * Get the class for this stationary spell
      *
-     * @return the classname for this spell
+     * @return the class name for this spell
      */
     @NotNull
     public Class<?> getClassName() {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpells.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpells.java
@@ -492,16 +492,13 @@ public class O2StationarySpells implements Listener {
      * Run each spell's upkeep and clean up killed spells
      */
     public void upkeep() {
-        List<O2StationarySpell> s = new ArrayList<>(O2StationarySpells);
+        List<O2StationarySpell> stationarySpells = new ArrayList<>(O2StationarySpells);
 
-        for (O2StationarySpell statSpell : s) {
-            statSpell.upkeep();
+        for (O2StationarySpell stationarySpell : stationarySpells) {
+            stationarySpell.upkeep();
 
-            if (statSpell.kill) {
-                common.printDebugMessage("O2StationarySpells.upkeep: removing " + statSpell.getSpellType(), null, null, false);
-
-                O2StationarySpells.remove(statSpell);
-            }
+            if (stationarySpell.kill)
+                O2StationarySpells.remove(stationarySpell);
         }
     }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpells.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpells.java
@@ -40,6 +40,9 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Manager for all stationary spells
+ *
+ * @author Azami7
+ * @version Ollivanders2
  */
 public class O2StationarySpells implements Listener {
     /**
@@ -361,6 +364,11 @@ public class O2StationarySpells implements Listener {
         }
     }
 
+    /**
+     * Handle player deal events
+     *
+     * @param event the player death event
+     */
     @EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerDeathEvent(@NotNull PlayerDeathEvent event) {
         for (O2StationarySpell stationary : O2StationarySpells) {
@@ -487,7 +495,7 @@ public class O2StationarySpells implements Listener {
         List<O2StationarySpell> s = new ArrayList<>(O2StationarySpells);
 
         for (O2StationarySpell statSpell : s) {
-            statSpell.checkEffect();
+            statSpell.upkeep();
 
             if (statSpell.kill) {
                 common.printDebugMessage("O2StationarySpells.upkeep: removing " + statSpell.getSpellType(), null, null, false);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO.java
@@ -21,12 +21,14 @@ import net.pottercraft.ollivanders2.Ollivanders2;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * The basic protection spell
+ * The basic protection spell.
+ * <p>
+ * {@link net.pottercraft.ollivanders2.spell.PROTEGO}
  *
  * @see <a href = "https://harrypotter.fandom.com/wiki/Shield_Charm">https://harrypotter.fandom.com/wiki/Shield_Charm</a>
- * {@link net.pottercraft.ollivanders2.spell.PROTEGO}
  */
 public class PROTEGO extends ShieldSpell {
+    // todo rewrite based on HP canon
     /**
      * min radius for this spell
      */
@@ -83,7 +85,7 @@ public class PROTEGO extends ShieldSpell {
      * Age the spell by 1 tick,
      */
     @Override
-    public void checkEffect() {
+    public void upkeep() {
         age();
 
         Player ply = Bukkit.getPlayer(getCasterID());
@@ -165,5 +167,6 @@ public class PROTEGO extends ShieldSpell {
     }
 
     @Override
-    void doCleanUp() {}
+    void doCleanUp() {
+    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO_HORRIBILIS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO_HORRIBILIS.java
@@ -16,9 +16,12 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Destroys spell projectiles crossing the boundary.
- *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Protego_horribilis">https://harrypotter.fandom.com/wiki/Protego_horribilis</a>
+ * <p>
  * {@link net.pottercraft.ollivanders2.spell.PROTEGO_HORRIBILIS}
+ *
+ * @author Azami7
+ * @version Ollivanders2
+ * @see <a href = "https://harrypotter.fandom.com/wiki/Protego_horribilis">https://harrypotter.fandom.com/wiki/Protego_horribilis</a>
  */
 public class PROTEGO_HORRIBILIS extends ShieldSpell {
     /**
@@ -76,7 +79,7 @@ public class PROTEGO_HORRIBILIS extends ShieldSpell {
      * Age the spell by a tick and kill projectiles crossing the boundaries
      */
     @Override
-    public void checkEffect() {
+    public void upkeep() {
         age();
         List<O2Spell> projectiles = p.getProjectiles();
 
@@ -105,5 +108,6 @@ public class PROTEGO_HORRIBILIS extends ShieldSpell {
     }
 
     @Override
-    void doCleanUp() {}
+    void doCleanUp() {
+    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO_MAXIMA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO_MAXIMA.java
@@ -15,12 +15,14 @@ import java.util.UUID;
 
 /**
  * Hurts any entities within 0.5 meters of the spell wall.
- *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Protego_Maxima">https://harrypotter.fandom.com/wiki/Protego_Maxima</a>
+ * <p>
  * {@link net.pottercraft.ollivanders2.spell.PROTEGO_MAXIMA}
+ *
+ * @author Azami7
+ * @version Ollivanders2
+ * @see <a href = "https://harrypotter.fandom.com/wiki/Protego_Maxima">https://harrypotter.fandom.com/wiki/Protego_Maxima</a>
  */
-public class PROTEGO_MAXIMA extends ShieldSpell
-{
+public class PROTEGO_MAXIMA extends ShieldSpell {
     /**
      * min radius for this spell
      */
@@ -71,8 +73,7 @@ public class PROTEGO_MAXIMA extends ShieldSpell
      *
      * @param plugin a callback to the MC plugin
      */
-    public PROTEGO_MAXIMA(@NotNull Ollivanders2 plugin)
-    {
+    public PROTEGO_MAXIMA(@NotNull Ollivanders2 plugin) {
         super(plugin);
 
         spellType = O2StationarySpellType.PROTEGO_MAXIMA;
@@ -88,8 +89,7 @@ public class PROTEGO_MAXIMA extends ShieldSpell
      * @param duration the duration of the spell
      * @param damage   the damage done to other entities in this spell area
      */
-    public PROTEGO_MAXIMA(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration, double damage)
-    {
+    public PROTEGO_MAXIMA(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration, double damage) {
         super(plugin, pid, location);
         spellType = O2StationarySpellType.PROTEGO_MAXIMA;
         minRadius = minRadiusConfig;
@@ -108,20 +108,16 @@ public class PROTEGO_MAXIMA extends ShieldSpell
      * Age the spell and damage any entities nearby
      */
     @Override
-    public void checkEffect()
-    {
+    public void upkeep() {
         age();
 
         Collection<LivingEntity> nearbyEntities = EntityCommon.getLivingEntitiesInRadius(location, radius + 1);
 
         // only do damage twice per second
-        if (cooldown <= 0)
-        {
-            for (LivingEntity e : nearbyEntities)
-            {
+        if (cooldown <= 0) {
+            for (LivingEntity e : nearbyEntities) {
                 double distance = e.getLocation().distance(location);
-                if (distance > radius - 0.5 && distance < radius + 0.5)
-                {
+                if (distance > radius - 0.5 && distance < radius + 0.5) {
                     e.damage(damage);
                     flair(10);
                 }
@@ -140,8 +136,7 @@ public class PROTEGO_MAXIMA extends ShieldSpell
      */
     @Override
     @NotNull
-    public Map<String, String> serializeSpellData()
-    {
+    public Map<String, String> serializeSpellData() {
         Map<String, String> spellData = new HashMap<>();
 
         spellData.put(damageLabel, Double.toString(damage));
@@ -155,20 +150,15 @@ public class PROTEGO_MAXIMA extends ShieldSpell
      * @param spellData a map of the saved spell data
      */
     @Override
-    public void deserializeSpellData(@NotNull Map<String, String> spellData)
-    {
-        for (Map.Entry<String, String> e : spellData.entrySet())
-        {
-            try
-            {
-                if (e.getKey().equals(damageLabel))
-                {
+    public void deserializeSpellData(@NotNull Map<String, String> spellData) {
+        for (Map.Entry<String, String> e : spellData.entrySet()) {
+            try {
+                if (e.getKey().equals(damageLabel)) {
                     double d = Double.parseDouble(e.getValue());
                     setDamage(d);
                 }
             }
-            catch (Exception exception)
-            {
+            catch (Exception exception) {
                 common.printDebugMessage("Unable to read Protego Maxima damage", exception, null, false);
             }
         }
@@ -179,8 +169,7 @@ public class PROTEGO_MAXIMA extends ShieldSpell
      *
      * @param damage the amount of damage the spell should do
      */
-    private void setDamage(double damage)
-    {
+    private void setDamage(double damage) {
         if (damage < minDamageConfig)
             damage = minDamageConfig;
         else if (damage > maxDamageConfig)
@@ -190,5 +179,6 @@ public class PROTEGO_MAXIMA extends ShieldSpell
     }
 
     @Override
-    void doCleanUp() {}
+    void doCleanUp() {
+    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO_TOTALUM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO_TOTALUM.java
@@ -18,12 +18,14 @@ import java.util.UUID;
 
 /**
  * Doesn't let entities pass into the protected area.
- *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Protego_totalum">https://harrypotter.fandom.com/wiki/Protego_totalum</a>
+ * <p>
  * {@link net.pottercraft.ollivanders2.spell.PROTEGO_TOTALUM}
+ *
+ * @author Azami7
+ * @version Ollivanders2
+ * @see <a href = "https://harrypotter.fandom.com/wiki/Protego_totalum">https://harrypotter.fandom.com/wiki/Protego_totalum</a>
  */
-public class PROTEGO_TOTALUM extends ShieldSpell
-{
+public class PROTEGO_TOTALUM extends ShieldSpell {
     /**
      * min radius for this spell
      */
@@ -46,8 +48,7 @@ public class PROTEGO_TOTALUM extends ShieldSpell
      *
      * @param plugin a callback to the MC plugin
      */
-    public PROTEGO_TOTALUM(@NotNull Ollivanders2 plugin)
-    {
+    public PROTEGO_TOTALUM(@NotNull Ollivanders2 plugin) {
         super(plugin);
 
         spellType = O2StationarySpellType.PROTEGO_TOTALUM;
@@ -62,8 +63,7 @@ public class PROTEGO_TOTALUM extends ShieldSpell
      * @param radius   the radius for this spell
      * @param duration the duration of the spell
      */
-    public PROTEGO_TOTALUM(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration)
-    {
+    public PROTEGO_TOTALUM(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
         super(plugin, pid, location);
         spellType = O2StationarySpellType.PROTEGO_TOTALUM;
 
@@ -82,8 +82,7 @@ public class PROTEGO_TOTALUM extends ShieldSpell
      * Age the spell by 1 tick
      */
     @Override
-    void checkEffect()
-    {
+    void upkeep() {
         age();
     }
 
@@ -93,8 +92,7 @@ public class PROTEGO_TOTALUM extends ShieldSpell
      * @param event the player move event
      */
     @Override
-    void doOnPlayerMoveEvent(@NotNull PlayerMoveEvent event)
-    {
+    void doOnPlayerMoveEvent(@NotNull PlayerMoveEvent event) {
         Location toLoc = event.getTo();
         Location fromLoc = event.getFrom(); // will never be null
 
@@ -105,18 +103,14 @@ public class PROTEGO_TOTALUM extends ShieldSpell
         if (Ollivanders2Common.isInside(fromLoc, location, radius))
             return;
 
-        if (Ollivanders2Common.isInside(toLoc, location, radius))
-        {
+        if (Ollivanders2Common.isInside(toLoc, location, radius)) {
             event.setCancelled(true);
             common.printDebugMessage("PROTEGO_TOTALUM: canceled PlayerMoveEvent", null, null, false);
 
-            new BukkitRunnable()
-            {
+            new BukkitRunnable() {
                 @Override
-                public void run()
-                {
-                    if (event.isCancelled())
-                    {
+                public void run() {
+                    if (event.isCancelled()) {
                         flair(10);
                         event.getPlayer().sendMessage(Ollivanders2.chatColor + "A magical force prevents you moving here.");
                     }
@@ -131,13 +125,11 @@ public class PROTEGO_TOTALUM extends ShieldSpell
      * @param event the creature spawn event
      */
     @Override
-    void doOnCreatureSpawnEvent(@NotNull CreatureSpawnEvent event)
-    {
+    void doOnCreatureSpawnEvent(@NotNull CreatureSpawnEvent event) {
         Entity entity = event.getEntity(); // will never be null
         Location entityLocation = entity.getLocation();
 
-        if (Ollivanders2Common.isInside(entityLocation, location, radius))
-        {
+        if (Ollivanders2Common.isInside(entityLocation, location, radius)) {
             event.setCancelled(true);
             common.printDebugMessage("PROTEGO_TOTALUM: canceled CreatureSpawnEvent", null, null, false);
         }
@@ -149,26 +141,21 @@ public class PROTEGO_TOTALUM extends ShieldSpell
      * @param event the event
      */
     @Override
-    void doOnEntityTargetEvent(@NotNull EntityTargetEvent event)
-    {
+    void doOnEntityTargetEvent(@NotNull EntityTargetEvent event) {
         Entity target = event.getTarget();
         if (target == null)
             return;
 
         Location targetLocation = target.getLocation();
 
-        if (isLocationInside(targetLocation))
-        {
+        if (isLocationInside(targetLocation)) {
             event.setCancelled(true);
             common.printDebugMessage("PROTEGO_TOTALUM: canceled EntityTargetEvent", null, null, false);
 
-            new BukkitRunnable()
-            {
+            new BukkitRunnable() {
                 @Override
-                public void run()
-                {
-                    if (event.isCancelled() && target instanceof Player)
-                    {
+                public void run() {
+                    if (event.isCancelled() && target instanceof Player) {
                         flair(10);
                         target.sendMessage(Ollivanders2.chatColor + "A magical force protects you.");
                     }
@@ -184,8 +171,7 @@ public class PROTEGO_TOTALUM extends ShieldSpell
      */
     @Override
     @NotNull
-    public Map<String, String> serializeSpellData()
-    {
+    public Map<String, String> serializeSpellData() {
         return new HashMap<>();
     }
 
@@ -195,8 +181,10 @@ public class PROTEGO_TOTALUM extends ShieldSpell
      * @param spellData a map of the saved spell data
      */
     @Override
-    public void deserializeSpellData(@NotNull Map<String, String> spellData) {}
+    public void deserializeSpellData(@NotNull Map<String, String> spellData) {
+    }
 
     @Override
-    void doCleanUp() {}
+    void doCleanUp() {
+    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/REPELLO_MUGGLETON.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/REPELLO_MUGGLETON.java
@@ -1,9 +1,9 @@
 package net.pottercraft.ollivanders2.stationaryspell;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,7 +17,7 @@ import java.util.UUID;
  *
  * @author Azami7
  * @version Ollivanders2
- * @See <a href = "https://harrypotter.fandom.com/wiki/Muggle-Repelling_Charm">https://harrypotter.fandom.com/wiki/Muggle-Repelling_Charm</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Muggle-Repelling_Charm">https://harrypotter.fandom.com/wiki/Muggle-Repelling_Charm</a>
  * @since 2.21
  */
 public class REPELLO_MUGGLETON extends ConcealmentShieldSpell {
@@ -80,7 +80,7 @@ public class REPELLO_MUGGLETON extends ConcealmentShieldSpell {
      * @param entity the entity looking inside the area
      * @return true if the entity is not a Muggle, false otherwise
      */
-    protected boolean canSee(@NotNull Entity entity) {
+    protected boolean canSee(@NotNull LivingEntity entity) {
         boolean isMuggle = isMuggle(entity);
 
         if (isMuggle)
@@ -98,7 +98,7 @@ public class REPELLO_MUGGLETON extends ConcealmentShieldSpell {
      * @return true, this spell does not prevent targeting
      */
     @Override
-    protected boolean canTarget(@NotNull Entity entity) {
+    protected boolean canTarget(@NotNull LivingEntity entity) {
         return true;
     }
 
@@ -108,7 +108,7 @@ public class REPELLO_MUGGLETON extends ConcealmentShieldSpell {
      * @param entity the entity entering the area
      * @return true if the entity is not a Muggle, false otherwise
      */
-    protected boolean canEnter(@NotNull Entity entity) {
+    protected boolean canEnter(@NotNull LivingEntity entity) {
         return !isMuggle(entity);
     }
 
@@ -118,15 +118,27 @@ public class REPELLO_MUGGLETON extends ConcealmentShieldSpell {
      * @param entity the entity entering the area
      * @return true if the entity is not a Muggle, false otherwise
      */
-    protected boolean canHear(@NotNull Entity entity) {
+    protected boolean canHear(@NotNull LivingEntity entity) {
         return !isMuggle(entity);
     }
 
     /**
      * Check the proximity alarm conditions at the location.
      * Repello Muggleton does not have a proximity alarm.
+     *
+     * @param player the player that triggered the alarm
      */
-    protected boolean checkAlarm(@NotNull Location alertLocation) {
+    protected boolean checkAlarm(@NotNull Player player) {
+        return false;
+    }
+
+    /**
+     * Check the proximity alarm conditions at the location. Assumes that a check to determine that a proximity alarm
+     * should go off for this location has happened and called this.
+     *
+     * @param entity the entity that triggered the alarm
+     */
+    protected boolean checkAlarm(@NotNull LivingEntity entity) {
         return false;
     }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/REPELLO_MUGGLETON.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/REPELLO_MUGGLETON.java
@@ -1,6 +1,7 @@
 package net.pottercraft.ollivanders2.stationaryspell;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -29,6 +30,9 @@ public class REPELLO_MUGGLETON extends ConcealmentShieldSpell {
         super(plugin);
 
         spellType = O2StationarySpellType.REPELLO_MUGGLETON;
+
+        initMessages();
+
     }
 
     /**
@@ -41,13 +45,14 @@ public class REPELLO_MUGGLETON extends ConcealmentShieldSpell {
      * @param duration the duration of the spell
      */
     public REPELLO_MUGGLETON(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
-        super(plugin, pid, location);
-
-        setRadius(radius);
-        setDuration(duration);
+        super(plugin, pid, location, radius, duration);
 
         spellType = O2StationarySpellType.REPELLO_MUGGLETON;
 
+        initMessages();
+    }
+
+    private void initMessages() {
         messages.add("You just remembered you need to do something someplace else.");
         messages.add("You just recalled an important appointment you need to get to somewhere else.");
         messages.add("Why were you going that way? You want to go a different way.");
@@ -76,7 +81,14 @@ public class REPELLO_MUGGLETON extends ConcealmentShieldSpell {
      * @return true if the entity is not a Muggle, false otherwise
      */
     protected boolean canSee(@NotNull Entity entity) {
-        return !isMuggle(entity);
+        boolean isMuggle = isMuggle(entity);
+
+        if (isMuggle)
+            common.printDebugMessage(entity.getName() + " cannot see players in this area", null, null, false);
+        else
+            common.printDebugMessage(entity.getName() + " can see players in this area", null, null, false);
+
+        return !isMuggle;
     }
 
     /**


### PR DESCRIPTION
- added stationary spell spell Cave Inimicum
- reworked Repello Muggleton to align with HP canon
- added new abstract class ConcealmentShieldSpell
- added getPlayersInsideSpellRadius() to O2StationarySpell
- added isHostile() to EntityCommon to check if a living entity is hostile.
- added isInvisible() to O2PlayerCommon to check if a player is invisible due to an invisibility cloak or effect
- added wearingInvisibilityCloak() to O2PlayerCommon to check when a player is wearing an invisibility cloak
- renamed O2StationarySpell checkEffect() to upkeep() because we're no longer using the scheduler to drive spell actions/effects
- renamed teleport events to teleport actions because events are an actual concept for the event system in MC so that name was misleading
- javadoc cleanup
- warnings cleanup

https://github.com/Azami7/Ollivanders2/issues/22