### PR TITLE
Herbicide rework

### DIFF
--- a/Ollivanders/src/config.yml
+++ b/Ollivanders/src/config.yml
@@ -82,6 +82,9 @@ soulFireFlooEffect: true
 # /olli debug
 debug: false
 #
+# Turns off all potion brewing success checks
+overrideBrewSuccessCheck: false
+#
 # Override version checks. This will force the plugin to load regardless of MC api version.
 # **IMPORTANT** Backup your plugins/Ollivanders2 directory before enabling this option - running unsupported versions may corrupt plugin data
 overrideVersionCheck: false

--- a/Ollivanders/src/net/pottercraft/ollivanders2/common/Ollivanders2Common.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/common/Ollivanders2Common.java
@@ -560,7 +560,8 @@ public class Ollivanders2Common {
         Material material = block.getType();
 
         return (material == Material.OAK_LOG || material == Material.BIRCH_LOG || material == Material.ACACIA_LOG
-                || material == Material.DARK_OAK_LOG || material == Material.JUNGLE_LOG || material == Material.SPRUCE_LOG);
+                || material == Material.DARK_OAK_LOG || material == Material.JUNGLE_LOG || material == Material.SPRUCE_LOG
+                || material == Material.CHERRY_LOG || material == Material.MANGROVE_LOG || material == Material.PALE_OAK_LOG);
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/PROTEGO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/PROTEGO.java
@@ -91,7 +91,7 @@ public class PROTEGO extends SpellShieldEffect {
         EntityType type = event.getEntityType();
 
         // this spell only stops basic projectiles like arrows, snowballs, eggs, and thrown potions
-        if (type == EntityType.ARROW || type == EntityType.SNOWBALL || type == EntityType.EGG || type == EntityType.POTION) {
+        if (type == EntityType.ARROW || type == EntityType.SNOWBALL || type == EntityType.EGG || type == EntityType.SPLASH_POTION || type == EntityType.LINGERING_POTION) {
             // is this projectile within maxDistance of this spell center?
             if (Ollivanders2Common.isInside(player.getLocation(), projectile.getLocation(), maxDistance)) {
                 common.printDebugMessage("adding projectile " + type, null, null, false);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/item/wand/O2WandCoreType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/item/wand/O2WandCoreType.java
@@ -18,6 +18,7 @@ import java.util.List;
  * @see <a href="https://harrypotter.fandom.com/wiki/Wand_core">https://harrypotter.fandom.com/wiki/Wand_core</a>
  */
 public enum O2WandCoreType {
+    // todo fix legacy wand core types
     /**
      * dragon heartstring
      */

--- a/Ollivanders/src/net/pottercraft/ollivanders2/listeners/OllivandersListener.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/listeners/OllivandersListener.java
@@ -846,7 +846,7 @@ public class OllivandersListener implements Listener {
 
         if (potion != null) {
             if (potion instanceof O2SplashPotion)
-                ((O2SplashPotion) potion).thrownEffect(event);
+                ((O2SplashPotion) potion).doOnPotionSplashEvent(event);
         }
     }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/HERBICIDE_POTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/HERBICIDE_POTION.java
@@ -1,9 +1,13 @@
 package net.pottercraft.ollivanders2.potion;
 
+import net.pottercraft.ollivanders2.Ollivanders2API;
 import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.item.O2ItemType;
 import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.stationaryspell.HERBICIDE;
 import org.bukkit.Color;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.PotionSplashEvent;
@@ -13,16 +17,19 @@ import org.bukkit.entity.LivingEntity;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Herbicide Potion (or simply Herbicide) is a potion that kills or damages creepers. It will also harm other
- * entities, including players, though not as much as Creepers.
+ * Herbicide Potion (or simply Herbicide) is a potion that kills or damages creepers and kills all plants in the splash
+ * area of the potion. It will also harm other entities, including players, though not as much as Creepers.
  *
  * @author Azami7
  * @see <a href = "https://harrypotter.fandom.com/wiki/Herbicide_Potion">https://harrypotter.fandom.com/wiki/Herbicide_Potion</a>
  * @since 2.2.7
  */
 public final class HERBICIDE_POTION extends O2SplashPotion {
-    // todo rework to HP canon
+    // the minimum intensity for this effect when thrown on non-plant entities
     private final double minimumEffect = 0.1;
+
+    // the radius of a splash potion's effect in minecraft
+    private final int radius = 4;
 
     /**
      * Constructor
@@ -39,7 +46,7 @@ public final class HERBICIDE_POTION extends O2SplashPotion {
         ingredients.put(O2ItemType.HORKLUMP_JUICE, 2);
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 2);
 
-        text = "The Herbicide Potion is damages or kills Creepers. It is also harmful to other living creatures.";
+        text = "The Herbicide Potion is damages plant-based entities and kills plants in a radius. It is minorly harmful to other living creatures.";
 
         // potion color
         potionColor = Color.fromRGB(51, 102, 0);
@@ -66,10 +73,21 @@ public final class HERBICIDE_POTION extends O2SplashPotion {
      */
     @Override
     public void thrownEffect(@NotNull PotionSplashEvent event) {
+        Entity thrower = event.getEntity();
+        Location eventLocation = event.getPotion().getLocation();
+
+        if (!(thrower instanceof Player))
+            return;
+
+        // minimize the effect on non-creeper or creaking
         for (LivingEntity e : event.getAffectedEntities()) {
-            if (e.getType() != EntityType.CREEPER) {
+            if (e.getType() != EntityType.CREEPER || e.getType() != EntityType.CREAKING) {
                 event.setIntensity(e, minimumEffect);
             }
         }
+
+        // affect all the plant blocks in the radius of the potion effect
+        HERBICIDE herbicide = new net.pottercraft.ollivanders2.stationaryspell.HERBICIDE(p, thrower.getUniqueId(), eventLocation, radius, duration);
+        Ollivanders2API.getStationarySpells().addStationarySpell(herbicide);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/HERBICIDE_POTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/HERBICIDE_POTION.java
@@ -72,12 +72,9 @@ public final class HERBICIDE_POTION extends O2SplashPotion {
      * @param event the splash potion thrown event
      */
     @Override
-    public void thrownEffect(@NotNull PotionSplashEvent event) {
+    public void doOnPotionSplashEvent(@NotNull PotionSplashEvent event) {
         Entity thrower = event.getEntity();
         Location eventLocation = event.getPotion().getLocation();
-
-        if (!(thrower instanceof Player))
-            return;
 
         // minimize the effect on non-creeper or creaking
         for (LivingEntity e : event.getAffectedEntities()) {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2Potion.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2Potion.java
@@ -238,7 +238,7 @@ public abstract class O2Potion
             // is this ingredient in the recipe?
             if (!cauldronIngredients.containsKey(ingredientType))
             {
-                common.printDebugMessage("   recipe does not contain " + ingredientType.getName(), null, null, false);
+                common.printDebugMessage("   cauldron does not contain " + ingredientType.getName(), null, null, false);
                 return false;
             }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2Potion.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2Potion.java
@@ -312,6 +312,9 @@ public abstract class O2Potion
      */
     private boolean canBrew(@NotNull Player brewer)
     {
+        if (p.getConfig().isSet("overrideBrewSuccessCheck") && p.getConfig().getBoolean("overrideBrewSuccessCheck"))
+            return true;
+
         // When maxSpellLevel is on, potions are always successful
         if (Ollivanders2.maxSpellLevel)
             return true;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2SplashPotion.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2SplashPotion.java
@@ -28,5 +28,5 @@ public abstract class O2SplashPotion extends O2Potion {
      *
      * @param event the splash potion thrown event
      */
-    public abstract void thrownEffect(@NotNull PotionSplashEvent event);
+    public abstract void doOnPotionSplashEvent(@NotNull PotionSplashEvent event);
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/WIGGENWELD_POTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/WIGGENWELD_POTION.java
@@ -68,7 +68,7 @@ public class WIGGENWELD_POTION extends O2SplashPotion {
      * @param event the splash potion thrown event
      */
     @Override
-    public void thrownEffect(@NotNull PotionSplashEvent event) {
+    public void doOnPotionSplashEvent(@NotNull PotionSplashEvent event) {
         for (LivingEntity e : event.getAffectedEntities()) {
             if (e instanceof Player) {
                 Player player = (Player) e;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/HERBIVICUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/HERBIVICUS.java
@@ -2,6 +2,7 @@ package net.pottercraft.ollivanders2.spell;
 
 import java.util.ArrayList;
 
+import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.common.Ollivanders2Common;
@@ -64,6 +65,10 @@ public final class HERBIVICUS extends O2Spell {
 
         // pass-through materials
         projectilePassThrough.add(Material.WATER);
+
+        // required worldGuard state flags
+        if (Ollivanders2.worldGuardEnabled)
+            worldGuardFlags.add(Flags.BUILD);
 
         initSpell();
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HERBICIDE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HERBICIDE.java
@@ -1,0 +1,212 @@
+package net.pottercraft.ollivanders2.stationaryspell;
+
+import com.sk89q.worldguard.protection.flags.Flags;
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.Ageable;
+import org.bukkit.block.data.BlockData;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class HERBICIDE extends ThrownPotionStationarySpell {
+    Map<Material, Material> blocksReplacements = new HashMap<>() {{
+        put(Material.ACACIA_LEAVES, Material.LEAF_LITTER);
+        put(Material.ACACIA_SAPLING, Material.STICK);
+        put(Material.ALLIUM, Material.AIR);
+        put(Material.AZALEA, Material.DEAD_BUSH);
+        put(Material.AZALEA_LEAVES, Material.LEAF_LITTER);
+        put(Material.AZURE_BLUET, Material.AIR);
+        put(Material.BIG_DRIPLEAF, Material.LEAF_LITTER);
+        put(Material.BIG_DRIPLEAF_STEM, Material.AIR);
+        put(Material.BIRCH_LEAVES, Material.LEAF_LITTER);
+        put(Material.BIRCH_SAPLING, Material.STICK);
+        put(Material.BLUE_ORCHID, Material.AIR);
+        put(Material.BROWN_MUSHROOM, Material.AIR);
+        put(Material.CAVE_VINES_PLANT, Material.AIR);
+        put(Material.CHERRY_LEAVES, Material.LEAF_LITTER);
+        put(Material.CHERRY_SAPLING, Material.STICK);
+        put(Material.CHORUS_PLANT, Material.DEAD_BUSH);
+        put(Material.CHORUS_FLOWER, Material.AIR);
+        put(Material.CORNFLOWER, Material.AIR);
+        put(Material.DANDELION, Material.AIR);
+        put(Material.DARK_OAK_LEAVES, Material.LEAF_LITTER);
+        put(Material.DARK_OAK_SAPLING, Material.STICK);
+        put(Material.FERN, Material.LEAF_LITTER);
+        put(Material.FLOWERING_AZALEA, Material.DEAD_BUSH);
+        put(Material.FLOWERING_AZALEA_LEAVES, Material.LEAF_LITTER);
+        put(Material.GLOW_LICHEN, Material.AIR);
+        put(Material.GRASS_BLOCK, Material.DIRT);
+        put(Material.JUNGLE_LEAVES, Material.LEAF_LITTER);
+        put(Material.JUNGLE_SAPLING, Material.STICK);
+        put(Material.LARGE_FERN, Material.LEAF_LITTER);
+        put(Material.LILAC, Material.AIR);
+        put(Material.LILY_OF_THE_VALLEY, Material.AIR);
+        put(Material.LILY_PAD, Material.AIR);
+        put(Material.MANGROVE_LEAVES, Material.LEAF_LITTER);
+        put(Material.MOSS_BLOCK, Material.AIR);
+        put(Material.MOSS_CARPET, Material.AIR);
+        put(Material.MOSSY_COBBLESTONE, Material.COBBLESTONE);
+        put(Material.MOSSY_COBBLESTONE_SLAB, Material.COBBLESTONE_SLAB);
+        put(Material.MOSSY_COBBLESTONE_STAIRS, Material.COBBLESTONE_STAIRS);
+        put(Material.MOSSY_COBBLESTONE_WALL, Material.COBBLESTONE_WALL);
+        put(Material.MOSSY_STONE_BRICK_SLAB, Material.STONE_BRICK_SLAB);
+        put(Material.MOSSY_STONE_BRICK_STAIRS, Material.STONE_BRICK_STAIRS);
+        put(Material.MOSSY_STONE_BRICK_WALL, Material.STONE_BRICK_WALL);
+        put(Material.MOSSY_STONE_BRICKS, Material.STONE_BRICKS);
+        put(Material.MUSHROOM_STEM, Material.AIR);
+        put(Material.MYCELIUM, Material.DIRT);
+        put(Material.OAK_LEAVES, Material.LEAF_LITTER);
+        put(Material.OAK_SAPLING, Material.STICK);
+        put(Material.ORANGE_TULIP, Material.AIR);
+        put(Material.OXEYE_DAISY, Material.AIR);
+        put(Material.PALE_HANGING_MOSS, Material.AIR);
+        put(Material.PALE_MOSS_BLOCK, Material.DIRT);
+        put(Material.PALE_MOSS_CARPET, Material.DIRT);
+        put(Material.PALE_OAK_LEAVES, Material.LEAF_LITTER);
+        put(Material.PALE_OAK_SAPLING, Material.STICK);
+        put(Material.PEONY, Material.AIR);
+        put(Material.PINK_PETALS, Material.AIR);
+        put(Material.PINK_TULIP, Material.AIR);
+        put(Material.POPPY, Material.AIR);
+        put(Material.POTTED_ACACIA_SAPLING, Material.POTTED_DEAD_BUSH);
+        put(Material.POTTED_ALLIUM, Material.FLOWER_POT);
+        put(Material.POTTED_AZALEA_BUSH, Material.POTTED_DEAD_BUSH);
+        put(Material.POTTED_AZURE_BLUET, Material.FLOWER_POT);
+        put(Material.POTTED_BAMBOO, Material.POTTED_DEAD_BUSH);
+        put(Material.POTTED_BIRCH_SAPLING, Material.POTTED_DEAD_BUSH);
+        put(Material.POTTED_BLUE_ORCHID, Material.FLOWER_POT);
+        put(Material.POTTED_BROWN_MUSHROOM, Material.FLOWER_POT);
+        put(Material.POTTED_CACTUS, Material.POTTED_DEAD_BUSH);
+        put(Material.POTTED_CHERRY_SAPLING, Material.POTTED_DEAD_BUSH);
+        put(Material.POTTED_CLOSED_EYEBLOSSOM, Material.FLOWER_POT);
+        put(Material.POTTED_CORNFLOWER, Material.FLOWER_POT);
+        put(Material.POTTED_CRIMSON_FUNGUS, Material.FLOWER_POT);
+        put(Material.POTTED_CRIMSON_ROOTS, Material.FLOWER_POT);
+        put(Material.POTTED_DANDELION, Material.FLOWER_POT);
+        put(Material.POTTED_DARK_OAK_SAPLING, Material.POTTED_DEAD_BUSH);
+        put(Material.POTTED_FERN, Material.FLOWER_POT);
+        put(Material.POTTED_FLOWERING_AZALEA_BUSH, Material.POTTED_DEAD_BUSH);
+        put(Material.POTTED_JUNGLE_SAPLING, Material.POTTED_DEAD_BUSH);
+        put(Material.POTTED_LILY_OF_THE_VALLEY, Material.FLOWER_POT);
+        put(Material.POTTED_MANGROVE_PROPAGULE, Material.POTTED_DEAD_BUSH);
+        put(Material.POTTED_OAK_SAPLING, Material.POTTED_DEAD_BUSH);
+        put(Material.POTTED_OPEN_EYEBLOSSOM, Material.FLOWER_POT);
+        put(Material.POTTED_ORANGE_TULIP, Material.FLOWER_POT);
+        put(Material.POTTED_OXEYE_DAISY, Material.FLOWER_POT);
+        put(Material.POTTED_PALE_OAK_SAPLING, Material.POTTED_DEAD_BUSH);
+        put(Material.POTTED_PINK_TULIP, Material.FLOWER_POT);
+        put(Material.POTTED_POPPY, Material.FLOWER_POT);
+        put(Material.POTTED_RED_MUSHROOM, Material.FLOWER_POT);
+        put(Material.POTTED_RED_TULIP, Material.FLOWER_POT);
+        put(Material.POTTED_SPRUCE_SAPLING, Material.POTTED_DEAD_BUSH);
+        put(Material.POTTED_TORCHFLOWER, Material.FLOWER_POT);
+        put(Material.POTTED_WARPED_FUNGUS, Material.FLOWER_POT);
+        put(Material.POTTED_WARPED_ROOTS, Material.FLOWER_POT);
+        put(Material.POTTED_WITHER_ROSE, Material.FLOWER_POT);
+        put(Material.RED_MUSHROOM, Material.AIR);
+        put(Material.RED_MUSHROOM_BLOCK, Material.AIR);
+        put(Material.RED_TULIP, Material.AIR);
+        put(Material.ROSE_BUSH, Material.DEAD_BUSH);
+        put(Material.SHORT_DRY_GRASS, Material.AIR);
+        put(Material.SHORT_GRASS, Material.AIR);
+        put(Material.SMALL_DRIPLEAF, Material.AIR);
+        put(Material.SPORE_BLOSSOM, Material.AIR);
+        put(Material.SPRUCE_LEAVES, Material.LEAF_LITTER);
+        put(Material.SPRUCE_SAPLING, Material.STICK);
+        put(Material.SUNFLOWER, Material.AIR);
+        put(Material.SWEET_BERRY_BUSH, Material.DEAD_BUSH);
+        put(Material.TALL_DRY_GRASS, Material.AIR);
+        put(Material.TALL_GRASS, Material.AIR);
+        put(Material.TORCHFLOWER, Material.AIR);
+        put(Material.VINE, Material.AIR);
+        put(Material.WARPED_FUNGUS, Material.AIR);
+        put(Material.WARPED_STEM, Material.AIR);
+        put(Material.WEEPING_VINES, Material.AIR);
+        put(Material.WEEPING_VINES_PLANT, Material.AIR);
+        put(Material.WHITE_TULIP, Material.AIR);
+        put(Material.WILDFLOWERS, Material.AIR);
+        put(Material.WITHER_ROSE, Material.AIR);
+    }};
+
+    /**
+     * Simple constructor used for deserializing saved stationary spells at server start. Do not use to cast spell.
+     *
+     * @param plugin a callback to the MC plugin
+     */
+    public HERBICIDE(@NotNull Ollivanders2 plugin) {
+        super(plugin);
+
+        spellType = O2StationarySpellType.HERBICIDE;
+    }
+
+    /**
+     * Constructor
+     *
+     * @param plugin   a callback to the MC plugin
+     * @param pid      the player who cast the spell
+     * @param location the center location of the spell
+     * @param radius   the radius for this spell
+     * @param duration the duration of the spell
+     */
+    public HERBICIDE(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
+        super(plugin, pid, location);
+        spellType = O2StationarySpellType.HERBICIDE;
+
+        setRadius(radius);
+        setDuration(duration);
+
+        if (Ollivanders2.worldGuardEnabled)
+            worldGuardFlags.add(Flags.BUILD);
+
+        // check that world guard permissions allow this stationary spell at every location in the spell radius
+        checkWorldGuard();
+
+        if (!isKilled()) // possible if the world guard check failed
+           common.printDebugMessage("Creating stationary spell type " + spellType.name(), null, null, false);
+    }
+
+    /**
+     * Age the spell by 1 tick
+     */
+    @Override
+    public void upkeep() {
+        age();
+
+        // kill any plant blocks in the radius
+        for (Block block : Ollivanders2Common.getBlocksInRadius(location, radius)) {
+            // kill crops
+            BlockData blockData = block.getBlockData();
+            if (blockData instanceof Ageable) {
+                ((Ageable)blockData).setAge(0);
+                block.setBlockData(blockData);
+                continue;
+            }
+
+            // replace other plant blocks with "dead" alternatives
+            Material blockType = block.getType();
+            if (blocksReplacements.containsKey(blockType)) {
+                block.setType(blocksReplacements.get(blockType));
+            }
+        }
+    }
+
+    @Override
+    @NotNull
+    public Map<String, String> serializeSpellData() {
+        return new HashMap<>();
+    }
+
+    @Override
+    public void deserializeSpellData(@NotNull Map<String, String> spellData) {
+    }
+
+    @Override
+    void doCleanUp() {
+    }
+}

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HERBICIDE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HERBICIDE.java
@@ -5,9 +5,11 @@ import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.Ageable;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
@@ -16,39 +18,35 @@ import java.util.UUID;
 
 public class HERBICIDE extends ThrownPotionStationarySpell {
     Map<Material, Material> blocksReplacements = new HashMap<>() {{
-        put(Material.ACACIA_LEAVES, Material.LEAF_LITTER);
-        put(Material.ACACIA_SAPLING, Material.STICK);
+        put(Material.ACACIA_LEAVES, Material.AIR);
         put(Material.ALLIUM, Material.AIR);
         put(Material.AZALEA, Material.DEAD_BUSH);
-        put(Material.AZALEA_LEAVES, Material.LEAF_LITTER);
+        put(Material.AZALEA_LEAVES, Material.AIR);
         put(Material.AZURE_BLUET, Material.AIR);
-        put(Material.BIG_DRIPLEAF, Material.LEAF_LITTER);
+        put(Material.BAMBOO_SAPLING, Material.AIR);
+        put(Material.BIG_DRIPLEAF, Material.AIR);
         put(Material.BIG_DRIPLEAF_STEM, Material.AIR);
-        put(Material.BIRCH_LEAVES, Material.LEAF_LITTER);
-        put(Material.BIRCH_SAPLING, Material.STICK);
+        put(Material.BIRCH_LEAVES, Material.AIR);
         put(Material.BLUE_ORCHID, Material.AIR);
         put(Material.BROWN_MUSHROOM, Material.AIR);
         put(Material.CAVE_VINES_PLANT, Material.AIR);
-        put(Material.CHERRY_LEAVES, Material.LEAF_LITTER);
-        put(Material.CHERRY_SAPLING, Material.STICK);
+        put(Material.CHERRY_LEAVES, Material.AIR);
         put(Material.CHORUS_PLANT, Material.DEAD_BUSH);
         put(Material.CHORUS_FLOWER, Material.AIR);
         put(Material.CORNFLOWER, Material.AIR);
         put(Material.DANDELION, Material.AIR);
-        put(Material.DARK_OAK_LEAVES, Material.LEAF_LITTER);
-        put(Material.DARK_OAK_SAPLING, Material.STICK);
-        put(Material.FERN, Material.LEAF_LITTER);
+        put(Material.DARK_OAK_LEAVES, Material.AIR);
+        put(Material.FERN, Material.AIR);
         put(Material.FLOWERING_AZALEA, Material.DEAD_BUSH);
-        put(Material.FLOWERING_AZALEA_LEAVES, Material.LEAF_LITTER);
+        put(Material.FLOWERING_AZALEA_LEAVES, Material.AIR);
         put(Material.GLOW_LICHEN, Material.AIR);
         put(Material.GRASS_BLOCK, Material.DIRT);
-        put(Material.JUNGLE_LEAVES, Material.LEAF_LITTER);
-        put(Material.JUNGLE_SAPLING, Material.STICK);
-        put(Material.LARGE_FERN, Material.LEAF_LITTER);
+        put(Material.JUNGLE_LEAVES, Material.AIR);
+        put(Material.LARGE_FERN, Material.AIR);
         put(Material.LILAC, Material.AIR);
         put(Material.LILY_OF_THE_VALLEY, Material.AIR);
         put(Material.LILY_PAD, Material.AIR);
-        put(Material.MANGROVE_LEAVES, Material.LEAF_LITTER);
+        put(Material.MANGROVE_LEAVES, Material.AIR);
         put(Material.MOSS_BLOCK, Material.AIR);
         put(Material.MOSS_CARPET, Material.AIR);
         put(Material.MOSSY_COBBLESTONE, Material.COBBLESTONE);
@@ -61,15 +59,13 @@ public class HERBICIDE extends ThrownPotionStationarySpell {
         put(Material.MOSSY_STONE_BRICKS, Material.STONE_BRICKS);
         put(Material.MUSHROOM_STEM, Material.AIR);
         put(Material.MYCELIUM, Material.DIRT);
-        put(Material.OAK_LEAVES, Material.LEAF_LITTER);
-        put(Material.OAK_SAPLING, Material.STICK);
+        put(Material.OAK_LEAVES, Material.AIR);
         put(Material.ORANGE_TULIP, Material.AIR);
         put(Material.OXEYE_DAISY, Material.AIR);
         put(Material.PALE_HANGING_MOSS, Material.AIR);
         put(Material.PALE_MOSS_BLOCK, Material.DIRT);
         put(Material.PALE_MOSS_CARPET, Material.DIRT);
-        put(Material.PALE_OAK_LEAVES, Material.LEAF_LITTER);
-        put(Material.PALE_OAK_SAPLING, Material.STICK);
+        put(Material.PALE_OAK_LEAVES, Material.AIR);
         put(Material.PEONY, Material.AIR);
         put(Material.PINK_PETALS, Material.AIR);
         put(Material.PINK_TULIP, Material.AIR);
@@ -117,8 +113,7 @@ public class HERBICIDE extends ThrownPotionStationarySpell {
         put(Material.SHORT_GRASS, Material.AIR);
         put(Material.SMALL_DRIPLEAF, Material.AIR);
         put(Material.SPORE_BLOSSOM, Material.AIR);
-        put(Material.SPRUCE_LEAVES, Material.LEAF_LITTER);
-        put(Material.SPRUCE_SAPLING, Material.STICK);
+        put(Material.SPRUCE_LEAVES, Material.AIR);
         put(Material.SUNFLOWER, Material.AIR);
         put(Material.SWEET_BERRY_BUSH, Material.DEAD_BUSH);
         put(Material.TALL_DRY_GRASS, Material.AIR);
@@ -132,6 +127,18 @@ public class HERBICIDE extends ThrownPotionStationarySpell {
         put(Material.WHITE_TULIP, Material.AIR);
         put(Material.WILDFLOWERS, Material.AIR);
         put(Material.WITHER_ROSE, Material.AIR);
+    }};
+
+    Map<Material, Material> blocksToItemReplacements = new HashMap<>() {{
+        put(Material.ACACIA_SAPLING, Material.STICK);
+        put(Material.BAMBOO, Material.BAMBOO);
+        put(Material.BIRCH_SAPLING, Material.STICK);
+        put(Material.CHERRY_SAPLING, Material.STICK);
+        put(Material.DARK_OAK_SAPLING, Material.STICK);
+        put(Material.JUNGLE_SAPLING, Material.STICK);
+        put(Material.OAK_SAPLING, Material.STICK);
+        put(Material.PALE_OAK_SAPLING, Material.STICK);
+        put(Material.SPRUCE_SAPLING, Material.STICK);
     }};
 
     /**
@@ -166,9 +173,6 @@ public class HERBICIDE extends ThrownPotionStationarySpell {
 
         // check that world guard permissions allow this stationary spell at every location in the spell radius
         checkWorldGuard();
-
-        if (!isKilled()) // possible if the world guard check failed
-           common.printDebugMessage("Creating stationary spell type " + spellType.name(), null, null, false);
     }
 
     /**
@@ -176,24 +180,36 @@ public class HERBICIDE extends ThrownPotionStationarySpell {
      */
     @Override
     public void upkeep() {
-        age();
+        if (duration % 10 == 0) {
+            // kill any plant blocks in the radius
+            for (Block block : Ollivanders2Common.getBlocksInRadius(location, radius)) {
+                // replace plant blocks with "dead" alternatives
+                Material blockType = block.getType();
+                if (blocksReplacements.containsKey(blockType)) {
+                    block.setType(blocksReplacements.get(blockType));
+                    continue;
+                }
+                else if (blocksToItemReplacements.containsKey(blockType)) {
+                    World world = block.getLocation().getWorld();
+                    if (world == null) {
+                        common.printDebugMessage("HERBICIDE: null world", null, null, true);
+                        continue;
+                    }
 
-        // kill any plant blocks in the radius
-        for (Block block : Ollivanders2Common.getBlocksInRadius(location, radius)) {
-            // kill crops
-            BlockData blockData = block.getBlockData();
-            if (blockData instanceof Ageable) {
-                ((Ageable)blockData).setAge(0);
-                block.setBlockData(blockData);
-                continue;
-            }
+                    world.dropItemNaturally(block.getLocation(), new ItemStack(blocksToItemReplacements.get(blockType)));
+                    continue;
+                }
 
-            // replace other plant blocks with "dead" alternatives
-            Material blockType = block.getType();
-            if (blocksReplacements.containsKey(blockType)) {
-                block.setType(blocksReplacements.get(blockType));
+                // kill crops
+                BlockData blockData = block.getBlockData();
+                if (blockData instanceof Ageable) {
+                    ((Ageable) blockData).setAge(0);
+                    block.setBlockData(blockData);
+                }
             }
         }
+
+        age();
     }
 
     @Override

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpellType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpellType.java
@@ -32,6 +32,10 @@ public enum O2StationarySpellType {
      */
     HARMONIA_NECTERE_PASSUS(HARMONIA_NECTERE_PASSUS.class, MagicLevel.EXPERT),
     /**
+     * {@link HERBICIDE}
+     */
+    HERBICIDE(HERBICIDE.class, MagicLevel.BEGINNER),
+    /**
      * {@link HORCRUX}
      */
     HORCRUX(HORCRUX.class, MagicLevel.EXPERT),

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/ThrownPotionStationarySpell.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/ThrownPotionStationarySpell.java
@@ -1,0 +1,67 @@
+package net.pottercraft.ollivanders2.stationaryspell;
+
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public abstract class ThrownPotionStationarySpell extends O2StationarySpell {
+    /**
+     * A list of the worldguard permissions needed for this spell
+     */
+    List<StateFlag> worldGuardFlags = new ArrayList<>();
+
+    /**
+     * Simple constructor used for deserializing saved stationary spells at server start. Do not use to cast spell.
+     *
+     * @param plugin a callback to the MC plugin
+     */
+    public ThrownPotionStationarySpell(@NotNull Ollivanders2 plugin) {
+        super(plugin);
+    }
+
+    /**
+     * Simple constructor used for deserializing saved stationary spells at server start. Do not use to cast spell.
+     *
+     * @param plugin   a callback to the MC plugin
+     * @param pid      the player who cast the spell
+     * @param location the center location of the spell
+     */
+    public ThrownPotionStationarySpell(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location) {
+        super(plugin, pid, location);
+    }
+
+    /**
+     * Checks world guard, if enabled, to determine if this spell can be cast here by this player. Normally stationary
+     * spells don't need to check this because they are cast by O2Spells which check this for them but this stationary
+     * spell is a thrown potion effect
+     */
+    protected void checkWorldGuard() {
+        if (!Ollivanders2.worldGuardEnabled)
+            return;
+
+        Player caster = p.getServer().getPlayer(playerUUID);
+        if (caster == null) {
+            kill();
+            return;
+        }
+
+        for (StateFlag flag : worldGuardFlags) { // check every flag relevant to this spell
+            for (Block block : Ollivanders2Common.getBlocksInRadius(location, radius)) { // check at every block location in the spell's radius
+                if (!Ollivanders2.worldGuardO2.checkWGFlag(caster, block.getLocation(), flag)) {
+                    common.printDebugMessage(spellType.toString() + " cannot be cast because of WorldGuard flag " + flag, null, null, false);
+
+                    kill();
+                    return;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Herbicide rework
- added to herbicide affecting plant blocks in the area of the thrown potion
- added new stationary spell type for affecting an area from a potion splash
- updated plugin to MC 1.21.7

https://github.com/Azami7/Ollivanders2/issues/595