### PR TITLE
Unit tests

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
@@ -1093,7 +1093,7 @@ public class Ollivanders2 extends JavaPlugin {
             if (amount > 64)
                 amount = 64;
 
-            String itemName = Ollivanders2Common.stringArrayToString(Arrays.copyOfRange(args, 3, args.length));
+            String itemName = String.join(" ", Arrays.copyOfRange(args, 3, args.length));
             ItemStack item = items.getItemStartsWith(itemName, amount);
 
             if (item == null) {
@@ -1446,7 +1446,7 @@ public class Ollivanders2 extends JavaPlugin {
                     else if (sender instanceof Player) {
                         // potion ingredient mandrake leaf
                         String[] subArgs = Arrays.copyOfRange(args, 2, args.length);
-                        return giveItem((Player) sender, Ollivanders2Common.stringArrayToString(subArgs));
+                        return giveItem((Player) sender, String.join(" ", subArgs));
                     }
                     else
                         return false;
@@ -1468,7 +1468,7 @@ public class Ollivanders2 extends JavaPlugin {
 
                         if (targetPlayer != null) {
                             String[] subArgs = Arrays.copyOfRange(args, 3, args.length);
-                            return givePotion((Player) sender, targetPlayer, Ollivanders2Common.stringArrayToString(subArgs));
+                            return givePotion((Player) sender, targetPlayer, String.join(" ", subArgs));
                         }
                     }
                 }
@@ -1479,7 +1479,7 @@ public class Ollivanders2 extends JavaPlugin {
                 if (sender instanceof Player) {
                     // potions memory potion
                     String[] subArgs = Arrays.copyOfRange(args, 1, args.length);
-                    return givePotion((Player) sender, (Player) sender, Ollivanders2Common.stringArrayToString(subArgs));
+                    return givePotion((Player) sender, (Player) sender, String.join(" ", subArgs));
                 }
                 else
                     return false;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/O2Books.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/O2Books.java
@@ -534,7 +534,7 @@ public final class O2Books implements Listener {
      */
     @Nullable
     private ItemStack getBookFromArgs(@NotNull String[] args, @NotNull CommandSender sender) {
-        String title = Ollivanders2Common.stringArrayToString(args);
+        String title = String.join(" ", args);
 
         ItemStack bookItem = getBookByTitle(title);
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/common/EntityCommon.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/common/EntityCommon.java
@@ -6,7 +6,6 @@ import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
-import org.bukkit.entity.Bee;
 import org.bukkit.entity.Cat;
 import org.bukkit.entity.Enemy;
 import org.bukkit.entity.Entity;
@@ -15,18 +14,15 @@ import org.bukkit.entity.Horse;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Llama;
+import org.bukkit.entity.Mob;
 import org.bukkit.entity.Parrot;
-import org.bukkit.entity.PigZombie;
 import org.bukkit.entity.Rabbit;
-import org.bukkit.entity.Wolf;
 import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -62,8 +58,12 @@ public class EntityCommon {
         add(EntityDamageEvent.DamageCause.ENTITY_ATTACK);
         add(EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK);
         add(EntityDamageEvent.DamageCause.ENTITY_EXPLOSION);
+        add(EntityDamageEvent.DamageCause.MAGIC);
+        add(EntityDamageEvent.DamageCause.POISON);
         add(EntityDamageEvent.DamageCause.PROJECTILE);
+        add(EntityDamageEvent.DamageCause.SONIC_BOOM);
         add(EntityDamageEvent.DamageCause.THORNS);
+        add(EntityDamageEvent.DamageCause.WITHER);
     }};
 
     /**
@@ -90,7 +90,7 @@ public class EntityCommon {
         add(EntityType.CHERRY_BOAT);
         add(EntityType.CHERRY_CHEST_BOAT);
         add(EntityType.DARK_OAK_BOAT);
-        add(EntityType.DARK_OAK_BOAT);
+        add(EntityType.DARK_OAK_CHEST_BOAT);
         add(EntityType.JUNGLE_BOAT);
         add(EntityType.JUNGLE_CHEST_BOAT);
         add(EntityType.MANGROVE_BOAT);
@@ -103,53 +103,6 @@ public class EntityCommon {
         add(EntityType.SPRUCE_CHEST_BOAT);
         add(EntityType.BAMBOO_RAFT);
         add(EntityType.BAMBOO_CHEST_RAFT);
-    }};
-
-    /**
-     * The magic level for every potion effect type, primarily for use with Finite Incantatum
-     * <p>
-     * {@link net.pottercraft.ollivanders2.spell.FINITE_INCANTATEM}
-     */
-    static HashMap<PotionEffectType, MagicLevel> potionEffectLevels = new HashMap<>() {{
-        put(PotionEffectType.ABSORPTION, MagicLevel.OWL);
-        put(PotionEffectType.BAD_OMEN, MagicLevel.NEWT);
-        put(PotionEffectType.BLINDNESS, MagicLevel.OWL);
-        put(PotionEffectType.CONDUIT_POWER, MagicLevel.NEWT);
-        put(PotionEffectType.DARKNESS, MagicLevel.OWL);
-        put(PotionEffectType.DOLPHINS_GRACE, MagicLevel.NEWT);
-        put(PotionEffectType.FIRE_RESISTANCE, MagicLevel.NEWT);
-        put(PotionEffectType.GLOWING, MagicLevel.BEGINNER);
-        put(PotionEffectType.HASTE, MagicLevel.BEGINNER);
-        put(PotionEffectType.HEALTH_BOOST, MagicLevel.NEWT);
-        put(PotionEffectType.HERO_OF_THE_VILLAGE, MagicLevel.NEWT);
-        put(PotionEffectType.HUNGER, MagicLevel.BEGINNER);
-        put(PotionEffectType.INFESTED, MagicLevel.OWL);
-        put(PotionEffectType.INSTANT_DAMAGE, MagicLevel.OWL);
-        put(PotionEffectType.INSTANT_HEALTH, MagicLevel.OWL);
-        put(PotionEffectType.INVISIBILITY, MagicLevel.EXPERT);
-        put(PotionEffectType.JUMP_BOOST, MagicLevel.BEGINNER);
-        put(PotionEffectType.LEVITATION, MagicLevel.OWL);
-        put(PotionEffectType.LUCK, MagicLevel.BEGINNER);
-        put(PotionEffectType.MINING_FATIGUE, MagicLevel.BEGINNER);
-        put(PotionEffectType.NAUSEA, MagicLevel.OWL);
-        put(PotionEffectType.NIGHT_VISION, MagicLevel.BEGINNER);
-        put(PotionEffectType.OOZING, MagicLevel.OWL);
-        put(PotionEffectType.POISON, MagicLevel.OWL);
-        put(PotionEffectType.RAID_OMEN, MagicLevel.NEWT);
-        put(PotionEffectType.REGENERATION, MagicLevel.NEWT);
-        put(PotionEffectType.RESISTANCE, MagicLevel.NEWT);
-        put(PotionEffectType.SATURATION, MagicLevel.BEGINNER);
-        put(PotionEffectType.SLOW_FALLING, MagicLevel.NEWT);
-        put(PotionEffectType.SLOWNESS, MagicLevel.BEGINNER);
-        put(PotionEffectType.SPEED, MagicLevel.BEGINNER);
-        put(PotionEffectType.STRENGTH, MagicLevel.NEWT);
-        put(PotionEffectType.TRIAL_OMEN, MagicLevel.NEWT);
-        put(PotionEffectType.UNLUCK, MagicLevel.BEGINNER);
-        put(PotionEffectType.WATER_BREATHING, MagicLevel.NEWT);
-        put(PotionEffectType.WEAKNESS, MagicLevel.OWL);
-        put(PotionEffectType.WEAVING, MagicLevel.OWL);
-        put(PotionEffectType.WIND_CHARGED, MagicLevel.OWL);
-        put(PotionEffectType.WITHER, MagicLevel.NEWT);
     }};
 
     /**
@@ -297,18 +250,6 @@ public class EntityCommon {
     }
 
     /**
-     * Gets item entities within radius of the projectile
-     *
-     * @param location the location to check
-     * @param radius   radius within which to get entities
-     * @return List of item entities within one block of projectile
-     */
-    @NotNull
-    static public List<Item> getItems(@NotNull Location location, double radius) {
-        return getItemsInBounds(location, radius, radius, radius);
-    }
-
-    /**
      * Get an item by material
      *
      * @param location the location to check
@@ -318,7 +259,7 @@ public class EntityCommon {
      */
     @Nullable
     static public Item getNearbyItemByMaterial(@NotNull Location location, @NotNull Material material, double radius) {
-        List<Item> items = getItems(location, radius);
+        List<Item> items = getItemsInRadius(location, radius);
 
         for (Item item : items) {
             if (item.getItemStack().getType() == material)
@@ -338,7 +279,7 @@ public class EntityCommon {
      */
     @Nullable
     static public Item getNearbyItemByMaterialList(@NotNull Location location, @NotNull ArrayList<Material> materials, double radius) {
-        List<Item> items = getItems(location, radius);
+        List<Item> items = getItemsInRadius(location, radius);
 
         for (Item item : items) {
             if (materials.contains(item.getItemStack().getType()))
@@ -357,8 +298,8 @@ public class EntityCommon {
      * @return the item if found, null otherwise
      */
     @Nullable
-    static public Item getNearbyItemByType(@NotNull Location location, @NotNull O2ItemType itemType, double radius) {
-        List<Item> items = getItems(location, radius);
+    static public Item getNearbyO2ItemByType(@NotNull Location location, @NotNull O2ItemType itemType, double radius) {
+        List<Item> items = getItemsInRadius(location, radius);
 
         for (Item item : items) {
             if (itemType.isItemThisType(item))
@@ -376,6 +317,10 @@ public class EntityCommon {
      */
     @NotNull
     static public Cat.Type getRandomCatType(int seed) {
+        seed = Math.abs(seed);
+        if (seed == 0)
+            seed = 1;
+
         int rand = Math.abs(Ollivanders2Common.random.nextInt(seed)) % 11;
 
         Cat.Type type;
@@ -426,7 +371,7 @@ public class EntityCommon {
      */
     @NotNull
     static public Cat.Type getRandomCatType() {
-        return getRandomCatType((int) TimeCommon.getDefaultWorldTime());
+        return getRandomCatType((int)TimeCommon.getDefaultWorldTime());
     }
 
     /**
@@ -438,6 +383,10 @@ public class EntityCommon {
     @NotNull
     static public Rabbit.Type getRandomRabbitType(int seed) {
         Rabbit.Type type;
+
+        seed = Math.abs(seed);
+        if (seed == 0)
+            seed = 1;
 
         int rand = Math.abs(Ollivanders2Common.random.nextInt(seed)) % 61;
 
@@ -478,6 +427,10 @@ public class EntityCommon {
     @NotNull
     static public Horse.Style getRandomHorseStyle(int seed) {
         Horse.Style style;
+
+        seed = Math.abs(seed);
+        if (seed == 0)
+            seed = 1;
 
         int rand = Math.abs(Ollivanders2Common.random.nextInt(seed)) % 20;
 
@@ -521,6 +474,10 @@ public class EntityCommon {
     @NotNull
     static public Horse.Color getRandomHorseColor(int seed) {
         Horse.Color color;
+
+        seed = Math.abs(seed);
+        if (seed == 0)
+            seed = 1;
 
         int rand = Math.abs(Ollivanders2Common.random.nextInt(seed)) % 7;
 
@@ -571,6 +528,10 @@ public class EntityCommon {
     static public Llama.Color getRandomLlamaColor(int seed) {
         Llama.Color color;
 
+        seed = Math.abs(seed);
+        if (seed == 0)
+            seed = 1;
+
         int rand = Math.abs(Ollivanders2Common.random.nextInt(seed)) % 4;
 
         switch (rand) {
@@ -608,8 +569,12 @@ public class EntityCommon {
      * @return the color
      */
     @NotNull
-    static public Parrot.Variant getRandomParrotColor(int seed) {
+    static public Parrot.Variant getRandomParrotVariant(int seed) {
         Parrot.Variant variant;
+
+        seed = Math.abs(seed);
+        if (seed == 0)
+            seed = 1;
 
         int rand = Math.abs(Ollivanders2Common.random.nextInt(seed)) % 5;
 
@@ -639,8 +604,8 @@ public class EntityCommon {
      * @return the color
      */
     @NotNull
-    static public Parrot.Variant getRandomParrotColor() {
-        return getRandomParrotColor((int) TimeCommon.getDefaultWorldTime());
+    static public Parrot.Variant getRandomParrotVariant() {
+        return getRandomParrotVariant((int) TimeCommon.getDefaultWorldTime());
     }
 
     /**
@@ -651,6 +616,10 @@ public class EntityCommon {
      */
     @NotNull
     static public DyeColor getRandomNaturalSheepColor(int seed) {
+        seed = Math.abs(seed);
+        if (seed == 0)
+            seed = 1;
+
         int rand = Math.abs(Ollivanders2Common.random.nextInt(seed)) % 100;
 
         if (rand < 2) // 2% chance
@@ -674,20 +643,6 @@ public class EntityCommon {
     }
 
     /**
-     * Get the magic effect level for MC Potion Effects.
-     *
-     * @param potionEffectType the effect type to get the level of
-     * @return the effect type level or OWL if it is not explicitly defined
-     */
-    @NotNull
-    static public MagicLevel getPotionEffectMagicLevel(@NotNull PotionEffectType potionEffectType) {
-        if (potionEffectLevels.containsKey(potionEffectType))
-            return potionEffectLevels.get(potionEffectType);
-        else
-            return MagicLevel.OWL;
-    }
-
-    /**
      * Is this living entity a hostile? This assumes Player entities are not hostile.
      *
      * @return true if it is a hostile or angry mob, false otherwise
@@ -698,16 +653,8 @@ public class EntityCommon {
         if (livingEntity instanceof Enemy)
             return true;
 
-        // are they an angry bee?
-        if (livingEntity instanceof Bee && ((Bee) livingEntity).getAnger() > 0)
-            return true;
-
-        // are they an angry wolf?
-        if (livingEntity instanceof Wolf && ((Wolf) livingEntity).isAngry())
-            return true;
-
-        // are they an angry zombie piglin?
-        if (livingEntity instanceof PigZombie && ((PigZombie) livingEntity).isAngry())
+        // are they a mob with a target set?
+        if (livingEntity instanceof Mob && ((Mob)livingEntity).getTarget() != null)
             return true;
 
         return false;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/common/TimeCommon.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/common/TimeCommon.java
@@ -59,7 +59,7 @@ public enum TimeCommon {
      * @return the time for the default world
      */
     static public long getDefaultWorldTime() {
-        return Bukkit.getServer().getWorlds().get(0).getFullTime();
+        return Bukkit.getServer().getWorlds().getFirst().getFullTime();
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/item/O2Items.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/item/O2Items.java
@@ -288,7 +288,7 @@ public class O2Items {
      * @return a nearby item of the type, if found, null otherwise
      */
     public Item getNearbyItemByO2ItemType(@NotNull Location location, @NotNull O2ItemType type, double radius) {
-        List<Item> items = EntityCommon.getItems(location, radius);
+        List<Item> items = EntityCommon.getItemsInRadius(location, radius);
 
         for (Item item : items) {
             // is this item the O2ItemType?

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2Potions.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2Potions.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
 
+import net.pottercraft.ollivanders2.common.MagicLevel;
 import net.pottercraft.ollivanders2.item.O2ItemType;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
@@ -22,6 +23,7 @@ import org.bukkit.Material;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -115,6 +117,53 @@ public class O2Potions {
         add(O2ItemType.VALERIAN_SPRIGS);
         add(O2ItemType.VALERIAN_ROOT);
         add(O2ItemType.WOLFSBANE);
+    }};
+
+    /**
+     * The magic level for every minecraft potion effect type, primarily for use with Finite Incantatum
+     * <p>
+     * {@link net.pottercraft.ollivanders2.spell.FINITE_INCANTATEM}
+     */
+    static HashMap<PotionEffectType, MagicLevel> potionEffectLevels = new HashMap<>() {{
+        put(PotionEffectType.ABSORPTION, MagicLevel.OWL);
+        put(PotionEffectType.BAD_OMEN, MagicLevel.NEWT);
+        put(PotionEffectType.BLINDNESS, MagicLevel.OWL);
+        put(PotionEffectType.CONDUIT_POWER, MagicLevel.NEWT);
+        put(PotionEffectType.DARKNESS, MagicLevel.OWL);
+        put(PotionEffectType.DOLPHINS_GRACE, MagicLevel.NEWT);
+        put(PotionEffectType.FIRE_RESISTANCE, MagicLevel.NEWT);
+        put(PotionEffectType.GLOWING, MagicLevel.BEGINNER);
+        put(PotionEffectType.HASTE, MagicLevel.BEGINNER);
+        put(PotionEffectType.HEALTH_BOOST, MagicLevel.NEWT);
+        put(PotionEffectType.HERO_OF_THE_VILLAGE, MagicLevel.NEWT);
+        put(PotionEffectType.HUNGER, MagicLevel.BEGINNER);
+        put(PotionEffectType.INFESTED, MagicLevel.OWL);
+        put(PotionEffectType.INSTANT_DAMAGE, MagicLevel.OWL);
+        put(PotionEffectType.INSTANT_HEALTH, MagicLevel.OWL);
+        put(PotionEffectType.INVISIBILITY, MagicLevel.EXPERT);
+        put(PotionEffectType.JUMP_BOOST, MagicLevel.BEGINNER);
+        put(PotionEffectType.LEVITATION, MagicLevel.OWL);
+        put(PotionEffectType.LUCK, MagicLevel.BEGINNER);
+        put(PotionEffectType.MINING_FATIGUE, MagicLevel.BEGINNER);
+        put(PotionEffectType.NAUSEA, MagicLevel.OWL);
+        put(PotionEffectType.NIGHT_VISION, MagicLevel.BEGINNER);
+        put(PotionEffectType.OOZING, MagicLevel.OWL);
+        put(PotionEffectType.POISON, MagicLevel.OWL);
+        put(PotionEffectType.RAID_OMEN, MagicLevel.NEWT);
+        put(PotionEffectType.REGENERATION, MagicLevel.NEWT);
+        put(PotionEffectType.RESISTANCE, MagicLevel.NEWT);
+        put(PotionEffectType.SATURATION, MagicLevel.BEGINNER);
+        put(PotionEffectType.SLOW_FALLING, MagicLevel.NEWT);
+        put(PotionEffectType.SLOWNESS, MagicLevel.BEGINNER);
+        put(PotionEffectType.SPEED, MagicLevel.BEGINNER);
+        put(PotionEffectType.STRENGTH, MagicLevel.NEWT);
+        put(PotionEffectType.TRIAL_OMEN, MagicLevel.NEWT);
+        put(PotionEffectType.UNLUCK, MagicLevel.BEGINNER);
+        put(PotionEffectType.WATER_BREATHING, MagicLevel.NEWT);
+        put(PotionEffectType.WEAKNESS, MagicLevel.OWL);
+        put(PotionEffectType.WEAVING, MagicLevel.OWL);
+        put(PotionEffectType.WIND_CHARGED, MagicLevel.OWL);
+        put(PotionEffectType.WITHER, MagicLevel.NEWT);
     }};
 
     /**
@@ -371,5 +420,19 @@ public class O2Potions {
      */
     public boolean isLoaded(@NotNull O2PotionType potionType) {
         return O2PotionMap.containsValue(potionType);
+    }
+
+    /**
+     * Get the magic effect level for MC Potion Effects.
+     *
+     * @param potionEffectType the effect type to get the level of
+     * @return the effect type level or OWL if it is not explicitly defined
+     */
+    @NotNull
+    static public MagicLevel getPotionEffectMagicLevel(@NotNull PotionEffectType potionEffectType) {
+        if (potionEffectLevels.containsKey(potionEffectType))
+            return potionEffectLevels.get(potionEffectType);
+        else
+            return MagicLevel.OWL;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/AVIFORS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/AVIFORS.java
@@ -59,7 +59,7 @@ public final class AVIFORS extends FriendlyMobDisguise {
         disguiseType = DisguiseType.getType(targetType);
         disguise = new MobDisguise(disguiseType);
         ParrotWatcher watcher = (ParrotWatcher) disguise.getWatcher();
-        watcher.setVariant(EntityCommon.getRandomParrotColor());
+        watcher.setVariant(EntityCommon.getRandomParrotVariant());
         watcher.setFlyingWithElytra(true);
 
         initSpell();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/AVIS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/AVIS.java
@@ -99,7 +99,7 @@ public final class AVIS extends O2Spell {
             }
 
             Parrot bird = (Parrot) (world.spawnEntity(location, EntityType.PARROT));
-            bird.setVariant(EntityCommon.getRandomParrotColor());
+            bird.setVariant(EntityCommon.getRandomParrotVariant());
 
             birdsRemaining = birdsRemaining - 1;
         }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/DIFFINDO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/DIFFINDO.java
@@ -19,8 +19,7 @@ import org.jetbrains.annotations.NotNull;
  * @see <a href = "https://harrypotter.fandom.com/wiki/Severing_Charm">https://harrypotter.fandom.com/wiki/Severing_Charm</a>
  */
 // todo why does this spell do two totally unrelated things? fix this to align with books
-public final class DIFFINDO extends O2Spell
-{
+public final class DIFFINDO extends O2Spell {
     private static final int maxRadius = 20;
 
     /**
@@ -28,15 +27,13 @@ public final class DIFFINDO extends O2Spell
      *
      * @param plugin the Ollivanders2 plugin
      */
-    public DIFFINDO(Ollivanders2 plugin)
-    {
+    public DIFFINDO(Ollivanders2 plugin) {
         super(plugin);
 
         spellType = O2SpellType.DIFFINDO;
         branch = O2MagicBranch.CHARMS;
 
-        flavorText = new ArrayList<>()
-        {{
+        flavorText = new ArrayList<>() {{
             add("The Severing Charm");
             add("With the Severing Charm, cutting or tearing objects is a simple matter of wand control.");
             add("The spell can be quite precise in skilled hands, and the Severing Charm is widely used in a variety of wizarding trades.");
@@ -52,15 +49,13 @@ public final class DIFFINDO extends O2Spell
      * @param player    the player who cast this spell
      * @param rightWand which wand the player was using
      */
-    public DIFFINDO(@NotNull Ollivanders2 plugin, @NotNull Player player, @NotNull Double rightWand)
-    {
+    public DIFFINDO(@NotNull Ollivanders2 plugin, @NotNull Player player, @NotNull Double rightWand) {
         super(plugin, player, rightWand);
         spellType = O2SpellType.DIFFINDO;
         branch = O2MagicBranch.CHARMS;
 
         // world guard flags
-        if (Ollivanders2.worldGuardEnabled)
-        {
+        if (Ollivanders2.worldGuardEnabled) {
             worldGuardFlags.add(Flags.PVP);
             worldGuardFlags.add(Flags.BUILD);
             worldGuardFlags.add(Flags.ITEM_DROP);
@@ -73,14 +68,12 @@ public final class DIFFINDO extends O2Spell
      * Split a log or a player's inventory
      */
     @Override
-    protected void doCheckEffect()
-    {
+    protected void doCheckEffect() {
         // first check for players
         splitBackpack();
 
         // next check for log
-        if (hasHitTarget() && !isKilled())
-        {
+        if (hasHitTarget() && !isKilled()) {
             splitLogs();
             kill();
         }
@@ -89,25 +82,21 @@ public final class DIFFINDO extends O2Spell
     /**
      * Split a player's inventory open and make items fall out
      */
-    private void splitBackpack()
-    {
+    private void splitBackpack() {
         List<Player> players = getNearbyPlayers(defaultRadius);
 
-        for (Player plyr : players)
-        {
+        for (Player plyr : players) {
             if (plyr.getUniqueId() == player.getUniqueId())
                 continue;
 
             PlayerInventory inv = plyr.getInventory();
             ArrayList<ItemStack> remStack = new ArrayList<>();
-            for (ItemStack stack : inv.getContents())
-            {
+            for (ItemStack stack : inv.getContents()) {
                 // 0-99% chance of this item being dropped, based on usesModifier where 200 casts gives 99% chance
                 if ((usesModifier / 2) > ((Math.abs(Ollivanders2Common.random.nextInt()) % 100) + 1))
                     remStack.add(stack);
             }
-            for (ItemStack rem : remStack)
-            {
+            for (ItemStack rem : remStack) {
                 inv.remove(rem);
                 plyr.getWorld().dropItemNaturally(plyr.getLocation(), rem);
             }
@@ -120,8 +109,7 @@ public final class DIFFINDO extends O2Spell
     /**
      * Split logs within a radius of the spell target location
      */
-    private void splitLogs()
-    {
+    private void splitLogs() {
         double radius = usesModifier / 4;
         if (radius < 1)
             radius = 1;
@@ -130,21 +118,16 @@ public final class DIFFINDO extends O2Spell
 
 
         Block target = getTargetBlock();
-        if (target == null)
-        {
+        if (target == null) {
             common.printDebugMessage("DIFFINDO.doCheckEffect: target block is null", null, null, false);
             kill();
             return;
         }
 
-        if (Ollivanders2Common.isNaturalLog(target))
-        {
-            for (Block nearbyBlock : Ollivanders2Common.getBlocksInRadius(location, radius))
-            {
-                if (Ollivanders2Common.isNaturalLog(nearbyBlock))
-                {
+        if (Ollivanders2Common.naturalLogs.contains(target)) {
+            for (Block nearbyBlock : Ollivanders2Common.getBlocksInRadius(location, radius)) {
+                if (Ollivanders2Common.naturalLogs.contains(nearbyBlock))
                     nearbyBlock.breakNaturally();
-                }
             }
         }
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/FINITE_INCANTATEM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/FINITE_INCANTATEM.java
@@ -5,10 +5,10 @@ import java.util.Collection;
 
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.common.EntityCommon;
 import net.pottercraft.ollivanders2.common.MagicLevel;
 import net.pottercraft.ollivanders2.effect.O2EffectType;
 import net.pottercraft.ollivanders2.item.enchantment.ItemEnchantmentType;
+import net.pottercraft.ollivanders2.potion.O2Potions;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -129,7 +129,7 @@ public final class FINITE_INCANTATEM extends O2Spell {
                 Collection<PotionEffect> potionEffects = live.getActivePotionEffects();
 
                 for (PotionEffect effect : potionEffects) {
-                    MagicLevel level = EntityCommon.getPotionEffectMagicLevel(effect.getType());
+                    MagicLevel level = O2Potions.getPotionEffectMagicLevel(effect.getType());
 
                     if (level.ordinal() <= spellType.getLevel().ordinal())
                         player.removePotionEffect(effect.getType());

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/FRANGE_LIGNEA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/FRANGE_LIGNEA.java
@@ -75,7 +75,7 @@ public final class FRANGE_LIGNEA extends O2Spell {
         if (target == null)
             return;
 
-        if (Ollivanders2Common.isNaturalLog(target)) {
+        if (Ollivanders2Common.naturalLogs.contains(target)) {
             // break the log in to the correct wand core type
             O2WandWoodType woodType = O2WandWoodType.getWandWoodTypeByMaterial(target.getType());
             if (woodType == null) {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/LIGATIS_COR.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/LIGATIS_COR.java
@@ -71,7 +71,7 @@ public final class LIGATIS_COR extends O2Spell {
         }
 
         // is there a wand nearby?
-        Item baseWand = EntityCommon.getNearbyItemByType(location, O2ItemType.WAND, 1.5);
+        Item baseWand = EntityCommon.getNearbyO2ItemByType(location, O2ItemType.WAND, 1.5);
         if (baseWand == null)
             return;
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spell.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spell.java
@@ -445,7 +445,7 @@ public abstract class O2Spell {
      */
     @NotNull
     public List<Item> getItems(double radius) {
-        return EntityCommon.getItems(location, radius);
+        return EntityCommon.getItemsInRadius(location, radius);
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/ALIQUAM_FLOO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/ALIQUAM_FLOO.java
@@ -155,7 +155,7 @@ public class ALIQUAM_FLOO extends O2StationarySpell {
             }
         }
         else {
-            for (Item item : EntityCommon.getItems(location, 1)) {
+            for (Item item : EntityCommon.getItemsInRadius(location, 1)) {
                 if (!O2ItemType.FLOO_POWDER.isItemThisType(item))
                     continue;
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HORCRUX.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HORCRUX.java
@@ -194,7 +194,7 @@ public class HORCRUX extends O2StationarySpell {
     void doOnPlayerJoinEvent(@NotNull PlayerJoinEvent event) {
         if (!itemLoaded) {
             // did the game respawn the item?
-            for (Item itemsAtLocation : EntityCommon.getItems(location, 1)) {
+            for (Item itemsAtLocation : EntityCommon.getItemsInRadius(location, 1)) {
                 if (itemsAtLocation.getItemStack().getType() == horcruxMaterial) {
                     horcruxItem = itemsAtLocation;
                     return;

--- a/Ollivanders/test/java/ollivanders/book/ABeginnersGuideToTransfigurationTest.java
+++ b/Ollivanders/test/java/ollivanders/book/ABeginnersGuideToTransfigurationTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class ABeginnersGuideToTransfigurationTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new A_BEGINNERS_GUIDE_TO_TRANSFIGURATION(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/AchievementsInCharmingTest.java
+++ b/Ollivanders/test/java/ollivanders/book/AchievementsInCharmingTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class AchievementsInCharmingTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new ACHIEVEMENTS_IN_CHARMING(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/AdvancedFireworksTest.java
+++ b/Ollivanders/test/java/ollivanders/book/AdvancedFireworksTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class AdvancedFireworksTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new ADVANCED_FIREWORKS(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/AdvancedPotionMakingTest.java
+++ b/Ollivanders/test/java/ollivanders/book/AdvancedPotionMakingTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class AdvancedPotionMakingTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new ADVANCED_POTION_MAKING(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/AdvancedTransfigurationTest.java
+++ b/Ollivanders/test/java/ollivanders/book/AdvancedTransfigurationTest.java
@@ -22,14 +22,6 @@ import java.io.File;
 public class AdvancedTransfigurationTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-
-        // load dependency plugins first
-        MockBukkit.loadWith(LibsDisguisesMock.class, new File("Ollivanders/test/resources/mocks/LibsDisguises/plugin.yml"));
-
-        // load plugin
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new ADVANCED_TRANSFIGURATION(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/BasicFireworksTest.java
+++ b/Ollivanders/test/java/ollivanders/book/BasicFireworksTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class BasicFireworksTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new BASIC_FIREWORKS(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/BasicHexesTest.java
+++ b/Ollivanders/test/java/ollivanders/book/BasicHexesTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class BasicHexesTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new BASIC_HEXES(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/BookOfPotionsTest.java
+++ b/Ollivanders/test/java/ollivanders/book/BookOfPotionsTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class BookOfPotionsTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new BOOK_OF_POTIONS(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/BookTestSuper.java
+++ b/Ollivanders/test/java/ollivanders/book/BookTestSuper.java
@@ -1,12 +1,17 @@
 package ollivanders.book;
 
+import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.book.O2Book;
+import ollivanders.pluginDependencies.LibsDisguisesMock;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.MockBukkit;
+
+import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -15,6 +20,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 abstract public class BookTestSuper {
     O2Book book;
     BookMeta meta;
+    static Ollivanders2 testPlugin;
+
+    @BeforeAll
+    static void globalSetUp() {
+        MockBukkit.mock();
+        // load dependency plugins first
+        MockBukkit.loadWith(LibsDisguisesMock.class, new File("Ollivanders/test/resources/mocks/LibsDisguises/plugin.yml"));
+        // load plugin
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
+    }
 
     abstract void setUp();
 
@@ -122,8 +137,8 @@ abstract public class BookTestSuper {
         assertFalse(meta.getAuthor().isEmpty(), "Author should not be empty");
     }
 
-    @AfterEach
-    void tearDown() {
+    @AfterAll
+    static void globalTearDown() {
         MockBukkit.unmock();
     }
 }

--- a/Ollivanders/test/java/ollivanders/book/BreakWithABansheeTest.java
+++ b/Ollivanders/test/java/ollivanders/book/BreakWithABansheeTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class BreakWithABansheeTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new BREAK_WITH_A_BANSHEE(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/ChadwicksCharmsVolume1Test.java
+++ b/Ollivanders/test/java/ollivanders/book/ChadwicksCharmsVolume1Test.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class ChadwicksCharmsVolume1Test extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new CHADWICKS_CHARMS_VOLUME_1(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/CharmingColorsTest.java
+++ b/Ollivanders/test/java/ollivanders/book/CharmingColorsTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class CharmingColorsTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new CHARMING_COLORS(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/ConfrontingTheFacelessTest.java
+++ b/Ollivanders/test/java/ollivanders/book/ConfrontingTheFacelessTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class ConfrontingTheFacelessTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new CONFRONTING_THE_FACELESS(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/CursesAndCountercursesTest.java
+++ b/Ollivanders/test/java/ollivanders/book/CursesAndCountercursesTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class CursesAndCountercursesTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new CURSES_AND_COUNTERCURSES(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/DeMedicinaPraeceptaTest.java
+++ b/Ollivanders/test/java/ollivanders/book/DeMedicinaPraeceptaTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class DeMedicinaPraeceptaTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new DE_MEDICINA_PRAECEPTA(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/DefenseAgainstTheDarkArtsTest.java
+++ b/Ollivanders/test/java/ollivanders/book/DefenseAgainstTheDarkArtsTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class DefenseAgainstTheDarkArtsTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new DEFENSE_AGAINST_THE_DARK_ARTS(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/EssentialDarkArtsTest.java
+++ b/Ollivanders/test/java/ollivanders/book/EssentialDarkArtsTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class EssentialDarkArtsTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new ESSENTIAL_DARK_ARTS(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/ExtremeIncantationsTest.java
+++ b/Ollivanders/test/java/ollivanders/book/ExtremeIncantationsTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class ExtremeIncantationsTest extends BookTestSuper {
    @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new EXTREME_INCANTATIONS(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/ForTheGreaterGoodTest.java
+++ b/Ollivanders/test/java/ollivanders/book/ForTheGreaterGoodTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class ForTheGreaterGoodTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new FOR_THE_GREATER_GOOD(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/GaddingWithGhoulsTest.java
+++ b/Ollivanders/test/java/ollivanders/book/GaddingWithGhoulsTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class GaddingWithGhoulsTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new GADDING_WITH_GHOULS(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/HarmoniousConnectionsTest.java
+++ b/Ollivanders/test/java/ollivanders/book/HarmoniousConnectionsTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class HarmoniousConnectionsTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new HARMONIOUS_CONNECTIONS(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/HolidaysWithHagsTest.java
+++ b/Ollivanders/test/java/ollivanders/book/HolidaysWithHagsTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class HolidaysWithHagsTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new HOLIDAYS_WITH_HAGS(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/IntermediateTransfigurationTest.java
+++ b/Ollivanders/test/java/ollivanders/book/IntermediateTransfigurationTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class IntermediateTransfigurationTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new INTERMEDIATE_TRANSFIGURATION(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/JinxesForTheJinxedTest.java
+++ b/Ollivanders/test/java/ollivanders/book/JinxesForTheJinxedTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class JinxesForTheJinxedTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new JINXES_FOR_THE_JINXED(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/MagicalDraftsAndPotionsTest.java
+++ b/Ollivanders/test/java/ollivanders/book/MagicalDraftsAndPotionsTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class MagicalDraftsAndPotionsTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new MAGICAL_DRAFTS_AND_POTIONS(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/MagickMosteEvileTest.java
+++ b/Ollivanders/test/java/ollivanders/book/MagickMosteEvileTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class MagickMosteEvileTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new MAGICK_MOSTE_EVILE(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/ModernMagicalTransportationTest.java
+++ b/Ollivanders/test/java/ollivanders/book/ModernMagicalTransportationTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class ModernMagicalTransportationTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new MODERN_MAGICAL_TRANSPORTATION(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/MostePotentePotions.java
+++ b/Ollivanders/test/java/ollivanders/book/MostePotentePotions.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class MostePotentePotions extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new MOSTE_POTENTE_POTIONS(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/NumerologyAndGrammaticaTest.java
+++ b/Ollivanders/test/java/ollivanders/book/NumerologyAndGrammaticaTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class NumerologyAndGrammaticaTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new NUMEROLOGY_AND_GRAMMATICA(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/O2BookTest.java
+++ b/Ollivanders/test/java/ollivanders/book/O2BookTest.java
@@ -11,8 +11,8 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.ServerMock;
@@ -34,14 +34,16 @@ public class O2BookTest {
     static Ollivanders2 testPlugin;
     static ServerMock mockServer;
 
-    @BeforeEach
-    void setUp () {
+    @BeforeAll
+    static void globalSetUp() {
         mockServer = MockBukkit.mock();
         testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
 
         // set up world
         testWorld = mockServer.addSimpleWorld("world");
     }
+
+    void setUp() {}
 
     /**
      * Basic Constructor & Initialization Tests
@@ -276,8 +278,8 @@ public class O2BookTest {
         assertTrue(found);
     }
 
-    @AfterEach
-    void tearDown () {
+    @AfterAll
+    static void globalTearDown () {
         MockBukkit.unmock();
     }
 }

--- a/Ollivanders/test/java/ollivanders/book/O2BooksTest.java
+++ b/Ollivanders/test/java/ollivanders/book/O2BooksTest.java
@@ -7,7 +7,7 @@ import net.pottercraft.ollivanders2.book.O2Books;
 import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.player.O2Player;
 import net.pottercraft.ollivanders2.spell.O2SpellType;
-import ollivanders.TestCommon;
+import ollivanders.testcommon.TestCommon;
 import ollivanders.pluginDependencies.LibsDisguisesMock;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
@@ -33,15 +33,20 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Unit tests for O2Books.java
+ * Unit tests for O2Books.java.
+ * Tests book retrieval, book learning mechanics, and book-related commands.
  */
 public class O2BooksTest {
     static Ollivanders2 testPlugin;
     static ServerMock mockServer;
     static O2Books books;
 
+    /**
+     * Set up the mock server, load dependency plugins, load the main plugin with test config,
+     * and get the books instance from the plugin.
+     */
     @BeforeAll
-    static void setUp () {
+    static void globalSetUp () {
         mockServer = MockBukkit.mock();
 
         // load dependency plugins first
@@ -64,6 +69,12 @@ public class O2BooksTest {
         assertTrue(mockServer.getPluginManager().isPluginEnabled("LibsDisguises"));
     }
 
+    /**
+     * Test that reading a book triggers the book learning mechanic and increases
+     * the player's spell level for spells contained in that book.
+     * This test simulates a player right-clicking with a book and verifies the
+     * spell count increases after scheduled tasks execute.
+     */
     @Test
     void onBookReadTest() throws InterruptedException {
         // make sure bookLearning is on in the config
@@ -96,6 +107,10 @@ public class O2BooksTest {
         assertNotEquals(spellLevel, o2p.getSpellCount(O2SpellType.LUMOS), "Spell level did not change after book was read.");
     }
 
+    /**
+     * Test that getBookByTitle correctly retrieves a book by its full title
+     * and returns a valid WRITTEN_BOOK item with correct metadata.
+     */
     @Test
     void getBookByTitleTest() {
         String title = O2BookType.STANDARD_BOOK_OF_SPELLS_GRADE_1.getTitle(testPlugin);
@@ -107,6 +122,10 @@ public class O2BooksTest {
         assertEquals(title, bookMeta.getTitle(), "book title incorrect.");
     }
 
+    /**
+     * Test that getBookByType correctly retrieves a book by its O2BookType enum value
+     * and returns a valid WRITTEN_BOOK item with correct metadata.
+     */
     @Test
     void getBookByTypeTest() {
         String title = O2BookType.STANDARD_BOOK_OF_SPELLS_GRADE_1.getTitle(testPlugin);
@@ -118,6 +137,11 @@ public class O2BooksTest {
         assertEquals(title, bookMeta.getTitle(), "book title incorrect.");
     }
 
+    /**
+     * Test that getBookTypeByTitle correctly retrieves a book type by title using
+     * various search methods: full title (case-sensitive), partial title, and
+     * case-insensitive matching.
+     */
     @Test
     void getBookTypeByTitleTest() {
         // try full title, case-sensitive
@@ -139,6 +163,10 @@ public class O2BooksTest {
         assertEquals(title, bookType.getTitle(testPlugin), "bookType.getTitle() does not match expected title");
     }
 
+    /**
+     * Test that getAllBooks returns a non-empty list containing all book types
+     * defined in the O2BookType enum.
+     */
     @Test
     void getAllBooksTest() {
         List<ItemStack> bookStack = books.getAllBooks();
@@ -146,6 +174,10 @@ public class O2BooksTest {
         assertEquals(O2BookType.values().length, bookStack.size(), "books.getAllBooks() did not return a list with all books");
     }
 
+    /**
+     * Test that getAllBookTitles returns a non-empty list containing the titles
+     * of all books defined in the O2BookType enum.
+     */
     @Test
     void getAllBookTitles() {
         List<String> bookTitles = books.getAllBookTitles();
@@ -197,6 +229,10 @@ public class O2BooksTest {
         assertTrue(TestCommon.isInPlayerInventory(player, Material.WRITTEN_BOOK));
     }
 
+    /**
+     * Test that the "/olli books list" command returns a list of all available books.
+     * The response should contain book titles from the loaded books.
+     */
     @Test
     void runCommandListTest() {
         PlayerMock player = mockServer.addPlayer("Steve");
@@ -207,6 +243,10 @@ public class O2BooksTest {
         assertTrue(commandResponse.contains("Standard Book of Spells"), "Ollivanders2 books list did not return list of loaded books");
     }
 
+    /**
+     * Test that the "/olli books give [player] [book title]" command successfully
+     * gives the specified book to the target player's inventory.
+     */
     @Test
     void runCommandGiveTest() {
         PlayerMock player = mockServer.addPlayer("Steve");
@@ -217,6 +257,10 @@ public class O2BooksTest {
         assertTrue(TestCommon.isInPlayerInventory(player2, Material.WRITTEN_BOOK, "Basic Hexes"), "Did not find the book in the player's inventory");
     }
 
+    /**
+     * Test that the "/olli books give [player] [book title]" command returns an
+     * appropriate error message when the specified player is not found on the server.
+     */
     @Test
     void runCommandGivePlayerNotFoundTest() {
         PlayerMock player = mockServer.addPlayer("Steve");
@@ -227,6 +271,10 @@ public class O2BooksTest {
         assertTrue(TestCommon.messageStartsWith("Did not find player", commandResponse), "Unexpected command response. Expected: \"Did not find player\", Actual: " + commandResponse);
     }
 
+    /**
+     * Test that the "/olli books give [player]" command (without book title)
+     * returns a usage message indicating the correct command syntax.
+     */
     @Test
     void runCommandGiveUsageTest() {
         PlayerMock player = mockServer.addPlayer("Steve");
@@ -237,6 +285,10 @@ public class O2BooksTest {
         assertTrue(TestCommon.messageStartsWith("Usage:", commandResponse), "Unexpected command response. Expected: \"Usage:\", Actual: " + commandResponse);
     }
 
+    /**
+     * Test that the "/olli books [book title]" command successfully gives the
+     * specified book to the command sender's inventory.
+     */
     @Test
     void runCommandBookTitleTest() {
         PlayerMock player = mockServer.addPlayer("Steve");
@@ -246,6 +298,10 @@ public class O2BooksTest {
         assertTrue(TestCommon.isInPlayerInventory(player, Material.WRITTEN_BOOK, "Basic Hexes"), "Did not find the book in the player's inventory");
     }
 
+    /**
+     * Test that the "/olli books [invalid book title]" command returns an
+     * appropriate error message when the specified book title doesn't exist.
+     */
     @Test
     void runCommandBookTitleDoesntExistTest() {
         PlayerMock player = mockServer.addPlayer("Steve");
@@ -256,8 +312,11 @@ public class O2BooksTest {
         assertTrue(TestCommon.messageStartsWith("No book named", commandResponse), "Unexpected command response. Expected: \"No book named\", Actual: " + commandResponse);
     }
 
+    /**
+     * Clean up the mock server after all tests have run.
+     */
     @AfterAll
-    static void tearDown() {
+    static void globalTearDown() {
         MockBukkit.unmock();
     }
 }

--- a/Ollivanders/test/java/ollivanders/book/OmensOraclesAndTheGoat.java
+++ b/Ollivanders/test/java/ollivanders/book/OmensOraclesAndTheGoat.java
@@ -25,9 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class OmensOraclesAndTheGoat extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new OMENS_ORACLES_AND_THE_GOAT(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/PotionOpusculeTest.java
+++ b/Ollivanders/test/java/ollivanders/book/PotionOpusculeTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class PotionOpusculeTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new POTION_OPUSCULE(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/PracticalDefensiveMagicTest.java
+++ b/Ollivanders/test/java/ollivanders/book/PracticalDefensiveMagicTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class PracticalDefensiveMagicTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new PRACTICAL_DEFENSIVE_MAGIC(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/QuintessenseAQuestTest.java
+++ b/Ollivanders/test/java/ollivanders/book/QuintessenseAQuestTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class QuintessenseAQuestTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new QUINTESSENCE_A_QUEST(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/SecretsOfTheDarkestArtTest.java
+++ b/Ollivanders/test/java/ollivanders/book/SecretsOfTheDarkestArtTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class SecretsOfTheDarkestArtTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new SECRETS_OF_THE_DARKEST_ART(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/SecretsOfWandloreTest.java
+++ b/Ollivanders/test/java/ollivanders/book/SecretsOfWandloreTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class SecretsOfWandloreTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new SECRETS_OF_WANDLORE(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/StandardBookOfSpellsGrade1Test.java
+++ b/Ollivanders/test/java/ollivanders/book/StandardBookOfSpellsGrade1Test.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class StandardBookOfSpellsGrade1Test extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new STANDARD_BOOK_OF_SPELLS_GRADE_1(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/StandardBookOfSpellsGrade2Test.java
+++ b/Ollivanders/test/java/ollivanders/book/StandardBookOfSpellsGrade2Test.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class StandardBookOfSpellsGrade2Test extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new STANDARD_BOOK_OF_SPELLS_GRADE_2(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/StandardBookOfSpellsGrade3Test.java
+++ b/Ollivanders/test/java/ollivanders/book/StandardBookOfSpellsGrade3Test.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class StandardBookOfSpellsGrade3Test extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new STANDARD_BOOK_OF_SPELLS_GRADE_3(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/StandardBookOfSpellsGrade4Test.java
+++ b/Ollivanders/test/java/ollivanders/book/StandardBookOfSpellsGrade4Test.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class StandardBookOfSpellsGrade4Test extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new STANDARD_BOOK_OF_SPELLS_GRADE_4(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/StandardBookOfSpellsGrade5Test.java
+++ b/Ollivanders/test/java/ollivanders/book/StandardBookOfSpellsGrade5Test.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class StandardBookOfSpellsGrade5Test extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new STANDARD_BOOK_OF_SPELLS_GRADE_5(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/StandardBookOfSpellsGrade6Test.java
+++ b/Ollivanders/test/java/ollivanders/book/StandardBookOfSpellsGrade6Test.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class StandardBookOfSpellsGrade6Test extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new STANDARD_BOOK_OF_SPELLS_GRADE_6(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/StandardBookOfSpellsGrade7Test.java
+++ b/Ollivanders/test/java/ollivanders/book/StandardBookOfSpellsGrade7Test.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class StandardBookOfSpellsGrade7Test extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new STANDARD_BOOK_OF_SPELLS_GRADE_7(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/TetrabibliosTest.java
+++ b/Ollivanders/test/java/ollivanders/book/TetrabibliosTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class TetrabibliosTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new TETRABIBLIOS(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/TheDarkForcesTest.java
+++ b/Ollivanders/test/java/ollivanders/book/TheDarkForcesTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class TheDarkForcesTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new THE_DARK_FORCES(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/TheHealersHelpmateTest.java
+++ b/Ollivanders/test/java/ollivanders/book/TheHealersHelpmateTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class TheHealersHelpmateTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new THE_HEALERS_HELPMATE(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/TravelsWithTrollsTest.java
+++ b/Ollivanders/test/java/ollivanders/book/TravelsWithTrollsTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class TravelsWithTrollsTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new TRAVELS_WITH_TROLLS(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/UnfoggingTheFutureTest.java
+++ b/Ollivanders/test/java/ollivanders/book/UnfoggingTheFutureTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class UnfoggingTheFutureTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new UNFOGGING_THE_FUTURE(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/VoyagesWithVampiresTest.java
+++ b/Ollivanders/test/java/ollivanders/book/VoyagesWithVampiresTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class VoyagesWithVampiresTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new VOYAGES_WITH_VAMPIRES(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/WanderingsWithWerewolvesTest.java
+++ b/Ollivanders/test/java/ollivanders/book/WanderingsWithWerewolvesTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class WanderingsWithWerewolvesTest extends BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new WANDERINGS_WITH_WEREWOLVES(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/book/YearWithAYetiTest.java
+++ b/Ollivanders/test/java/ollivanders/book/YearWithAYetiTest.java
@@ -21,9 +21,6 @@ import java.io.File;
 public class YearWithAYetiTest extends  BookTestSuper {
     @BeforeEach
     void setUp() {
-        MockBukkit.mock();
-        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/book_config.yml"));
-
         book = new YEAR_WITH_A_YETI(testPlugin);
         meta = (BookMeta) book.getBookItem().getItemMeta();
     }

--- a/Ollivanders/test/java/ollivanders/common/CuboidTest.java
+++ b/Ollivanders/test/java/ollivanders/common/CuboidTest.java
@@ -1,0 +1,120 @@
+package ollivanders.common;
+
+import net.pottercraft.ollivanders2.common.Cuboid;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the Cuboid class.
+ * Tests cuboid area validation, location checking, and parsing functionality.
+ */
+public class CuboidTest {
+    static ServerMock mockServer;
+    static final String worldName = "world";
+    static World testWorld;
+    static int[] cuboidArea = {0, 0, 0, 100, 100, 100};
+    static Cuboid testCuboid;
+
+    /**
+     * Set up the mock server, test world, and test cuboid before all tests.
+     */
+    @BeforeAll
+    static void globalSetUp () {
+        mockServer = MockBukkit.mock();
+        testWorld = mockServer.addSimpleWorld(worldName);
+
+        testCuboid = new Cuboid(worldName, cuboidArea);
+    }
+
+    /**
+     * Test that a location inside the cuboid is correctly identified as inside.
+     */
+    @Test
+    void isInsideTest() {
+        assertTrue(testCuboid.isInside(new Location(testWorld, 5, 5, 5)), "testCuboid.isInside(new Location(testWorld, 5, 5, 5) is false, expected true");
+    }
+
+    /**
+     * Test that a location in a different world is not considered inside the cuboid,
+     * even if the coordinates are within the cuboid's bounds.
+     */
+    @Test
+    void IsInsideWrongWorldTest() {
+        World anotherWorld = mockServer.addSimpleWorld("nether");
+        assertFalse(testCuboid.isInside(new Location (anotherWorld, 5, 5, 5)), "testCuboid.isInside(new Location (anotherWorld, 5, 5, 5) is true, expected false");
+    }
+
+    /**
+     * Test that a location with coordinates outside the cuboid's bounds is correctly
+     * identified as outside.
+     */
+    @Test
+    void isInsideCoordsOutsideTest() {
+        assertFalse(testCuboid.isInside(new Location(testWorld, 200, 200, 200)), "testCuboid.isInside(new Location(testWorld, 200, 200, 200) true, expected false");
+    }
+
+    /**
+     * Test that parseArea correctly converts a space-delimited string of coordinates
+     * into an integer array representing a cuboid area.
+     * Expected format: "x1 y1 z1 x2 y2 z2"
+     */
+    @Test
+    void parseAreaTest() {
+        // make an area array from a string of two x, y, z coordinates in the format "0 0 0 0 0 0"
+        int[] area = Cuboid.parseArea("0 0 0 100 100 100");
+        assertNotNull(area, "Cuboid.parseArea() created null area");
+        assertArrayEquals(area, cuboidArea, "Cuboid.parseArea() did not create expected area");
+    }
+
+    /**
+     * Test that parseArea returns null when given malformed input strings,
+     * including non-numeric strings and strings with incorrect delimiters.
+     */
+    @Test
+    void parseAreaMalformattedStringTest() {
+        int[] area = Cuboid.parseArea("this is not a numerical string");
+        assertNull(area, "Cuboid.parseArea() did not return null when given a non-numeric string");
+
+        area = Cuboid.parseArea("0, 0, 0, 0, 0, 0");
+        assertNull(area, "Cuboid.parseArea() did not return null when given a comma-delimited string");
+    }
+
+    /**
+     * Test that parseArea returns null when given a string with fewer than 6 numbers.
+     * A valid cuboid area requires exactly 6 coordinates.
+     */
+    @Test
+    void parseAreaTooFewNumbersTest() {
+        int[] area = Cuboid.parseArea("1 2 3 4 5");
+        assertNull(area, "Cuboid.parseArea() did not return null when given too few numbers");
+    }
+
+    /**
+     * Test that parseArea returns null when given a string with more than 6 numbers.
+     * A valid cuboid area requires exactly 6 coordinates.
+     */
+    @Test
+    void parseAreaTooManyNumbersTest() {
+        int[] area = Cuboid.parseArea("1 2 3 4 5 6 7");
+        assertNull(area, "Cuboid.parseArea() did not return null when given too many numbers");
+    }
+
+    /**
+     * Clean up the mock server after all tests have run.
+     */
+    @AfterAll
+    static void globalTearDown() {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/ollivanders/common/EntityCommonTest.java
+++ b/Ollivanders/test/java/ollivanders/common/EntityCommonTest.java
@@ -1,0 +1,452 @@
+package ollivanders.common;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.common.EntityCommon;
+import net.pottercraft.ollivanders2.item.O2ItemType;
+import org.bukkit.DyeColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.Bee;
+import org.bukkit.entity.Cat;
+import org.bukkit.entity.Cow;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Horse;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Llama;
+import org.bukkit.entity.Minecart;
+import org.bukkit.entity.Parrot;
+import org.bukkit.entity.Rabbit;
+import org.bukkit.entity.Zombie;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for EntityCommon class.
+ *
+ * Tests entity search methods, item search methods, random entity type generation,
+ * and hostility detection for various mob types.
+ */
+public class EntityCommonTest {
+    static ServerMock mockServer;
+    static Ollivanders2 testPlugin;
+    static EntityCommon entityCommon;
+    World testWorld;
+
+    /**
+     * Global test setup. Initializes MockBukkit server and loads the plugin with test configuration.
+     */
+    @BeforeAll
+    static void globalSetUp () {
+        mockServer = MockBukkit.mock();
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+
+        entityCommon = new EntityCommon(testPlugin);
+    }
+
+    /**
+     * Per-test setup. Creates a fresh test world for each test.
+     */
+    @BeforeEach
+    void setUp() {
+        testWorld = mockServer.addSimpleWorld("world");
+    }
+
+    /**
+     * Test that entityTypeFromString() correctly converts a valid entity type string to an EntityType enum.
+     */
+    @Test
+    void entityTypeFromStringTest() {
+        EntityType expectedType = EntityType.RABBIT;
+        EntityType type = entityCommon.entityTypeFromString("RABBIT");
+        assertSame(expectedType, type, "entityCommon.entityTypeFromString() entities not the same, Expected: " + expectedType + " Actual: " + type);
+    }
+
+    /**
+     * Test that entityTypeFromString() returns null when given an invalid entity type string.
+     */
+    @Test
+    void entityTypeFromStringBadStringTest() {
+        assertNull(entityCommon.entityTypeFromString("ROBBIT"), "entityCommon.entityTypeFromString(\"Robbit\") did not return null");
+    }
+
+    /**
+     * Test that getEntitiesInBounds() correctly finds entities within a bounding box and excludes those outside it.
+     */
+    @Test
+    void getEntitiesInBoundsTest() {
+        testWorld.spawn(new Location(testWorld, 0, 4, 0), Rabbit.class);
+        testWorld.spawn(new Location(testWorld, 2, 4, 0), Rabbit.class);
+        testWorld.spawn(new Location(testWorld, 0, 4, 2), Rabbit.class);
+
+        // get all entities within 10 blocks of 0, 4, 0
+        Collection<Entity> entities = EntityCommon.getEntitiesInBounds(new Location(testWorld, 0, 4, 0), 10, 10, 10);
+        assertEquals(3, entities.size(), "EntityCommon.getEntitiesInBounds() did not find the expected number of entities");
+
+        testWorld.spawn(new Location(testWorld, 0, 4, 12), Rabbit.class);
+        entities = EntityCommon.getEntitiesInBounds(new Location(testWorld, 0, 4, 0), 10, 10, 10);
+        assertEquals(3, entities.size(), "EntityCommon.getEntitiesInBounds() did not find the expected number of entities");
+    }
+
+    /**
+     * Test that getEntitiesInRadius() correctly finds all entities (including non-living entities like minecarts)
+     * within a radius and excludes those outside it.
+     */
+    @Test void getEntitiesInRadiusTest() {
+        testWorld.spawn(new Location(testWorld, 100, 4, 100), Rabbit.class);
+        testWorld.spawn(new Location(testWorld, 102, 4, 100), Minecart.class);
+        testWorld.spawn(new Location(testWorld, 100, 4, 102), Rabbit.class);
+
+        // get all entities within a 10 block radius of 100, 4, 100
+        Collection<Entity> entities = EntityCommon.getEntitiesInRadius(new Location(testWorld, 100, 4, 100), 10);
+        assertEquals(3, entities.size(), "EntityCommon.getEntitiesInRadius() did not find the expected number of entities");
+
+        testWorld.spawn(new Location(testWorld, 100, 4, 112), Rabbit.class);
+        entities = EntityCommon.getEntitiesInRadius(new Location(testWorld, 100, 4, 100), 10);
+        assertEquals(3, entities.size(), "EntityCommon.getEntitiesInRadius() did not find the expected number of entities");
+    }
+
+    /**
+     * Test that getLivingEntitiesInRadius() correctly finds only LivingEntity instances within a radius,
+     * excluding non-living entities like minecarts.
+     */
+    @Test
+    void getLivingEntitiesInRadiusTest() {
+        testWorld.spawn(new Location(testWorld, 200, 4, 200), Rabbit.class);
+        testWorld.spawn(new Location(testWorld, 204, 4, 200), Rabbit.class);
+        testWorld.spawn(new Location(testWorld, 200, 4, 204), Rabbit.class);
+
+        List<LivingEntity> livingEntities = EntityCommon.getLivingEntitiesInRadius(new Location(testWorld, 200, 4, 200), 10);
+        assertEquals(3, livingEntities.size(), "EntityCommon.getLivingEntitiesInRadius() did not find the expected number of entities");
+
+        testWorld.spawn(new Location(testWorld, 204, 4, 204), Minecart.class);
+        testWorld.spawn(new Location(testWorld, 200, 4, 214), Rabbit.class);
+        livingEntities = EntityCommon.getLivingEntitiesInRadius(new Location(testWorld, 200, 4, 200), 10);
+        assertEquals(3, livingEntities.size(), "EntityCommon.getLivingEntitiesInRadius() did not find the expected number of entities");
+    }
+
+    /**
+     * Test that getNearbyEntitiesByType() correctly finds only entities of a specific type within a radius,
+     * filtering out other entity types.
+     */
+    @Test
+    void getNearbyEntitiesByTypeTest() {
+        testWorld.spawn(new Location(testWorld, 300, 4, 300), Rabbit.class);
+        testWorld.spawn(new Location(testWorld, 304, 4, 300), Rabbit.class);
+        testWorld.spawn(new Location(testWorld, 300, 4, 304), Rabbit.class);
+
+        List<Entity> entities = EntityCommon.getNearbyEntitiesByType(new Location(testWorld, 300, 4, 300), 10, EntityType.RABBIT);
+        assertEquals(3, entities.size(), "EntityCommon.getNearbyEntitiesByType() did not return the expected number of entities");
+
+        testWorld.spawn(new Location(testWorld, 304, 4, 304), Minecart.class);
+        testWorld.spawn(new Location(testWorld, 300, 4, 314), Rabbit.class);
+        entities = EntityCommon.getNearbyEntitiesByType(new Location(testWorld, 300, 4, 300), 10, EntityType.RABBIT);
+        assertEquals(3, entities.size(), "EntityCommon.getNearbyEntitiesByType() did not return the expected number of entities");
+    }
+
+    /**
+     * Test that getItemsInBounds() correctly finds dropped items within a bounding box
+     * and excludes both non-item entities and items outside the bounding box.
+     */
+    @Test
+    void getItemsInBoundsTest() {
+        testWorld.dropItemNaturally(new Location(testWorld, 400, 4, 400), new ItemStack(Material.APPLE));
+        testWorld.dropItemNaturally(new Location(testWorld, 401, 4, 400), new ItemStack(Material.APPLE));
+        testWorld.dropItemNaturally(new Location(testWorld, 400, 4, 401), new ItemStack(Material.APPLE));
+
+        List<Item> items = EntityCommon.getItemsInBounds(new Location(testWorld, 400, 4, 400), 10, 10, 10);
+        assertEquals(3, items.size(), "EntityCommon.getItemsInBounds() did not return expected number of items");
+
+        testWorld.spawn(new Location(testWorld, 404, 4, 404), Minecart.class);
+        testWorld.dropItemNaturally(new Location(testWorld, 400, 4, 415), new ItemStack(Material.APPLE));
+        items = EntityCommon.getItemsInBounds(new Location(testWorld, 400, 4, 400), 10, 10, 10);
+        assertEquals(3, items.size(), "EntityCommon.getItemsInBounds() did not return expected number of items");
+    }
+
+    /**
+     * Test that getItemsInRadius() correctly finds dropped items within a radius
+     * and excludes items outside the radius.
+     */
+    @Test
+    void getItemsInRadiusTest() {
+        testWorld.dropItemNaturally(new Location(testWorld, 500, 4, 500), new ItemStack(Material.APPLE));
+        testWorld.dropItemNaturally(new Location(testWorld, 501, 4, 500), new ItemStack(Material.APPLE));
+        testWorld.dropItemNaturally(new Location(testWorld, 500, 4, 501), new ItemStack(Material.APPLE));
+
+        List<Item> items = EntityCommon.getItemsInRadius(new Location(testWorld, 500, 4, 500), 10);
+        assertEquals(3, items.size(), "EntityCommon.getItemsInRadius() did not return expected number of items");
+
+        testWorld.dropItemNaturally(new Location(testWorld, 500, 4, 515), new ItemStack(Material.APPLE));
+        items = EntityCommon.getItemsInRadius(new Location(testWorld, 500, 4, 500), 10);
+        assertEquals(3, items.size(), "EntityCommon.getItemsInRadius() did not return expected number of items");
+    }
+
+    /**
+     * Test that getNearbyItemByMaterial() correctly finds items of a specific material type within a radius,
+     * returns null when no items exist, and returns null when only wrong material types are present.
+     */
+    @Test
+    void getNearbyItemByMaterialTest() {
+        Item item = EntityCommon.getNearbyItemByMaterial(new Location(testWorld, 600, 4, 600), Material.APPLE, 10);
+        assertNull(item, "EntityCommon.getNearbyItemByMaterial() did not return null when no items present");
+
+        testWorld.dropItemNaturally(new Location(testWorld, 604, 4, 600), new ItemStack(Material.ARROW));
+        item = EntityCommon.getNearbyItemByMaterial(new Location(testWorld, 600, 4, 600), Material.APPLE, 10);
+        assertNull(item, "EntityCommon.getNearbyItemByMaterial() did not return null when no item of the correct type present");
+
+        testWorld.dropItemNaturally(new Location(testWorld, 604, 4, 600), new ItemStack(Material.APPLE));
+        item = EntityCommon.getNearbyItemByMaterial(new Location(testWorld, 600, 4, 600), Material.APPLE, 10);
+        assertNotNull(item, "EntityCommon.getNearbyItemByMaterial() returned null when item nearby");
+        assertSame(Material.APPLE, item.getItemStack().getType());
+    }
+
+    /**
+     * Test that getNearbyItemByMaterialList() correctly finds items matching any material in a provided list,
+     * returns null when no items exist, and returns null when only materials not in the list are present.
+     */
+    @Test
+    void getNearbyItemByMaterialList() {
+        ArrayList<Material> materials = new ArrayList<>() {{
+            add(Material.APPLE);
+            add(Material.ARROW);
+        }};
+
+        Item item = EntityCommon.getNearbyItemByMaterialList(new Location(testWorld, 700, 4, 700), materials, 10);
+        assertNull(item, "EntityCommon.getNearbyItemByMaterialList() did not return null when no items present");
+
+        testWorld.dropItemNaturally(new Location(testWorld, 700, 4, 700), new ItemStack(Material.BELL));
+        item = EntityCommon.getNearbyItemByMaterialList(new Location(testWorld, 700, 4, 700), materials, 10);
+        assertNull(item, "EntityCommon.getNearbyItemByMaterialList() did not return null when no items of the correct types present");
+
+        testWorld.dropItemNaturally(new Location(testWorld, 704, 4, 700), new ItemStack(Material.ARROW));
+        item = EntityCommon.getNearbyItemByMaterialList(new Location(testWorld, 700, 4, 700), materials, 10);
+        assertNotNull(item, "EntityCommon.getNearbyItemByMaterialList() was null when item of correct type nearby");
+
+        testWorld.dropItemNaturally(new Location(testWorld, 702, 4, 700), new ItemStack(Material.APPLE));
+        item = EntityCommon.getNearbyItemByMaterialList(new Location(testWorld, 700, 4, 700), materials, 10);
+        assertNotNull(item, "EntityCommon.getNearbyItemByMaterialList() was null when item of correct type nearby");
+    }
+
+    /**
+     * Test that getNearbyO2ItemByType() correctly finds plugin-specific O2 items by type,
+     * returns null when no items exist, and returns null when only wrong O2 item types are present.
+     */
+    @Test
+    void getNearbyO2ItemByTypeTest() {
+        Item item = EntityCommon.getNearbyO2ItemByType(new Location(testWorld, 800, 4, 800), O2ItemType.FLOO_POWDER, 10);
+        assertNull(item, "EntityCommon.getNearbyO2ItemByType() did not return null when no nearby items exist");
+
+        ItemStack itemStack = O2ItemType.GALLEON.getItem(1);
+        assertNotNull(itemStack, "O2ItemType.GALLEON.getItem(1) returned null");
+        testWorld.dropItemNaturally(new Location(testWorld, 801, 4, 800), itemStack);
+        item = EntityCommon.getNearbyO2ItemByType(new Location(testWorld, 800, 4, 800), O2ItemType.FLOO_POWDER, 10);
+        assertNull(item, "EntityCommon.getNearbyO2ItemByType() not null when no item of correct type nearby");
+
+        itemStack = O2ItemType.FLOO_POWDER.getItem(1);
+        assertNotNull(itemStack, "O2ItemType.FLOO_POWDER.getItem(1) returned null");
+        testWorld.dropItemNaturally(new Location(testWorld, 800, 4, 800), itemStack);
+        item = EntityCommon.getNearbyO2ItemByType(new Location(testWorld, 800, 4, 800), O2ItemType.FLOO_POWDER, 10);
+        assertNotNull(item, "EntityCommon.getNearbyO2ItemByType() null when item of correct type nearby");
+    }
+
+    /**
+     * Test that getRandomCatType() returns a consistent value for the same seed
+     * and produces variety when called multiple times without a seed.
+     */
+    @Test
+    void getRandomCatTypeTest() {
+        Set<Cat.Type> catTypes = new HashSet<>();
+
+        assertSame(EntityCommon.getRandomCatType(1), EntityCommon.getRandomCatType(1));
+
+        for (int i = 0; i < 10; i++) {
+            Cat.Type type = EntityCommon.getRandomCatType();
+            mockServer.getScheduler().performTicks(4);
+            catTypes.add(type);
+        }
+
+        assertTrue(catTypes.size() > 1, "Expected variety in cat types, but all 10 were the same: " + catTypes);
+    }
+
+    /**
+     * Test that getRandomRabbitType() returns a consistent value for the same seed
+     * and produces variety when called multiple times without a seed.
+     */
+    @Test
+    void getRandomRabbitTypeTest() {
+        Set<Rabbit.Type> rabbitTypes = new HashSet<>();
+
+        assertSame(EntityCommon.getRandomRabbitType(1), EntityCommon.getRandomRabbitType(1));
+
+        for (int i = 0; i < 10; i++) {
+            Rabbit.Type type = EntityCommon.getRandomRabbitType();
+            mockServer.getScheduler().performTicks(4);
+            rabbitTypes.add(type);
+        }
+
+        assertTrue(rabbitTypes.size() > 1, "Expected variety in rabbit types, but all 10 were the same: " + rabbitTypes);
+    }
+
+    /**
+     * Test that getRandomHorseStyle() returns a consistent value for the same seed
+     * and produces variety when called multiple times without a seed.
+     */
+    @Test
+    void getRandomHorseStyleTest() {
+        Set<Horse.Style> horseStyles = new HashSet<>();
+
+        assertSame(EntityCommon.getRandomHorseStyle(1), EntityCommon.getRandomHorseStyle(1));
+
+        for (int i = 0; i < 20; i++) {
+            Horse.Style style = EntityCommon.getRandomHorseStyle();
+            mockServer.getScheduler().performTicks(3);
+            horseStyles.add(style);
+        }
+
+        assertTrue(horseStyles.size() > 1, "Expected variety in horse styles, but all were the same: " + horseStyles);
+    }
+
+    /**
+     * Test that getRandomHorseColor() returns a consistent value for the same seed
+     * and produces variety when called multiple times without a seed.
+     */
+    @Test
+    void getRandomHorseColorTest() {
+        Set<Horse.Color> horseColors = new HashSet<>();
+
+        assertSame(EntityCommon.getRandomHorseColor(1), EntityCommon.getRandomHorseColor(1));
+
+        for (int i = 0; i < 10; i++) {
+            Horse.Color color = EntityCommon.getRandomHorseColor();
+            mockServer.getScheduler().performTicks(4);
+            horseColors.add(color);
+        }
+
+        assertTrue(horseColors.size() > 1, "Expected variety in horse colors, but all 10 were the same: " + horseColors);
+    }
+
+    /**
+     * Test that getRandomLlamaColor() returns a consistent value for the same seed
+     * and produces variety when called multiple times without a seed.
+     */
+    @Test
+    void getRandomLlamaColorTest() {
+        Set<Llama.Color> llamaColors = new HashSet<>();
+
+        assertSame(EntityCommon.getRandomLlamaColor(1), EntityCommon.getRandomLlamaColor(1));
+
+        for (int i = 0; i < 10; i++) {
+            Llama.Color color = EntityCommon.getRandomLlamaColor();
+            mockServer.getScheduler().performTicks(4);
+            llamaColors.add(color);
+        }
+
+        assertTrue(llamaColors.size() > 1, "Expected variety in llama colors, but all 10 were the same: " + llamaColors);
+    }
+
+    /**
+     * Test that getRandomParrotVariant() returns a consistent value for the same seed
+     * and produces variety when called multiple times without a seed.
+     */
+    @Test
+    void getRandomParrotVariantTest() {
+        Set<Parrot.Variant> parrotVariant = new HashSet<>();
+
+        assertSame(EntityCommon.getRandomParrotVariant(1), EntityCommon.getRandomParrotVariant(1));
+
+        for (int i = 0; i < 10; i++) {
+            Parrot.Variant variant = EntityCommon.getRandomParrotVariant();
+            mockServer.getScheduler().performTicks(4);
+            parrotVariant.add(variant);
+        }
+
+        assertTrue(parrotVariant.size() > 1, "Expected variety in parrot variants, but all 10 were the same: " + parrotVariant);
+    }
+
+    /**
+     * Test that getRandomNaturalSheepColor() returns a consistent value for the same seed
+     * and produces variety when called multiple times without a seed.
+     */
+    @Test
+    void getRandomNaturalSheepColor() {
+        Set<DyeColor> sheepColors = new HashSet<>();
+
+        assertSame(EntityCommon.getRandomNaturalSheepColor(1), EntityCommon.getRandomNaturalSheepColor(1));
+
+        for (int i = 0; i < 10; i++) {
+            DyeColor color = EntityCommon.getRandomNaturalSheepColor();
+            mockServer.getScheduler().performTicks(4);
+            sheepColors.add(color);
+        }
+
+        assertTrue(sheepColors.size() > 1, "Expected variety in sheep colors, but all 10 were the same: " + sheepColors);
+    }
+
+    /**
+     * Test that isHostile() returns true for inherently hostile Enemy mobs like zombies.
+     */
+    @Test
+    void isHostileEnemyTest() {
+        Zombie zombie = testWorld.spawn(new Location(testWorld, 900, 4, 900), Zombie.class);
+        assertTrue(EntityCommon.isHostile(zombie), "EntityCommon.isHostile() should return true for Enemy mobs like Zombie");
+    }
+
+    /**
+     * Test that isHostile() returns false for passive mobs like cows.
+     */
+    @Test
+    void isHostilePassiveMobTest() {
+        Cow cow = testWorld.spawn(new Location(testWorld, 910, 4, 910), Cow.class);
+        assertFalse(EntityCommon.isHostile(cow), "EntityCommon.isHostile() should return false for passive mobs like Cow");
+    }
+
+    /**
+     * Test that isHostile() returns true for neutral mobs that have a target set.
+     */
+    @Test
+    void isNeutralMobWithTargetTest() {
+        Bee bee = testWorld.spawn(new Location(testWorld, 920, 4, 920), Bee.class);
+        Zombie target = testWorld.spawn(new Location(testWorld, 921, 4, 920), Zombie.class);
+        bee.setTarget(target);
+        assertTrue(EntityCommon.isHostile(bee), "EntityCommon.isHostile() should return true for mobs with targets");
+    }
+
+    /**
+     * Test that isHostile() returns false for neutral mobs that do not have a target set.
+     */
+    @Test
+    void isNeutralMobWithoutTargetTest() {
+        Bee bee = testWorld.spawn(new Location(testWorld, 930, 4, 930), Bee.class);
+        bee.setTarget(null);
+        assertFalse(EntityCommon.isHostile(bee), "EntityCommon.isHostile() should return false for mobs without targets");
+    }
+
+    /**
+     * Global test teardown. Unmocks the MockBukkit server.
+     */
+    @AfterAll
+    static void globalTearDown () {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/ollivanders/common/O2ColorTest.java
+++ b/Ollivanders/test/java/ollivanders/common/O2ColorTest.java
@@ -1,0 +1,334 @@
+package ollivanders.common;
+
+import net.pottercraft.ollivanders2.common.O2Color;
+import org.bukkit.ChatColor;
+import org.bukkit.Color;
+import org.bukkit.DyeColor;
+import org.bukkit.Material;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for O2Color enum.
+ *
+ * Tests the various color conversion methods and utilities provided by the O2Color enum,
+ * including Bukkit color, chat color, dye color conversions, material color operations,
+ * and random color generation.
+ */
+public class O2ColorTest {
+
+    /**
+     * Test that getBukkitColor() returns the correct Bukkit Color for each O2Color enum value.
+     */
+    @Test
+    void getBukkitColorTest() {
+        assertEquals(Color.RED, O2Color.RED.getBukkitColor());
+        assertEquals(Color.BLUE, O2Color.BLUE.getBukkitColor());
+        assertEquals(Color.WHITE, O2Color.WHITE.getBukkitColor());
+        assertEquals(Color.BLACK, O2Color.BLACK.getBukkitColor());
+    }
+
+    /**
+     * Test that getChatColor() returns the correct ChatColor for each O2Color enum value.
+     */
+    @Test
+    void getChatColorTest() {
+        assertEquals(ChatColor.RED, O2Color.RED.getChatColor());
+        assertEquals(ChatColor.BLUE, O2Color.BLUE.getChatColor());
+        assertEquals(ChatColor.WHITE, O2Color.WHITE.getChatColor());
+        assertEquals(ChatColor.BLACK, O2Color.BLACK.getChatColor());
+    }
+
+    /**
+     * Test that getChatColorCode() returns the correct Minecraft color code string for each O2Color enum value.
+     */
+    @Test
+    void getChatColorCodeTest() {
+        assertEquals("§c", O2Color.RED.getChatColorCode());
+        assertEquals("§9", O2Color.BLUE.getChatColorCode());
+        assertEquals("§f", O2Color.WHITE.getChatColorCode());
+        assertEquals("§0", O2Color.BLACK.getChatColorCode());
+    }
+
+    /**
+     * Test that getDyeColor() returns the correct DyeColor for each O2Color enum value.
+     */
+    @Test
+    void getDyeColorTest() {
+        assertEquals(DyeColor.RED, O2Color.RED.getDyeColor());
+        assertEquals(DyeColor.BLUE, O2Color.BLUE.getDyeColor());
+        assertEquals(DyeColor.WHITE, O2Color.WHITE.getDyeColor());
+        assertEquals(DyeColor.BLACK, O2Color.BLACK.getDyeColor());
+    }
+
+    /**
+     * Test that getColoredMaterial() creates the correct colored material from a base material name.
+     * Tests wool, carpet, and concrete materials.
+     */
+    @Test
+    void getColoredMaterialTest() {
+        Material wool = O2Color.RED.getColoredMaterial("WOOL");
+        assertEquals(Material.RED_WOOL, wool);
+
+        Material carpet = O2Color.BLUE.getColoredMaterial("CARPET");
+        assertEquals(Material.BLUE_CARPET, carpet);
+
+        Material concrete = O2Color.WHITE.getColoredMaterial("CONCRETE");
+        assertEquals(Material.WHITE_CONCRETE, concrete);
+    }
+
+    /**
+     * Test that getColoredMaterial() returns null when given an invalid material base name.
+     */
+    @Test
+    void getColoredMaterialInvalidTest() {
+        Material invalid = O2Color.RED.getColoredMaterial("INVALID_MATERIAL");
+        assertNull(invalid, "getColoredMaterial should return null for invalid material base name");
+    }
+
+    /**
+     * Test that getBukkitColorByNumber() returns valid colors for numbers in the range 0-15.
+     */
+    @Test
+    void getBukkitColorByNumberTest() {
+        // Test valid numbers
+        O2Color color0 = O2Color.getBukkitColorByNumber(0);
+        assertNotNull(color0);
+
+        O2Color color5 = O2Color.getBukkitColorByNumber(5);
+        assertNotNull(color5);
+
+        O2Color color15 = O2Color.getBukkitColorByNumber(15);
+        assertNotNull(color15);
+    }
+
+    /**
+     * Test that getBukkitColorByNumber() returns WHITE for out-of-range numbers.
+     */
+    @Test
+    void getBukkitColorByNumberOutOfRangeTest() {
+        // Test out of range numbers
+        assertEquals(O2Color.WHITE, O2Color.getBukkitColorByNumber(-1));
+        assertEquals(O2Color.WHITE, O2Color.getBukkitColorByNumber(16));
+        assertEquals(O2Color.WHITE, O2Color.getBukkitColorByNumber(100));
+        assertEquals(O2Color.WHITE, O2Color.getBukkitColorByNumber(-100));
+    }
+
+    /**
+     * Test that getRandomPrimaryDyeableColor() returns variety when called multiple times.
+     */
+    @Test
+    void getRandomPrimaryDyeableColorTest() {
+        Set<O2Color> colors = new HashSet<>();
+
+        for (int i = 0; i < 20; i++) {
+            O2Color color = O2Color.getRandomPrimaryDyeableColor();
+            assertNotNull(color, "getRandomPrimaryDyeableColor should not return null");
+            colors.add(color);
+        }
+
+        assertTrue(colors.size() > 1, "Expected variety in random primary dyeable colors");
+    }
+
+    /**
+     * Test that getRandomPrimaryDyeableColor() with the same seed returns the same color consistently,
+     * and that different seeds produce variety.
+     */
+    @Test
+    void getRandomPrimaryDyeableColorWithSeedTest() {
+        // Same seed should produce same color
+        O2Color color1 = O2Color.getRandomPrimaryDyeableColor(42);
+        O2Color color2 = O2Color.getRandomPrimaryDyeableColor(42);
+        assertSame(color1, color2, "Same seed should produce same color");
+
+        // Different seeds should potentially produce different colors
+        Set<O2Color> colors = new HashSet<>();
+        for (int i = 0; i < 20; i++) {
+            O2Color color = O2Color.getRandomPrimaryDyeableColor(i);
+            assertNotNull(color, "getRandomPrimaryDyeableColor should not return null");
+            colors.add(color);
+        }
+
+        assertTrue(colors.size() > 1, "Expected variety in colors with different seeds");
+    }
+
+    /**
+     * Test that getRandomDyeableColor() returns variety when called multiple times.
+     */
+    @Test
+    void getRandomDyeableColorTest() {
+        Set<O2Color> colors = new HashSet<>();
+
+        for (int i = 0; i < 30; i++) {
+            O2Color color = O2Color.getRandomDyeableColor();
+            assertNotNull(color, "getRandomDyeableColor should not return null");
+            colors.add(color);
+        }
+
+        assertTrue(colors.size() > 1, "Expected variety in random dyeable colors");
+    }
+
+    /**
+     * Test that getRandomDyeableColor() with the same seed returns the same color consistently,
+     * and that different seeds produce variety.
+     */
+    @Test
+    void getRandomDyeableColorWithSeedTest() {
+        // Same seed should produce same color
+        O2Color color1 = O2Color.getRandomDyeableColor(123);
+        O2Color color2 = O2Color.getRandomDyeableColor(123);
+        assertSame(color1, color2, "Same seed should produce same color");
+
+        // Different seeds should potentially produce different colors
+        Set<O2Color> colors = new HashSet<>();
+        for (int i = 0; i < 30; i++) {
+            O2Color color = O2Color.getRandomDyeableColor(i);
+            assertNotNull(color, "getRandomDyeableColor should not return null");
+            colors.add(color);
+        }
+
+        assertTrue(colors.size() > 1, "Expected variety in colors with different seeds");
+    }
+
+    /**
+     * Test that isColorable() correctly identifies wool materials as colorable.
+     */
+    @Test
+    void isColorableWoolTest() {
+        assertTrue(O2Color.isColorable(Material.RED_WOOL));
+        assertTrue(O2Color.isColorable(Material.BLUE_WOOL));
+        assertTrue(O2Color.isColorable(Material.WHITE_WOOL));
+    }
+
+    /**
+     * Test that isColorable() correctly identifies carpet materials as colorable.
+     */
+    @Test
+    void isColorableCarpetTest() {
+        assertTrue(O2Color.isColorable(Material.RED_CARPET));
+        assertTrue(O2Color.isColorable(Material.GREEN_CARPET));
+    }
+
+    /**
+     * Test that isColorable() correctly identifies concrete and concrete powder materials as colorable.
+     */
+    @Test
+    void isColorableConcreteTest() {
+        assertTrue(O2Color.isColorable(Material.BLUE_CONCRETE));
+        assertTrue(O2Color.isColorable(Material.YELLOW_CONCRETE_POWDER));
+    }
+
+    /**
+     * Test that isColorable() correctly identifies shulker box materials as colorable.
+     */
+    @Test
+    void isColorableShulkerBoxTest() {
+        assertTrue(O2Color.isColorable(Material.RED_SHULKER_BOX));
+        assertTrue(O2Color.isColorable(Material.BLUE_SHULKER_BOX));
+    }
+
+    /**
+     * Test that isColorable() correctly identifies stained glass and stained glass pane materials as colorable.
+     */
+    @Test
+    void isColorableGlassTest() {
+        assertTrue(O2Color.isColorable(Material.RED_STAINED_GLASS));
+        assertTrue(O2Color.isColorable(Material.BLUE_STAINED_GLASS_PANE));
+    }
+
+    /**
+     * Test that isColorable() correctly identifies bed materials as colorable.
+     */
+    @Test
+    void isColorableBedTest() {
+        assertTrue(O2Color.isColorable(Material.RED_BED));
+        assertTrue(O2Color.isColorable(Material.WHITE_BED));
+    }
+
+    /**
+     * Test that isColorable() correctly identifies candle materials as colorable.
+     */
+    @Test
+    void isColorableCandleTest() {
+        assertTrue(O2Color.isColorable(Material.RED_CANDLE));
+        assertTrue(O2Color.isColorable(Material.BLUE_CANDLE));
+    }
+
+    /**
+     * Test that isColorable() correctly identifies banner materials as colorable.
+     */
+    @Test
+    void isColorableBannerTest() {
+        assertTrue(O2Color.isColorable(Material.RED_BANNER));
+        assertTrue(O2Color.isColorable(Material.WHITE_BANNER));
+    }
+
+    /**
+     * Test that isColorable() correctly identifies non-colorable materials.
+     */
+    @Test
+    void isColorableNonColorableTest() {
+        assertFalse(O2Color.isColorable(Material.STONE));
+        assertFalse(O2Color.isColorable(Material.DIRT));
+        assertFalse(O2Color.isColorable(Material.GLASS));
+        assertFalse(O2Color.isColorable(Material.DIAMOND));
+        assertFalse(O2Color.isColorable(Material.IRON_INGOT));
+    }
+
+    /**
+     * Test that changeColor() correctly changes wool material colors.
+     */
+    @Test
+    void changeColorWoolTest() {
+        Material redWool = Material.RED_WOOL;
+        Material blueWool = O2Color.changeColor(redWool, O2Color.BLUE);
+        assertEquals(Material.BLUE_WOOL, blueWool);
+
+        Material whiteWool = O2Color.changeColor(blueWool, O2Color.WHITE);
+        assertEquals(Material.WHITE_WOOL, whiteWool);
+    }
+
+    /**
+     * Test that changeColor() correctly changes carpet material colors.
+     */
+    @Test
+    void changeColorCarpetTest() {
+        Material greenCarpet = Material.GREEN_CARPET;
+        Material yellowCarpet = O2Color.changeColor(greenCarpet, O2Color.YELLOW);
+        assertEquals(Material.YELLOW_CARPET, yellowCarpet);
+    }
+
+    /**
+     * Test that changeColor() correctly changes concrete material colors.
+     */
+    @Test
+    void changeColorConcreteTest() {
+        Material redConcrete = Material.RED_CONCRETE;
+        Material blueConcrete = O2Color.changeColor(redConcrete, O2Color.BLUE);
+        assertEquals(Material.BLUE_CONCRETE, blueConcrete);
+    }
+
+    /**
+     * Test that changeColor() returns the original material when attempting to change
+     * the color of non-colorable materials.
+     */
+    @Test
+    void changeColorNonColorableTest() {
+        Material stone = Material.STONE;
+        Material result = O2Color.changeColor(stone, O2Color.RED);
+        assertEquals(stone, result, "changeColor should return original material if not colorable");
+
+        Material diamond = Material.DIAMOND;
+        result = O2Color.changeColor(diamond, O2Color.BLUE);
+        assertEquals(diamond, result, "changeColor should return original material if not colorable");
+    }
+}

--- a/Ollivanders/test/java/ollivanders/common/Ollivanders2CommonTest.java
+++ b/Ollivanders/test/java/ollivanders/common/Ollivanders2CommonTest.java
@@ -1,0 +1,831 @@
+package ollivanders.common;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
+import ollivanders.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for Ollivanders2Common utility class.
+ * Tests cover string parsing, location serialization/deserialization, player interactions,
+ * message broadcasting, block operations, and coordinate conversions.
+ */
+public class Ollivanders2CommonTest {
+    static ServerMock mockServer;
+    static Ollivanders2 testPlugin;
+    static Ollivanders2Common o2common;
+    Location origin;
+    World testWorld;
+    final String worldName = "world";
+
+    @BeforeAll
+    static void globalSetUp() {
+        mockServer = MockBukkit.mock();
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+
+        o2common = new Ollivanders2Common(testPlugin);
+    }
+
+    @BeforeEach
+    void setUp() {
+        testWorld = mockServer.addSimpleWorld(worldName);
+        origin = new Location(testWorld, 0, 4, 0);
+    }
+
+    /**
+     * Tests parsing a valid UUID string to a UUID object.
+     * Verifies that a correctly formatted UUID string is successfully converted.
+     */
+    @Test
+    void uuidFromStringTest() {
+        String uuidString = "5d2bec8f-2402-4039-920b-bdbf348fa9a7";
+        UUID uuid = o2common.uuidFromString(uuidString);
+        assertNotNull(uuid, "o2common.uuidFromString() returned null for " + uuidString);
+    }
+
+    /**
+     * Tests parsing an invalid UUID string.
+     * Verifies that parsing an invalid string returns null.
+     */
+    @Test
+    void uuidFromStringBadStringTest() {
+        String uuidBadString = "badstring";
+        UUID uuid = o2common.uuidFromString(uuidBadString);
+        assertNull(uuid, "o2common.uuidFromString(uuidBadString) did not return null");
+    }
+
+    /**
+     * Tests parsing a valid integer string to an Integer object.
+     * Verifies that a correctly formatted numeric string is successfully converted.
+     */
+    @Test
+    void integerFromStringTest() {
+        String integerString = "12345";
+        Integer integer = o2common.integerFromString(integerString);
+        assertNotNull(integer, "o2common.integerFromString() returned null for " + integerString);
+    }
+
+    /**
+     * Tests parsing an invalid integer string.
+     * Verifies that parsing a non-numeric string returns null.
+     */
+    @Test
+    void integerFromStringBadStringTest() {
+        String integerBadString = "badstring";
+        Integer integer = o2common.integerFromString(integerBadString);
+        assertNull(integer, "o2common.integerFromString(uuidBadString) did not return null");
+    }
+
+    /**
+     * Tests parsing a valid boolean string to a Boolean object.
+     * Verifies that a "true" string is successfully converted to a Boolean.
+     */
+    @Test
+    void booleanFromStringTest() {
+        String boolString = "true";
+        Boolean bool = o2common.booleanFromString(boolString);
+        assertNotNull(bool, "o2common.booleanFromString() returned null for " + boolString);
+    }
+
+    /**
+     * Tests parsing an invalid boolean string.
+     * Verifies that parsing a non-boolean string returns false.
+     */
+    @Test
+    void booleanFromStringBadStringTest() {
+        String boolBadString = "badstring";
+        Boolean bool = o2common.booleanFromString(boolBadString);
+        assertFalse(bool, "o2common.booleanFromString(boolBadString) did not return false");
+    }
+
+    /**
+     * Tests checking if a location is within a radius of another location.
+     * Verifies that a location 5 blocks away is within a 10 block radius.
+     */
+    @Test
+    void isInsideTest() {
+        Location checkLocation = new Location(testWorld, 5, 4, 0);
+
+        assertTrue(Ollivanders2Common.isInside(origin, checkLocation, 10));
+    }
+
+    /**
+     * Tests checking if a location is outside a radius.
+     * Verifies that a location 15 blocks away is outside a 10 block radius.
+     */
+    @Test
+    void isInsideOutsideTest() {
+        Location checkLocation = new Location(testWorld, 15, 4, 0);
+
+        assertFalse(Ollivanders2Common.isInside(origin, checkLocation, 10));
+    }
+
+    /**
+     * Tests retrieving all blocks within a given radius.
+     * Verifies that a radius of 2 returns a 3x3x3 cube of 27 blocks.
+     */
+    @Test
+    void getBlocksInRadiusTest() {
+        List<Block> blocks = Ollivanders2Common.getBlocksInRadius(origin, 2);
+        // expect 3^3 blocks since radius of 2 is not inclusive of the origin block
+        assertEquals(27, blocks.size());
+    }
+
+    /**
+     * Tests converting enum names to human-readable format.
+     * Verifies that enum constants like "FUMOS_DUO" are converted to "fumos duo".
+     */
+    @Test
+    void enumRecodeTest() {
+        String sourceString = "FUMOS_DUO";
+        String expectedString = "fumos duo";
+        String enumString = Ollivanders2Common.enumRecode(sourceString);
+
+        assertEquals(expectedString, enumString, "Ollivanders2Common.enumRecode(sourceString) Expected: " + expectedString + " Actual: " + enumString);
+    }
+
+    /**
+     * Tests capitalizing the first letter of each word in a string.
+     * Verifies that "fumos duo" is converted to "Fumos Duo".
+     */
+    @Test
+    void firstLetterCapitalizeTest() {
+         String sourceString = "fumos duo";
+         String expectedString = "Fumos Duo";
+         String capitalizedString = Ollivanders2Common.firstLetterCapitalize(sourceString);
+
+         assertEquals(expectedString, capitalizedString, "Ollivanders2Common.firstLetterCapitalize(sourceString) Expected: " + expectedString + ", Actual: " + capitalizedString);
+    }
+
+    /**
+     * Tests serializing a Location to a Map of string key-value pairs.
+     * Verifies that location coordinates and world name are correctly mapped with a given label prefix.
+     */
+    @Test
+    void serializeLocationTest() {
+        String labelPrefix = "test";
+        Map<String, String> expected = new HashMap<>() {{
+            put(labelPrefix + "_" + Ollivanders2Common.locationWorldLabel, worldName);
+            put(labelPrefix + "_" + Ollivanders2Common.locationXLabel, "0");
+            put(labelPrefix + "_" + Ollivanders2Common.locationYLabel, "4");
+            put(labelPrefix + "_" + Ollivanders2Common.locationZLabel, "0");
+        }};
+
+        Map<String, String> actual = o2common.serializeLocation(origin, labelPrefix);
+        assertNotNull(actual, "o2common.serializeLocation(origin, labelPrefix) returned null");
+        assertTrue(actual.containsKey(labelPrefix + "_" + Ollivanders2Common.locationWorldLabel), "o2common.serializeLocation() does not contain " + labelPrefix + "_" + Ollivanders2Common.locationWorldLabel);
+        assertEquals(worldName, actual.get(labelPrefix + "_" + Ollivanders2Common.locationWorldLabel), "");
+    }
+
+    /**
+     * Tests serializing a Location with a null world.
+     * Verifies that locations with null worlds are rejected and return null.
+     */
+    @Test
+    void serializeLocationBadLocationTest() {
+        Location badLocation = new Location(null, 0, 4, 0);
+        Map<String, String> actual = o2common.serializeLocation(badLocation, "test");
+        assertNull(actual, "o2common.serializeLocation(badLocation, \"test\") did not return null");
+    }
+
+    /**
+     * Tests deserializing a Location from a Map of string key-value pairs.
+     * Verifies that a serialized location can be reconstructed with correct world name and coordinates.
+     */
+    @Test
+    void deserializeLocationTest() {
+        String labelPrefix = "test";
+        Map<String, String> serializedLocation = o2common.serializeLocation(origin, labelPrefix);
+        assertNotNull(serializedLocation, "o2common.serializeLocation(origin, labelPrefix) returned null");
+
+        Location actual = o2common.deserializeLocation(serializedLocation, labelPrefix);
+        assertNotNull(actual, "o2common.deserializeLocation(serializedLocation, labelPrefix) returned null");
+        World actualWorld = actual.getWorld();
+        assertNotNull(actualWorld, "actual.getWorld() was null");
+        assertEquals(worldName, actualWorld.getName(), "World name did not match, Expected: " + worldName + ", Actual: " + actualWorld.getName());
+    }
+
+    /**
+     * Tests deserializing a Location from a Map with missing or invalid coordinates.
+     * Verifies that deserialization with null or missing coordinates returns null.
+     */
+    @Test
+    void deserializeLocationNullTest() {
+        Map<String, String> badLocation = new HashMap<>() {{
+            put("test" + "_" + Ollivanders2Common.locationWorldLabel, "badWorld");
+            put("test" + "_" + Ollivanders2Common.locationXLabel, null);
+            put("test" + "_" + Ollivanders2Common.locationYLabel, "4");
+            put("test" + "_" + Ollivanders2Common.locationZLabel, "0");
+        }};
+
+        Location actual = o2common.deserializeLocation(badLocation, "test");
+        assertNull(actual, "o2common.deserializeLocation(badLocation, \"test\") with null X coord did not return null");
+
+        badLocation.remove("test" + "_" + Ollivanders2Common.locationXLabel);
+        actual = o2common.deserializeLocation(badLocation, "test");
+        assertNull(actual, "o2common.deserializeLocation(badLocation, \"test\") with missing X coord did not return null");
+    }
+
+    /**
+     * Tests checking if a player is facing a specific block type.
+     * Verifies that the correct block is returned when a player faces a matching block type.
+     */
+    @Test
+    void playerFacingBlockTypeTest() {
+        // get the block at origin
+        Block block = testWorld.getBlockAt(origin);
+
+        // check if the player is facing a block of type stone
+        Block facingBlock = playerFacingBlockTypeHelper(Material.STONE, Material.STONE);
+        assertNotNull(facingBlock, "Ollivanders2Common.playerFacingBlockType() should return a block when facing STONE");
+        assertEquals(block, facingBlock, "Should return the block at origin");
+    }
+
+    /**
+     * Tests checking for a specific block type when player faces a different block.
+     * Verifies that null is returned when the faced block type doesn't match the requested type.
+     */
+    @Test
+    void playerFacingBlockTypeFailureTest() {
+        // check if they are facing a block of type stone but actually make the type wood
+        Block facingBlock = playerFacingBlockTypeHelper(Material.DARK_OAK_WOOD, Material.STONE);
+        assertNull(facingBlock, "Ollivanders2Common.playerFacingBlockType() should return null facing WOOD");
+    }
+
+    /**
+     * Tests checking for a block type when the player is facing air.
+     * Verifies that null is returned when the player is not facing any blocks of the requested type.
+     */
+    @Test
+    void playerFacingBlockTypeNothingTest() {
+        // check if the player is facing a block of type stone (there should be none in that direction)
+        Block facingBlock = playerFacingBlockTypeHelper(Material.AIR, Material.STONE);
+        assertNull(facingBlock, "Ollivanders2Common.playerFacingBlockType() should return null when not facing the block type");
+    }
+
+    Block playerFacingBlockTypeHelper(Material originBlockType, Material checkBlockType) {
+        // make the block at origin type STONE
+        Block block = testWorld.getBlockAt(origin);
+        block.setType(originBlockType);
+
+        // create a player and have them stand 3 blocks away facing the block at origin
+        PlayerMock player = mockServer.addPlayer("Steve");
+        Location playerLocation = new Location(testWorld, 0, 4, 3);
+        player.setLocation(playerLocation);
+
+        // set the player's rotation to face the block at origin (yaw=180 to face negative Z, pitch=0 for horizontal)
+        player.setRotation(180, 0);
+
+        // advance the game ticks 5 for everything to settle
+        mockServer.getScheduler().performTicks(Ollivanders2Common.ticksPerSecond * 5);
+
+        // check if the player is facing a block of type stone
+        return Ollivanders2Common.playerFacingBlockType(player, checkBlockType);
+    }
+
+    /**
+     * Tests converting spherical coordinates to 3D vectors.
+     * Verifies that spherical coordinates are correctly converted with proper magnitude and direction.
+     * Tests both north pole and equator coordinates.
+     */
+    @Test
+    void sphereToVectorTest() {
+        // test conversion of spherical coordinates to vector
+        double radius = 10;
+
+        // test north pole (inclination = 0, azimuth = 0)
+        Vector northPole = Ollivanders2Common.sphereToVector(new double[]{0, 0}, (int) radius);
+        assertNotNull(northPole, "sphereToVector() should return a vector");
+        assertEquals(radius, northPole.length(), 0.01, "Vector magnitude should equal radius");
+
+        // test equator (inclination = π/2, azimuth = 0)
+        Vector equator = Ollivanders2Common.sphereToVector(new double[]{Math.PI / 2, 0}, (int) radius);
+        assertNotNull(equator, "sphereToVector() should return a vector");
+        assertEquals(radius, equator.length(), 0.01, "Vector magnitude should equal radius");
+    }
+
+    /**
+     * There is no effective way to test flair() since we cannot access the particle system to see if the effect worked
+     * as intended.
+     */
+    @Test
+    void flairTest() {
+        Ollivanders2Common.flair(new Location(testWorld, 200, 4, 200), 5, 3);
+        mockServer.getScheduler().performTicks(20);
+
+        Ollivanders2Common.flair(new Location(testWorld, 300, 4, 300), 5, 3, Particle.SMOKE);
+        mockServer.getScheduler().performTicks(20);
+
+        Ollivanders2Common.flair(null, 5, 5);
+        mockServer.getScheduler().performTicks(10);
+    }
+
+    /**
+     * Tests sending title and subtitle messages to multiple players.
+     * Verifies that all players in the list receive the correct title and subtitle text.
+     */
+    @Test
+    void sendTitleMessageTest() {
+        // create multiple mock players
+        PlayerMock player1 = mockServer.addPlayer("Fred");
+        PlayerMock player2 = mockServer.addPlayer("Joe");
+
+        // add players to a list
+        List<Player> players = new ArrayList<>();
+        players.add(player1);
+        players.add(player2);
+
+        // call sendTitleMessage with title and subtitle
+        String title = "Test Title";
+        String subtitle = "Test Subtitle";
+        Ollivanders2Common.sendTitleMessage("Test Title", "Test Subtitle", players);
+        mockServer.getScheduler().performTicks(10);
+
+        String receivedTitle = player1.nextTitle();
+        String recievedSubtitle = player1.nextSubTitle();
+        assertNotNull(receivedTitle, "player1.nextTitle() was null");
+        assertNotNull(recievedSubtitle, "player1.nextSubTitle() was null");
+        assertEquals(title, receivedTitle, "Player1 did not receive title, expected: " + title + ", actual: " + receivedTitle);
+        assertEquals(subtitle, recievedSubtitle, "Player1 did not receive subtitle, expected: " + subtitle + ", actual: " + recievedSubtitle);
+
+        receivedTitle = player2.nextTitle();
+        recievedSubtitle = player2.nextSubTitle();
+        assertNotNull(receivedTitle, "player2.nextTitle() was null");
+        assertNotNull(recievedSubtitle, "player2.nextSubTitle() was null");
+        assertEquals(title, receivedTitle, "Player2 did not receive title, expected: " + title + ", actual: " + receivedTitle);
+        assertEquals(subtitle, recievedSubtitle, "Player2 did not receive subtitle, expected: " + subtitle + ", actual: " + recievedSubtitle);
+    }
+
+    /**
+     * Tests sending messages to players within a given radius.
+     * Verifies that players within the radius receive the message while those outside do not.
+     */
+    @Test
+    void sendMessageInRadius() {
+        // create multiple mock players
+        PlayerMock player1 = mockServer.addPlayer("Autumn");
+        PlayerMock player2 = mockServer.addPlayer("Laura");
+        PlayerMock player3 = mockServer.addPlayer("Mae");
+
+        player1.setLocation(new Location(testWorld, 200, 4, 100));
+        player2.setLocation(new Location(testWorld, 200, 4, 102));
+        player3.setLocation(new Location(testWorld, 200, 4, 107));
+        mockServer.getScheduler().performTicks(5);
+
+        String testMessage = "testMessage";
+        Ollivanders2Common.sendMessageInRadius(testMessage, new Location(testWorld, 200, 4, 100), 5);
+        mockServer.getScheduler().performTicks(5);
+
+        String received = player1.nextMessage();
+        assertNotNull(received, "player1.nextMessage() was null");
+        assertTrue(TestCommon.messageEquals(testMessage, received), "Player1 did not receive correct message, expected: " + testMessage + ", actual: " + received);
+
+        received = player2.nextMessage();
+        assertNotNull(received, "player2.nextMessage() was null");
+        assertTrue(TestCommon.messageEquals(testMessage, received), "Player2 did not receive correct message, expected: " + testMessage + ", actual: " + received);
+
+        received = player3.nextMessage();
+        assertNull(received, "player3.nextMessage() was not null");
+    }
+
+    Handler logHandlerHelper(List<LogRecord> logRecords) {
+        Handler testLogHandler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                logRecords.add(record);
+            }
+
+            @Override
+            public void flush() {}
+
+            @Override
+            public void close() {}
+        };
+
+        return testLogHandler;
+    }
+
+    /**
+     * Tests printing debug messages when debug mode is enabled.
+     * Verifies that debug messages are logged when Ollivanders2.debug is true.
+     */
+    @Test
+    void printDebugMessageTest() {
+        List<LogRecord> logRecords = new ArrayList<>();
+        Handler testLogHandler = logHandlerHelper(logRecords);
+        testPlugin.getLogger().addHandler(testLogHandler);
+
+        String debugMessage = "debug message";
+        Ollivanders2.debug = true;
+        o2common.printDebugMessage(debugMessage, null, null, false);
+        Ollivanders2.debug = false;
+
+        assertEquals(1, logRecords.size(), "logRecords.size() did not increase");
+        String received = logRecords.getFirst().getMessage();
+        assertTrue(received.contains(debugMessage), "Did not find log message, expected: " + debugMessage + ", actual: " + received);
+    }
+
+    /**
+     * Tests that debug messages are suppressed when debug mode is disabled.
+     * Verifies that no debug messages are logged when Ollivanders2.debug is false.
+     */
+    @Test
+    void printDebugMessageNoDebugTest() {
+        List<LogRecord> logRecords = new ArrayList<>();
+        Handler testLogHandler = logHandlerHelper(logRecords);
+        testPlugin.getLogger().addHandler(testLogHandler);
+
+        String debugMessage = "no debug message";
+        o2common.printDebugMessage(debugMessage, null, null, false);
+
+        assertEquals(0, logRecords.size(), "logRecords.size() changed when Ollivanders2Common.printDebugMessage() called but Ollivanders2.debug false");
+    }
+
+    /**
+     * Tests printing debug messages as warnings.
+     * Verifies that debug messages can be logged with a WARNING level when flagged.
+     */
+    @Test
+    void printDebugMessageWarningTest() {
+        List<LogRecord> logRecords = new ArrayList<>();
+        Handler testLogHandler = logHandlerHelper(logRecords);
+        testPlugin.getLogger().addHandler(testLogHandler);
+
+        Ollivanders2.debug = true;
+        o2common.printDebugMessage("warning debug message", null, null, true);
+        Ollivanders2.debug = false;
+
+        assertEquals(1, logRecords.size(), "logRecords.size() did not increase");
+        Level received = logRecords.getFirst().getLevel();
+        assertSame(Level.WARNING, received, "Did not find warning log message, expected: " + Level.WARNING + ", actual: " + received);
+    }
+
+    /**
+     * Tests logging messages at INFO level.
+     * Verifies that log messages are properly recorded regardless of debug mode.
+     */
+    @Test
+    void printLogMessage() {
+        List<LogRecord> logRecords = new ArrayList<>();
+        Handler testLogHandler = logHandlerHelper(logRecords);
+        testPlugin.getLogger().addHandler(testLogHandler);
+
+        String logMessage = "log message";
+        o2common.printLogMessage(logMessage, null, null, false);
+
+        assertEquals(1, logRecords.size(), "logRecords.size() did not increase");
+        String received = logRecords.getFirst().getMessage();
+        assertTrue(received.contains(logMessage), "Did not get log message, expected: " + logMessage + ", actual: " + received);
+    }
+
+    /**
+     * Tests logging messages as warnings.
+     * Verifies that log messages can be recorded with a WARNING level when flagged.
+     */
+    @Test
+    void printLogWarningMessage() {
+        List<LogRecord> logRecords = new ArrayList<>();
+        Handler testLogHandler = logHandlerHelper(logRecords);
+        testPlugin.getLogger().addHandler(testLogHandler);
+
+        o2common.printLogMessage("warning log message", null, null, true);
+
+        assertEquals(1, logRecords.size(), "logRecords.size() did not increase");
+        Level received = logRecords.getFirst().getLevel();
+        assertSame(Level.WARNING, received, "Did not find warning log message, expected: " + Level.WARNING + ", actual: " + received);
+    }
+
+    /**
+     * Tests comparing two identical locations for equality.
+     * Verifies that identical locations are recognized as equal.
+     */
+    @Test
+    void locationEqualsTest() {
+        assertTrue(Ollivanders2Common.locationEquals(origin, origin), "Ollivanders2Common.locationEquals(origin, origin) did not return true");
+
+        Location loc1 = new Location(testWorld, 5, 5, 5);
+        Location loc2 = new Location(testWorld, 5, 5, 5);
+        assertTrue(Ollivanders2Common.locationEquals(loc1, loc2), "Ollivanders2Common.locationEquals(loc1, loc2) did not return true when locations identical");
+    }
+
+    /**
+     * Tests comparing different locations for inequality.
+     * Verifies that locations with different coordinates or worlds are recognized as unequal.
+     */
+    @Test
+    void locationEqualsFalseTest() {
+        Location loc1 = new Location(testWorld, 5, 5, 5);
+        Location loc2 = new Location(testWorld, 6, 5, 5);
+        assertFalse(Ollivanders2Common.locationEquals(loc1, loc2), "Ollivanders2Common.locationEquals() was not false when location X coords different");
+
+        World nether = mockServer.addSimpleWorld("nether");
+        loc2 = new Location(nether, 5, 5, 5);
+        assertFalse(Ollivanders2Common.locationEquals(loc1, loc2), "Ollivanders2Common.locationEquals() was not false when world are different");
+    }
+
+    /**
+     * Tests filtering recipients by distance with a standard radius.
+     * Verifies that players within the radius are kept and those outside are removed.
+     */
+    @Test
+    void chatDropoffTest() {
+        // create players at different distances from origin
+        PlayerMock player1 = mockServer.addPlayer("Close1");
+        player1.setLocation(new Location(testWorld, 2, 4, 0));  // 2 blocks away
+
+        PlayerMock player2 = mockServer.addPlayer("Close2");
+        player2.setLocation(new Location(testWorld, 0, 4, 3));  // 3 blocks away
+
+        PlayerMock player3 = mockServer.addPlayer("Far1");
+        player3.setLocation(new Location(testWorld, 10, 4, 0));  // 10 blocks away
+
+        PlayerMock player4 = mockServer.addPlayer("Far2");
+        player4.setLocation(new Location(testWorld, 0, 4, 15));  // 15 blocks away
+
+        // create recipients set with all players
+        Set<Player> recipients = new HashSet<>();
+        recipients.add(player1);
+        recipients.add(player2);
+        recipients.add(player3);
+        recipients.add(player4);
+
+        // test with dropoff of 5 blocks - should only keep close players
+        Ollivanders2Common.chatDropoff(recipients, 5, origin);
+
+        // Verify close players are still in the set
+        assertTrue(recipients.contains(player1), "Player at 2 blocks should be within 5 block dropoff");
+        assertTrue(recipients.contains(player2), "Player at 3 blocks should be within 5 block dropoff");
+
+        // Verify far players were removed
+        assertFalse(recipients.contains(player3), "Player at 10 blocks should be removed from 5 block dropoff");
+        assertFalse(recipients.contains(player4), "Player at 15 blocks should be removed from 5 block dropoff");
+
+        assertEquals(2, recipients.size(), "Expected 2 recipients remaining after 5 block dropoff");
+    }
+
+    /**
+     * Tests chat dropoff with a large radius.
+     * Verifies that all players are kept when the radius is sufficiently large.
+     */
+    @Test
+    void chatDropoffLargeRadiusTest() {
+        // create players at various distances
+        PlayerMock player1 = mockServer.addPlayer("PlayA");
+        player1.setLocation(new Location(testWorld, 5, 4, 5));  // ~7 blocks away
+
+        PlayerMock player2 = mockServer.addPlayer("PlayB");
+        player2.setLocation(new Location(testWorld, 10, 4, 10));  // ~14 blocks away
+
+        PlayerMock player3 = mockServer.addPlayer("PlayC");
+        player3.setLocation(new Location(testWorld, 20, 4, 0));  // 20 blocks away
+
+        Set<Player> recipients = new HashSet<>();
+        recipients.add(player1);
+        recipients.add(player2);
+        recipients.add(player3);
+
+        // test with large dropoff of 50 blocks - should keep all
+        Ollivanders2Common.chatDropoff(recipients, 50, origin);
+
+        assertTrue(recipients.contains(player1), "Player should be within 50 block dropoff");
+        assertTrue(recipients.contains(player2), "Player should be within 50 block dropoff");
+        assertTrue(recipients.contains(player3), "Player should be within 50 block dropoff");
+        assertEquals(3, recipients.size(), "All 3 players should remain with 50 block dropoff");
+    }
+
+    /**
+     * Tests chat dropoff with a very small radius.
+     * Verifies that only players very close to the origin are kept with a small radius.
+     */
+    @Test
+    void chatDropoffSmallRadiusTest() {
+        // create players at close distances
+        PlayerMock player1 = mockServer.addPlayer("X");
+        player1.setLocation(new Location(testWorld, 0, 4, 0));  // 0 blocks away (at origin)
+
+        PlayerMock player2 = mockServer.addPlayer("Y");
+        player2.setLocation(new Location(testWorld, 1, 4, 0));  // 1 block away
+
+        PlayerMock player3 = mockServer.addPlayer("Z");
+        player3.setLocation(new Location(testWorld, 3, 4, 0));  // 3 blocks away
+
+        Set<Player> recipients = new HashSet<>();
+        recipients.add(player1);
+        recipients.add(player2);
+        recipients.add(player3);
+
+        // test with small dropoff of 1 block - should only keep origin player
+        Ollivanders2Common.chatDropoff(recipients, 1, origin);
+
+        assertTrue(recipients.contains(player1), "Player at origin should be within 1 block dropoff");
+        assertFalse(recipients.contains(player2), "Player at 1 block should be removed from 1 block dropoff (< not <=)");
+        assertFalse(recipients.contains(player3), "Player at 3 blocks should be removed from 1 block dropoff");
+        assertEquals(1, recipients.size(), "Only player at origin should remain with 1 block dropoff");
+    }
+
+    /**
+     * Tests chat dropoff with an empty recipients set.
+     * Verifies that the method handles empty sets gracefully without errors.
+     */
+    @Test
+    void chatDropoffEmptyRecipientsTest() {
+        // test with empty recipients set - should not throw
+        Set<Player> recipients = new HashSet<>();
+
+        Ollivanders2Common.chatDropoff(recipients, 10, origin);
+
+        assertEquals(0, recipients.size(), "Empty set should remain empty after chatDropoff");
+    }
+
+    /**
+     * Tests identifying door blocks.
+     * Verifies that standard door blocks are correctly identified.
+     */
+    @Test
+    void isDoorTest() {
+        Block doorBlock = testWorld.getBlockAt(new Location(testWorld, 200, 4, 300));
+        doorBlock.setType(Material.DARK_OAK_DOOR);
+
+        assertTrue(Ollivanders2Common.isDoor(doorBlock), "Ollivanders2Common.isDoor(doorBlock) returned false when block is Material.DARK_OAK_DOOR");
+    }
+
+    /**
+     * Tests identifying trapdoors as doors.
+     * Verifies that trapdoors are also recognized as door blocks.
+     */
+    @Test
+    void isDoorTrapdoorTest() {
+        Block trapdoorBlock = testWorld.getBlockAt(new Location(testWorld, 201, 4, 300));
+        trapdoorBlock.setType(Material.DARK_OAK_TRAPDOOR);
+
+        assertTrue(Ollivanders2Common.isDoor(trapdoorBlock), "Ollivanders2Common.isDoor(doorBlock) returned false when block is Material.DARK_OAK_TRAPDOOR");
+    }
+
+    /**
+     * Tests that non-door blocks are not identified as doors.
+     * Verifies that fences and other blocks are correctly distinguished from doors.
+     */
+    @Test
+    void isDoorNotDoorTest() {
+        Block notDoorBlock = testWorld.getBlockAt(new Location(testWorld, 202, 4, 300));
+        notDoorBlock.setType(Material.DARK_OAK_FENCE);
+
+        assertFalse(Ollivanders2Common.isDoor(notDoorBlock), "Ollivanders2Common.isDoor(notDoorBlock) returned true when block is Material.DARK_OAK_FENCE");
+    }
+
+    /**
+     * Tests identifying chest blocks.
+     * Verifies that standard chest blocks are correctly identified.
+     */
+    @Test
+    void isChestTest() {
+        Block chestBlock = testWorld.getBlockAt(new Location(testWorld, 200, 4, 301));
+        chestBlock.setType(Material.CHEST);
+
+        assertTrue(Ollivanders2Common.isChest(chestBlock), "Ollivanders2Common.isChest(chestBlock) returned false when block is Material.CHEST");
+    }
+
+    /**
+     * Tests identifying shulker boxes as container blocks.
+     * Verifies that shulker boxes are recognized as valid storage containers.
+     */
+    @Test
+    void isChestShulkerBoxTest() {
+        Block shulkerBoxBlock = testWorld.getBlockAt(new Location(testWorld, 200, 4, 302));
+        shulkerBoxBlock.setType(Material.BLUE_SHULKER_BOX);
+
+        assertTrue(Ollivanders2Common.isChest(shulkerBoxBlock), "Ollivanders2Common.isChest(chestBlock) returned false when block is Material.CHEST");
+    }
+
+    /**
+     * Tests that non-container blocks are not identified as chests.
+     * Verifies that barrels and other blocks are correctly distinguished from chests.
+     */
+    @Test
+    void isChestNotChestTest() {
+        Block notChestBlock = testWorld.getBlockAt(new Location(testWorld, 200, 4, 303));
+        notChestBlock.setType(Material.BARREL);
+
+        assertFalse(Ollivanders2Common.isChest(notChestBlock), "Ollivanders2Common.isChest(notChestBlock) returned true when block is Material.BARREL");
+    }
+
+    /**
+     * Tests identifying blocks adjacent in all six cardinal directions.
+     * Verifies that blocks one unit away in any direction are recognized as adjacent.
+     */
+    @Test
+    void isAdjacentToTest() {
+        // create a center block
+        Block centerBlock = testWorld.getBlockAt(new Location(testWorld, 100, 5, 100));
+        centerBlock.setType(Material.STONE);
+
+        // test adjacent ABOVE (UP)
+        Block aboveBlock = testWorld.getBlockAt(new Location(testWorld, 100, 6, 100));
+        aboveBlock.setType(Material.DIRT);
+        assertTrue(Ollivanders2Common.isAdjacentTo(centerBlock, aboveBlock), "Block above should be adjacent");
+
+        // test adjacent BELOW (DOWN)
+        Block belowBlock = testWorld.getBlockAt(new Location(testWorld, 100, 4, 100));
+        belowBlock.setType(Material.DIRT);
+        assertTrue(Ollivanders2Common.isAdjacentTo(centerBlock, belowBlock), "Block below should be adjacent");
+
+        // test adjacent to the NORTH
+        Block northBlock = testWorld.getBlockAt(new Location(testWorld, 100, 5, 99));
+        northBlock.setType(Material.DIRT);
+        assertTrue(Ollivanders2Common.isAdjacentTo(centerBlock, northBlock), "Block to the north should be adjacent");
+
+        // test adjacent to the SOUTH
+        Block southBlock = testWorld.getBlockAt(new Location(testWorld, 100, 5, 101));
+        southBlock.setType(Material.DIRT);
+        assertTrue(Ollivanders2Common.isAdjacentTo(centerBlock, southBlock), "Block to the south should be adjacent");
+
+        // test adjacent to the EAST
+        Block eastBlock = testWorld.getBlockAt(new Location(testWorld, 101, 5, 100));
+        eastBlock.setType(Material.DIRT);
+        assertTrue(Ollivanders2Common.isAdjacentTo(centerBlock, eastBlock), "Block to the east should be adjacent");
+
+        // test adjacent to the WEST
+        Block westBlock = testWorld.getBlockAt(new Location(testWorld, 99, 5, 100));
+        westBlock.setType(Material.DIRT);
+        assertTrue(Ollivanders2Common.isAdjacentTo(centerBlock, westBlock), "Block to the west should be adjacent");
+    }
+
+    /**
+     * Tests that non-adjacent blocks are not identified as adjacent.
+     * Verifies that diagonal, distant, and far blocks are correctly distinguished from adjacent blocks.
+     */
+    @Test
+    void isAdjacentToNotAdjacentTest() {
+        // create a center block
+        Block centerBlock = testWorld.getBlockAt(new Location(testWorld, 200, 5, 100));
+        centerBlock.setType(Material.STONE);
+
+        // test diagonal block (not adjacent)
+        Block diagonalBlock = testWorld.getBlockAt(new Location(testWorld, 201, 5, 101));
+        diagonalBlock.setType(Material.DIRT);
+        assertFalse(Ollivanders2Common.isAdjacentTo(centerBlock, diagonalBlock), "Diagonal block should not be adjacent");
+
+        // test block 2 units away horizontally (not adjacent)
+        Block twoAwayBlock = testWorld.getBlockAt(new Location(testWorld, 200, 5, 102));
+        twoAwayBlock.setType(Material.DIRT);
+        assertFalse(Ollivanders2Common.isAdjacentTo(centerBlock, twoAwayBlock), "Block 2 units away should not be adjacent");
+
+        // test block 2 units away vertically (not adjacent)
+        Block twoUpBlock = testWorld.getBlockAt(new Location(testWorld, 200, 7, 100));
+        twoUpBlock.setType(Material.DIRT);
+        assertFalse(Ollivanders2Common.isAdjacentTo(centerBlock, twoUpBlock), "Block 2 units above should not be adjacent");
+    }
+
+    /**
+     * Tests that a block is not adjacent to itself.
+     * Verifies that the same block instance is not considered adjacent to itself.
+     */
+    @Test
+    void isAdjacentToSameBlockTest() {
+        // test that a block is not adjacent to itself
+        Block block = testWorld.getBlockAt(new Location(testWorld, 300, 5, 100));
+        block.setType(Material.STONE);
+
+        assertFalse(Ollivanders2Common.isAdjacentTo(block, block), "A block should not be adjacent to itself");
+    }
+
+    /**
+     * Global test teardown. Unmocks the MockBukkit server.
+     */
+    @AfterAll
+    static void globalTearDown () {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/ollivanders/common/TimeCommonTest.java
+++ b/Ollivanders/test/java/ollivanders/common/TimeCommonTest.java
@@ -1,0 +1,188 @@
+package ollivanders.common;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.common.TimeCommon;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+import java.io.File;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for TimeCommon enum.
+ * Tests cover game time constants, world time retrieval, and timestamp generation.
+ */
+public class TimeCommonTest {
+    static ServerMock mockServer;
+    static Ollivanders2 testPlugin;
+
+    @BeforeAll
+    static void globalSetUp() {
+        mockServer = MockBukkit.mock();
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+        mockServer.addSimpleWorld("world");
+    }
+
+    /**
+     * Tests that the MIDNIGHT enum constant has the correct tick value.
+     * Verifies that MIDNIGHT is set to 18000 ticks.
+     */
+    @Test
+    void midnightTickTest() {
+        assertEquals(18000, TimeCommon.MIDNIGHT.getTick(), "MIDNIGHT should have tick value of 18000");
+    }
+
+    /**
+     * Tests that the DAWN enum constant has the correct tick value.
+     * Verifies that DAWN is set to 23000 ticks.
+     */
+    @Test
+    void dawnTickTest() {
+        assertEquals(23000, TimeCommon.DAWN.getTick(), "DAWN should have tick value of 23000");
+    }
+
+    /**
+     * Tests that the MIDDAY enum constant has the correct tick value.
+     * Verifies that MIDDAY is set to 6000 ticks.
+     */
+    @Test
+    void middayTickTest() {
+        assertEquals(6000, TimeCommon.MIDDAY.getTick(), "MIDDAY should have tick value of 6000");
+    }
+
+    /**
+     * Tests that the SUNSET enum constant has the correct tick value.
+     * Verifies that SUNSET is set to 12000 ticks.
+     */
+    @Test
+    void sunsetTickTest() {
+        assertEquals(12000, TimeCommon.SUNSET.getTick(), "SUNSET should have tick value of 12000");
+    }
+
+    /**
+     * Tests retrieving the default world time from the server.
+     * Verifies that getDefaultWorldTime() returns a valid time value.
+     */
+    @Test
+    void getDefaultWorldTimeTest() {
+        long defaultWorldTime = TimeCommon.getDefaultWorldTime();
+        assertTrue(defaultWorldTime >= 0, "Default world time should be non-negative");
+    }
+
+    /**
+     * Tests that the default world time changes after advancing server time.
+     * Verifies that time progression is correctly reflected in the default world.
+     */
+    @Test
+    void getDefaultWorldTimeAdvancedTest() {
+        long initialTime = TimeCommon.getDefaultWorldTime();
+
+        // Advance time by 100 ticks
+        mockServer.getScheduler().performTicks(100);
+
+        long newTime = TimeCommon.getDefaultWorldTime();
+        assertTrue(newTime > initialTime, "World time should advance after scheduler ticks");
+    }
+
+    /**
+     * Tests timestamp generation in the correct format.
+     * Verifies that getCurrentTimestamp() returns a string matching the expected pattern yyyy-MM-dd-HH-mm-ss.
+     */
+    @Test
+    void getCurrentTimestampTest() {
+        String timestamp = TimeCommon.getCurrentTimestamp();
+
+        assertNotNull(timestamp, "getCurrentTimestamp() should not return null");
+
+        // Validate format using regex pattern: yyyy-MM-dd-HH-mm-ss
+        String pattern = "\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}";
+        assertTrue(Pattern.matches(pattern, timestamp),
+            "Timestamp should match pattern yyyy-MM-dd-HH-mm-ss, but got: " + timestamp);
+    }
+
+    /**
+     * Tests that consecutive timestamp calls are different when time has passed.
+     * Verifies that timestamps are generated at different times (with at least a small time difference).
+     */
+    @Test
+    void getCurrentTimestampUniqueTest() {
+        String timestamp1 = TimeCommon.getCurrentTimestamp();
+
+        // Sleep briefly to ensure time has passed
+        try {
+            Thread.sleep(10);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        String timestamp2 = TimeCommon.getCurrentTimestamp();
+
+        // Timestamps should be different (or at least the seconds should be tracked)
+        assertNotNull(timestamp1, "First timestamp should not be null");
+        assertNotNull(timestamp2, "Second timestamp should not be null");
+        assertTrue(!timestamp1.isEmpty() && !timestamp2.isEmpty(), "Timestamps should not be empty");
+    }
+
+    /**
+     * Tests that the timestamp is parseable back to a valid date.
+     * Verifies that the generated timestamp format can be used to reconstruct a Date object.
+     */
+    @Test
+    void getCurrentTimestampParseable() {
+        String timestamp = TimeCommon.getCurrentTimestamp();
+
+        try {
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss");
+            Date parsedDate = dateFormat.parse(timestamp);
+            assertNotNull(parsedDate, "Timestamp should be parseable to a Date object");
+        } catch (Exception e) {
+            fail("Timestamp '" + timestamp + "' should be parseable: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Tests that all TimeCommon enum constants have valid tick values.
+     * Verifies that all enum values return non-negative tick values.
+     */
+    @Test
+    void allEnumConstantsHaveValidTicksTest() {
+        for (TimeCommon timeConstant : TimeCommon.values()) {
+            assertTrue(timeConstant.getTick() >= 0,
+                timeConstant.name() + " should have a non-negative tick value");
+        }
+    }
+
+    /**
+     * Tests that different enum constants have different tick values.
+     * Verifies that each time of day has a unique tick value.
+     */
+    @Test
+    void enumConstantsHaveUniquTicksTest() {
+        TimeCommon[] values = TimeCommon.values();
+
+        for (int i = 0; i < values.length; i++) {
+            for (int j = i + 1; j < values.length; j++) {
+                assertTrue(values[i].getTick() != values[j].getTick(),
+                    values[i].name() + " and " + values[j].name() + " should have different tick values");
+            }
+        }
+    }
+
+    /**
+     * Global test teardown. Unmocks the MockBukkit server.
+     */
+    @AfterAll
+    static void globalTearDown() {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/ollivanders/house/O2HousesTest.java
+++ b/Ollivanders/test/java/ollivanders/house/O2HousesTest.java
@@ -6,7 +6,8 @@ import net.pottercraft.ollivanders2.house.O2HouseType;
 import net.pottercraft.ollivanders2.house.O2Houses;
 import net.pottercraft.ollivanders2.house.events.OllivandersPlayerSortedEvent;
 import org.bukkit.World;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.MockBukkit;
@@ -32,7 +33,7 @@ public class O2HousesTest {
     static World testWorld;
     static Ollivanders2 testPlugin;
     static ServerMock mockServer;
-    static O2Houses testHouses;
+    O2Houses testHouses;
 
     static PlayerMock player1;
     static final String player1Name = "Bob";
@@ -58,22 +59,24 @@ public class O2HousesTest {
         assertEquals(expectedScore, objective.getScore(house.getName()).getScore(), message);
     }
 
-    @BeforeEach
-    void setUp () {
+    @BeforeAll
+    static void globalSetUp() {
         mockServer = MockBukkit.mock();
         testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/houses_config.yml"));
-
         // set up world
         testWorld = mockServer.addSimpleWorld("world");
-
-        // get O2Houses
-        testHouses = Ollivanders2API.getHouses();
-        testHouses.reset();
 
         // create some players we will need
         player1 = mockServer.addPlayer(player1Name);
         player2 = mockServer.addPlayer(player2Name);
         player3 = mockServer.addPlayer(player3Name);
+    }
+
+    @BeforeEach
+    void setUp() {
+        // get O2Houses
+        testHouses = Ollivanders2API.getHouses();
+        testHouses.reset();
     }
 
     /**
@@ -264,8 +267,8 @@ public class O2HousesTest {
                 "Slytherin with 5 points should be tied for 3rd place");
     }
 
-    @AfterEach
-    void tearDown () {
+    @AfterAll
+    static void globalTearDown () {
         MockBukkit.unmock();
     }
 }

--- a/Ollivanders/test/java/ollivanders/testcommon/TestCommon.java
+++ b/Ollivanders/test/java/ollivanders/testcommon/TestCommon.java
@@ -1,4 +1,4 @@
-package ollivanders;
+package ollivanders.testcommon;
 
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.Nullable;
 import org.mockbukkit.mockbukkit.ServerMock;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -22,12 +21,26 @@ public class TestCommon {
      *
      * @param expected the message we expected
      * @param message the message received
-     * @return
+     * @return strippedMessage.startsWith(expected)
      */
     public static boolean messageStartsWith(@NotNull String expected, @NotNull String message) {
         String strippedMessage = message.replaceAll("§.", "");
 
         return strippedMessage.startsWith(expected);
+    }
+
+    /**
+     * Compare the message received by a player to the expected message. This needs a helper because
+     * we need to strip chat color codes from the messages sent by the plugin.
+     *
+     * @param expected the message we expected
+     * @param message the message received
+     * @return strippedMessage.equals(expected)
+     */
+    public static boolean messageEquals(@NotNull String expected, @NotNull String message) {
+        String strippedMessage = message.replaceAll("§.", "");
+
+        return strippedMessage.equals(expected);
     }
 
     /**
@@ -92,4 +105,6 @@ public class TestCommon {
 
         return false;
     }
+
+
 }

--- a/Ollivanders/test/resources/default_config.yml
+++ b/Ollivanders/test/resources/default_config.yml
@@ -129,8 +129,7 @@ zones:
       -
     disallowed-spells:
       -
-
-        #
-        # Strings
-      #
+#
+# Strings
+#
 useTranslations: false


### PR DESCRIPTION
* reworked book tests to have less redundancy betweeen book classes
* added tests for the Ollivanders2.common package
* deprecated redundant EntityCommon.getItems
* renamed EntityCommon.getRandomParrotColor()
* replaced isNaturalLog() with a static array like we use for chests and doors
* moved potionEffectLevels map to O2Potions from EntityCommon
* fixed bug in the EntityCommon.getRandom functions to handle when the seed is 0
* refactored EntityCommon.isHostile() to be simpler and handle future Mob changes better
* deprecated Ollivanders2Common.stringArrayToString in favor of String.join
* added missing doors/trapdoors to Ollivanders2Common lists
* simplified booleanFromString because it cannot ever fail to parse
* fixed bug in deserializeLocation where it could partially parse a location and think it worked
* removed unused Ollivanders2Common.vectorToSphere