### PR TITLE
Unit tests - divination package

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Divination.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Divination.java
@@ -94,7 +94,7 @@ public abstract class O2Divination {
      * @param target     the player the prophecy is about
      * @param experience the experience level of the prophet with this divination
      */
-    O2Divination(@NotNull Ollivanders2 plugin, @NotNull Player prophet, @NotNull Player target, int experience) {
+    public O2Divination(@NotNull Ollivanders2 plugin, @NotNull Player prophet, @NotNull Player target, int experience) {
         p = plugin;
         this.target = target;
         this.prophet = prophet;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Prophecies.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Prophecies.java
@@ -92,7 +92,7 @@ public class O2Prophecies {
     @Nullable
     public O2Prophecy getProphecyAboutPlayer(@NotNull UUID pid) {
         for (O2Prophecy prophecy : activeProphecies) {
-            if (prophecy.getTargetID() == pid) {
+            if (prophecy.getTargetID().equals(pid)) {
                 return prophecy;
             }
         }
@@ -129,7 +129,7 @@ public class O2Prophecies {
     @Nullable
     public O2Prophecy getProphecyByPlayer(@NotNull UUID pid) {
         for (O2Prophecy prophecy : activeProphecies) {
-            if (prophecy.getProphetID() == pid) {
+            if (prophecy.getProphetID().equals(pid)) {
                 return prophecy;
             }
         }
@@ -157,6 +157,7 @@ public class O2Prophecies {
             }
 
             if (prophecy.isKilled()) {
+                common.printDebugMessage("Removing prophecy", null, null, false);
                 activeProphecies.remove(prophecy);
             }
         }
@@ -173,9 +174,9 @@ public class O2Prophecies {
     }
 
     /**
-     * Load saved prophecies
+     * Load saved prophecies, this shouldn't be called by anything except the O2Prophecies onEnable() and unit tests.
      */
-    private void loadProphecies() {
+    public void loadProphecies() {
         GsonDAO gsonLayer = new GsonDAO();
         List<Map<String, String>> prophecies = gsonLayer.readSavedDataListMap(GsonDAO.o2PropheciesJSONFile);
 
@@ -187,9 +188,8 @@ public class O2Prophecies {
         for (Map<String, String> prophecyData : prophecies) {
             O2Prophecy prophecy = deserializeProphecy(prophecyData);
 
-            if (prophecy != null) {
+            if (prophecy != null)
                 activeProphecies.add(prophecy);
-            }
         }
 
         p.getLogger().info("Loaded " + activeProphecies.size() + " prophecies.");
@@ -337,7 +337,7 @@ public class O2Prophecies {
         ArrayList<O2Prophecy> prophecies = new ArrayList<>(offlineProphecies);
 
         for (O2Prophecy prophecy : prophecies) {
-            if (prophecy.getTargetID() == pid) {
+            if (prophecy.getTargetID().equals(pid)) {
                 activeProphecies.add(prophecy);
                 offlineProphecies.remove(prophecy);
 
@@ -359,7 +359,7 @@ public class O2Prophecies {
         String prophecy = null;
 
         for (O2Prophecy prop : activeProphecies) {
-            if (prop.getTargetID() == targetID) {
+            if (prop.getTargetID().equals(targetID)) {
                 prophecy = prop.getProphecyMessage();
             }
         }
@@ -369,11 +369,28 @@ public class O2Prophecies {
         }
 
         for (O2Prophecy prop : offlineProphecies) {
-            if (prop.getTargetID() == targetID) {
+            if (prop.getTargetID().equals(targetID)) {
                 prophecy = prop.getProphecyMessage();
             }
         }
 
         return prophecy;
+    }
+
+    /**
+     * Clear all pending prophecies.
+     */
+    public void resetProphecies() {
+        activeProphecies.clear();
+        offlineProphecies.clear();
+    }
+
+    /**
+     * The count of active prophecies
+     *
+     * @return the count of active prophecies
+     */
+    public int activeProphecyCount() {
+        return activeProphecies.size();
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Prophecy.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Prophecy.java
@@ -22,6 +22,11 @@ public class O2Prophecy {
     final private Ollivanders2 p;
 
     /**
+     * Maximum accuracy for a prophecy
+     */
+    static public final int maxAccuracy = 99;
+
+    /**
      * The effect that will happen to the player
      */
     private final O2EffectType effectType;
@@ -64,14 +69,16 @@ public class O2Prophecy {
     /**
      * Constructor
      *
+     * @param plugin         a reference to the plugin
      * @param effectType     the effect that will happen to the player
+     * @param message        the message to be displayed for the prophecy
      * @param targetID       the id of the player that will be affected
      * @param prophetID      the id of the player that made this prophecy
      * @param delayTime      the time, in game ticks, until the prophecy will come to pass, less than 1200 (1 minute) will be rounded up to 1200
-     * @param effectDuration the duration of the effect, 0 for permanent
+     * @param effectDuration the duration of the effect
      * @param accuracy       the accuracy of this prophecy as a percent from 0 to 99, greater than 99 will be rounded down to 99
      */
-    O2Prophecy(@NotNull Ollivanders2 plugin, @NotNull O2EffectType effectType, @NotNull String message, @NotNull UUID targetID, @NotNull UUID prophetID, long delayTime, int effectDuration, int accuracy) {
+    public O2Prophecy(@NotNull Ollivanders2 plugin, @NotNull O2EffectType effectType, @NotNull String message, @NotNull UUID targetID, @NotNull UUID prophetID, long delayTime, int effectDuration, int accuracy) {
         p = plugin;
         this.effectType = effectType;
         this.targetID = targetID;
@@ -80,9 +87,9 @@ public class O2Prophecy {
         this.time = delayTime;
         this.duration = effectDuration;
 
-        if (accuracy > 99)
-            this.accuracy = 99;
-        else if (accuracy < 0)
+        if (accuracy > maxAccuracy) // accuracy cannot be higher than maxAccuracy
+            this.accuracy = maxAccuracy;
+        else if (accuracy < 0) // accuracy cannot be negative
             this.accuracy = 0;
         else
             this.accuracy = accuracy;
@@ -114,7 +121,7 @@ public class O2Prophecy {
      * @return the target player's unique ID
      */
     @NotNull
-    UUID getProphetID() {
+    public UUID getProphetID() {
         return prophetID;
     }
 
@@ -141,7 +148,7 @@ public class O2Prophecy {
      *
      * @return the prophecy message
      */
-    String getProphecyMessage() {
+    public String getProphecyMessage() {
         return prophecyMessage;
     }
 
@@ -159,7 +166,7 @@ public class O2Prophecy {
      *
      * @return true if killed, false otherwise
      */
-    boolean isKilled() {
+    public boolean isKilled() {
         return kill;
     }
 
@@ -180,12 +187,12 @@ public class O2Prophecy {
     /**
      * Execute this prophecy.
      */
-    void fulfill() {
+    public void fulfill() {
         if (Ollivanders2.debug) {
             p.getLogger().info("Fulfilling prophecy");
         }
 
-        // this should only be called when the prophecy time has expired
+        // do nothing if the prophecy is already killed
         if (kill) {
             return;
         }
@@ -216,10 +223,10 @@ public class O2Prophecy {
             effect.setPermanent(false);
             Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
 
-            O2Player player = Ollivanders2API.getPlayers().getPlayer(prophetID);
-            if (player != null) {
-                String playerName = player.getPlayerName();
-                p.getServer().broadcastMessage(Ollivanders2.chatColor + "And so came to pass the prophecy of " + playerName + ", \"" + prophecyMessage + "\"");
+            O2Player prophet = Ollivanders2API.getPlayers().getPlayer(prophetID);
+            if (prophet != null) {
+                String prophetName = prophet.getPlayerName();
+                p.getServer().broadcastMessage(Ollivanders2.chatColor + "And so came to pass the prophecy of " + prophetName + ", \"" + prophecyMessage + "\"");
             }
         }
         else {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effect.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effect.java
@@ -45,7 +45,7 @@ public abstract class O2Effect {
     /**
      * The minimum duration for this effect
      */
-    private int minDuration = 5 * Ollivanders2Common.ticksPerSecond;
+    static public final int minDuration = 5 * Ollivanders2Common.ticksPerSecond;
 
     /**
      * A callback to the MC plugin

--- a/Ollivanders/test/java/ollivanders/book/BookTestSuper.java
+++ b/Ollivanders/test/java/ollivanders/book/BookTestSuper.java
@@ -6,7 +6,6 @@ import ollivanders.pluginDependencies.LibsDisguisesMock;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.MockBukkit;

--- a/Ollivanders/test/java/ollivanders/book/O2BooksTest.java
+++ b/Ollivanders/test/java/ollivanders/book/O2BooksTest.java
@@ -57,6 +57,9 @@ public class O2BooksTest {
 
         // Get the books instance from the plugin (initialized in onEnable)
         books = Ollivanders2API.getBooks();
+
+        // advance the server by 20 ticks to let the scheduler start (it has an initial delay of 20 ticks)
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
     }
 
     /**

--- a/Ollivanders/test/java/ollivanders/common/Ollivanders2CommonTest.java
+++ b/Ollivanders/test/java/ollivanders/common/Ollivanders2CommonTest.java
@@ -10,6 +10,7 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -295,7 +296,7 @@ public class Ollivanders2CommonTest {
         assertNull(facingBlock, "Ollivanders2Common.playerFacingBlockType() should return null when not facing the block type");
     }
 
-    Block playerFacingBlockTypeHelper(Material originBlockType, Material checkBlockType) {
+    Block playerFacingBlockTypeHelper(@NotNull Material originBlockType, @NotNull Material checkBlockType) {
         // make the block at origin type STONE
         Block block = testWorld.getBlockAt(origin);
         block.setType(originBlockType);
@@ -420,7 +421,7 @@ public class Ollivanders2CommonTest {
         assertNull(received, "player3.nextMessage() was not null");
     }
 
-    Handler logHandlerHelper(List<LogRecord> logRecords) {
+    Handler logHandlerHelper(@NotNull List<LogRecord> logRecords) {
         Handler testLogHandler = new Handler() {
             @Override
             public void publish(LogRecord record) {

--- a/Ollivanders/test/java/ollivanders/divination/AstrologyTest.java
+++ b/Ollivanders/test/java/ollivanders/divination/AstrologyTest.java
@@ -1,0 +1,12 @@
+package ollivanders.divination;
+
+import net.pottercraft.ollivanders2.divination.ASTROLOGY;
+import net.pottercraft.ollivanders2.divination.O2Divination;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class AstrologyTest extends DivinationTestSuper {
+    O2Divination createDivination(@NotNull Player prophet, @NotNull Player target, int experience) {
+        return new ASTROLOGY(testPlugin, prophet, target, experience);
+    }
+}

--- a/Ollivanders/test/java/ollivanders/divination/CartomancyTarotTest.java
+++ b/Ollivanders/test/java/ollivanders/divination/CartomancyTarotTest.java
@@ -1,0 +1,12 @@
+package ollivanders.divination;
+
+import net.pottercraft.ollivanders2.divination.CARTOMANCY_TAROT;
+import net.pottercraft.ollivanders2.divination.O2Divination;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class CartomancyTarotTest extends DivinationTestSuper {
+    O2Divination createDivination(@NotNull Player prophet, @NotNull Player target, int experience) {
+        return new CARTOMANCY_TAROT(testPlugin, prophet, target, experience);
+    }
+}

--- a/Ollivanders/test/java/ollivanders/divination/CartomancyTest.java
+++ b/Ollivanders/test/java/ollivanders/divination/CartomancyTest.java
@@ -1,0 +1,12 @@
+package ollivanders.divination;
+
+import net.pottercraft.ollivanders2.divination.CARTOMANCY;
+import net.pottercraft.ollivanders2.divination.O2Divination;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class CartomancyTest extends DivinationTestSuper {
+    O2Divination createDivination(@NotNull Player prophet, @NotNull Player target, int experience) {
+        return new CARTOMANCY(testPlugin, prophet, target, experience);
+    }
+}

--- a/Ollivanders/test/java/ollivanders/divination/CentaurDivinationTest.java
+++ b/Ollivanders/test/java/ollivanders/divination/CentaurDivinationTest.java
@@ -1,0 +1,12 @@
+package ollivanders.divination;
+
+import net.pottercraft.ollivanders2.divination.CENTAUR_DIVINATION;
+import net.pottercraft.ollivanders2.divination.O2Divination;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class CentaurDivinationTest extends DivinationTestSuper {
+    O2Divination createDivination(@NotNull Player prophet, @NotNull Player target, int experience) {
+        return new CENTAUR_DIVINATION(testPlugin, prophet, target, experience);
+    }
+}

--- a/Ollivanders/test/java/ollivanders/divination/CrystalBallTest.java
+++ b/Ollivanders/test/java/ollivanders/divination/CrystalBallTest.java
@@ -1,0 +1,12 @@
+package ollivanders.divination;
+
+import net.pottercraft.ollivanders2.divination.CRYSTAL_BALL;
+import net.pottercraft.ollivanders2.divination.O2Divination;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class CrystalBallTest extends DivinationTestSuper {
+    O2Divination createDivination(@NotNull Player prophet, @NotNull Player target, int experience) {
+        return new CRYSTAL_BALL(testPlugin, prophet, target, experience);
+    }
+}

--- a/Ollivanders/test/java/ollivanders/divination/DivinationTestSuper.java
+++ b/Ollivanders/test/java/ollivanders/divination/DivinationTestSuper.java
@@ -1,0 +1,78 @@
+package ollivanders.divination;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.divination.O2Divination;
+import ollivanders.testcommon.TestCommon;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+abstract public class DivinationTestSuper {
+    static ServerMock mockServer;
+    Ollivanders2 testPlugin;
+
+    @BeforeAll
+    static void globalSetUp() {
+        mockServer = MockBukkit.mock();
+    }
+
+    @BeforeEach
+    void setUp() {
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+
+        // advance the server by 20 ticks to let the scheduler start (it has an initial delay of 20 ticks)
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
+    }
+
+    abstract O2Divination createDivination(@NotNull Player prophet, @NotNull Player target, int experience);
+
+    @Test
+    void divineTest() {
+        // make sure we're starting with a clean list
+        List<String> prophecies = Ollivanders2API.getProphecies().getProphecies();
+        assertEquals(0, prophecies.size(), "Tests did not start out with empty prophecies list.");
+
+        // create a prophet and a target
+        PlayerMock prophet = mockServer.addPlayer("Jiji");
+        PlayerMock target = mockServer.addPlayer("Rajah");
+
+        // do the divination with high experience
+        O2Divination divination = createDivination(prophet, target, 100);
+        divination.divine();
+
+        // advance the game ticks
+        mockServer.getScheduler().performTicks(10);
+
+        // verify a prophecy was added
+        prophecies = Ollivanders2API.getProphecies().getProphecies();
+        assertEquals(1, prophecies.size(), "Number of prophecies is not 1 after O2Divination.divine()");
+        assertTrue(TestCommon.containsStringMatch(prophecies, target.getName()), "Target player name not found in any prophecy.");
+    }
+
+    @AfterEach
+    void tearDown() {
+        Ollivanders2API.getProphecies().resetProphecies();
+    }
+
+    /**
+     * Global test teardown. Unmocks the MockBukkit server.
+     */
+    @AfterAll
+    static void globalTearDown () {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/ollivanders/divination/O2PropheciesTest.java
+++ b/Ollivanders/test/java/ollivanders/divination/O2PropheciesTest.java
@@ -1,0 +1,180 @@
+package ollivanders.divination;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.divination.O2Prophecies;
+import net.pottercraft.ollivanders2.divination.O2Prophecy;
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import ollivanders.testcommon.TestCommon;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for O2Prophecies class.
+ * Comprehensive test covering prophecy creation, retrieval, aging, persistence, and player offline/online transitions.
+ * This is a mega test case to avoid non-deterministic test run order issues with JUnit 5.
+ */
+public class O2PropheciesTest {
+    static ServerMock mockServer;
+    static Ollivanders2 testPlugin;
+    static O2Prophecies prophecies;
+    static int delayTicks = 10;
+    static int effectDurationTicks = 10;
+    static int maxAccuracy;
+
+    /**
+     * Global test setup. Initializes MockBukkit server, loads the plugin with configuration,
+     * and advances the server to allow the scheduler to start.
+     */
+    @BeforeAll
+    static void globalSetUp() {
+        mockServer = MockBukkit.mock();
+        maxAccuracy = O2Prophecy.maxAccuracy;
+
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+        prophecies = Ollivanders2API.getProphecies();
+
+        // advance the server to let the scheduler start
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
+    }
+
+    /**
+     * Comprehensive test of O2Prophecies functionality.
+     * Tests include:
+     * - Adding prophecies and retrieving them by target or prophet
+     * - Searching for prophecies that don't exist
+     * - Aging prophecies and handling expiration
+     * - Saving prophecies to disk and loading them back
+     * - Verifying loaded prophecies have correct data
+     * - Handling player disconnection/reconnection (offline/online transitions)
+     * - getProphecy() method for both online and offline players
+     *
+     * This is a mega test case to avoid non-deterministic test run order issues with JUnit 5.
+     */
+    @Test
+    void propheciesTest() {
+        Ollivanders2.debug = true;
+        PlayerMock prophet1 = mockServer.addPlayer("Prophet1");
+        PlayerMock prophet2 = mockServer.addPlayer("Prophet2");
+        PlayerMock target1 = mockServer.addPlayer("Target1");
+        PlayerMock target2 = mockServer.addPlayer("Target2");
+
+        // make sure we're starting with a clean list
+        assertEquals(0, prophecies.getProphecies().size(), "Tests did not start out with empty prophecies list.");
+
+        // add a prophecy
+        String message1 = "test prophecy";
+        prophecies.addProphecy(new O2Prophecy(testPlugin, O2EffectType.UNLUCK, message1, target1.getUniqueId(), prophet1.getUniqueId(), delayTicks, effectDurationTicks, maxAccuracy));
+
+        // number of prophecies increases by 1
+        assertEquals(1, prophecies.getProphecies().size(), "The number of prophecies did not increase by 1 after prophecies.addProphecy()");
+
+        // we can find a prophecy with the expected message
+        assertTrue(TestCommon.containsStringMatch(prophecies.getProphecies(), message1), "Did not find prophecy with matching message, " + message1);
+
+        // we can find the prophecy about target1
+        O2Prophecy prophecy = prophecies.getProphecyAboutPlayer(target1.getUniqueId());
+        assertNotNull(prophecy, "Prophecy was null after prophecies.addProphecy()");
+        assertTrue(prophecy.getProphecyMessage().contains(message1), "Prophecy did not have expected message");
+
+        // we do find a prophecy about target2
+        prophecy = prophecies.getProphecyAboutPlayer(target2.getUniqueId());
+        assertNull(prophecy, "prophecies.getProphecyAboutPlayer(target2.getUniqueId()) was not null");
+
+        // we do not find a prophet about prophet1
+        prophecy = prophecies.getProphecyAboutPlayer(prophet1.getUniqueId());
+        assertNull(prophecy, "prophecies.getProphecyAboutPlayer(prophet1.getUniqueId()) was not null");
+
+        // we can find a prophecy by prophet1
+        prophecy = prophecies.getProphecyByPlayer(prophet1.getUniqueId());
+        assertNotNull(prophecy, "prophecies.getProphecyByPlayer(prophet1.getUniqueId()) was null");
+        assertTrue(prophecy.getProphecyMessage().contains(message1), "Prophecy did not have expected message");
+
+        // we do not find a prophecy by prophet2
+        prophecy = prophecies.getProphecyByPlayer(prophet2.getUniqueId());
+        assertNull(prophecy, "prophecies.getProphecyByPlayer(prophet2.getUniqueId()) is not null");
+
+        // we do not find a prophecy by target1
+        prophecy = prophecies.getProphecyByPlayer(target1.getUniqueId());
+        assertNull(prophecy, "prophecies.getProphecyByPlayer(target1.getUniqueId()) was not null");
+
+        // test upkeep processing
+        // advance the server by 1 tick and make sure the number of prophecies has not changed
+        mockServer.getScheduler().performTicks(1);
+        assertEquals(1, prophecies.getProphecies().size(), "After " + TestCommon.startupTicks + " game ticks, number of prophecies changed.");
+
+        // advance the server by delayTicks so the prophecy ages out
+        mockServer.getScheduler().performTicks(delayTicks);
+        assertEquals(0, prophecies.getProphecies().size(), "After " + delayTicks + " more game ticks, prophecies did not expire due to age");
+
+        // test saving and loading prophecies
+        // add 2 new prophecies
+        message1 = "test prophecy 1";
+        prophecies.addProphecy(new O2Prophecy(testPlugin, O2EffectType.UNLUCK, message1, target1.getUniqueId(), prophet1.getUniqueId(), delayTicks, effectDurationTicks, maxAccuracy));
+        String message2 = "test prophecy 2";
+        prophecies.addProphecy(new O2Prophecy(testPlugin, O2EffectType.UNLUCK, message2, target2.getUniqueId(), prophet2.getUniqueId(), delayTicks, effectDurationTicks, maxAccuracy));
+        // save them
+        prophecies.saveProphecies();
+        assertEquals(2, prophecies.getProphecies().size(), "prophecies.getProphecies().size() not 2 after adding 2 prophecies");
+        // clear the loaded prophecies
+        prophecies.resetProphecies();
+        assertEquals(0, prophecies.getProphecies().size(), "prophecies.getProphecies().size() not 0 after prophecies.resetProphecies();");
+        // load saved prophecies
+        prophecies.loadProphecies();
+        assertEquals(2, prophecies.getProphecies().size(), "prophecies.getProphecies().size() not 2 after prophecies.loadProphecies();");
+        // now make sure the loaded prophecies are right
+        prophecy = prophecies.getProphecyByPlayer(prophet1.getUniqueId());
+        assertNotNull(prophecy, "prophecies.getProphecyByPlayer(prophet1.getUniqueId()) was null after prophecies.loadProphecies()");
+        assertTrue(prophecy.getProphecyMessage().contains(message1), "prophecy did not have expected message");
+        prophecy = prophecies.getProphecyByPlayer(prophet2.getUniqueId());
+        assertNotNull(prophecy, "prophecies.getProphecyByPlayer(prophet2.getUniqueId()) was null after prophecies.loadProphecies()");
+        assertTrue(prophecy.getProphecyMessage().contains(message2), "prophecy did not have expected message");
+
+        // test onJoin
+        // disconnect target1
+        target1.disconnect();
+        // age the prophecies so that theirs moves to offlineProphecies
+        mockServer.getScheduler().performTicks(delayTicks + 1);
+        // verify the prophecies have moved to offline (should have 0 in active list)
+        assertEquals(0, prophecies.activeProphecyCount(), "Prophecies did not move to offline after " + (delayTicks + 1) + " ticks.");
+        // reconnect target1
+        target1.reconnect();
+        // verify onJoin() moved their offlineProphecy back to the active list
+        assertEquals(1, prophecies.activeProphecyCount(), "onJoin did not add an active prophecy for target1 on reconnect");
+
+        // getProphecy will return a prophecy about the specified player when they are online
+        prophecies.resetProphecies(); // clear the prophecies to reset
+        prophecies.addProphecy(new O2Prophecy(testPlugin, O2EffectType.UNLUCK, message2, target2.getUniqueId(), prophet2.getUniqueId(), delayTicks, effectDurationTicks, maxAccuracy));
+        assertNotNull(prophecies.getProphecy(target2.getUniqueId()));
+
+        // getProphecy will return a prophecy about the specified player when they are offline
+        target2.disconnect();
+        assertNotNull(prophecies.getProphecy(target2.getUniqueId()));
+
+        // getProphecy will return a prophecy about the specified player when it has moved to the offline list
+        mockServer.getScheduler().performTicks(delayTicks + 1);
+        assertNotNull(prophecies.getProphecy(target2.getUniqueId()));
+    }
+
+    /**
+     * Global test teardown. Unmocks the MockBukkit server.
+     */
+    @AfterAll
+    static void globalTearDown () {
+        prophecies.resetProphecies();
+        MockBukkit.unmock();
+
+        Ollivanders2.debug = false;
+    }
+}

--- a/Ollivanders/test/java/ollivanders/divination/O2ProphecyTest.java
+++ b/Ollivanders/test/java/ollivanders/divination/O2ProphecyTest.java
@@ -1,0 +1,172 @@
+package ollivanders.divination;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.divination.O2Prophecy;
+import net.pottercraft.ollivanders2.effect.O2Effect;
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import ollivanders.testcommon.TestCommon;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for O2Prophecy class.
+ * Tests cover prophecy aging, killing, fulfillment with high and low accuracy,
+ * message broadcasting, effect application, and behavior with offline players.
+ * All tests are in a single mega test method to avoid test order interference with JUnit 5.
+ */
+public class O2ProphecyTest {
+    static ServerMock mockServer;
+    static int maxAccuracy;
+    static Ollivanders2 testPlugin;
+    static PlayerMock prophet;
+    static PlayerMock target;
+
+    /**
+     * Global test setup. Initializes MockBukkit server, loads the plugin with configuration,
+     * creates two test players (prophet and target), and advances the server to allow the scheduler to start.
+     */
+    @BeforeAll
+    static void globalSetUp() {
+        mockServer = MockBukkit.mock();
+        maxAccuracy = O2Prophecy.maxAccuracy;
+
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+        prophet = mockServer.addPlayer("prophet");
+        target = mockServer.addPlayer("target");
+
+        // advance the server to let the scheduler start
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
+    }
+
+    /**
+     * Comprehensive test of O2Prophecy functionality.
+     * Tests include:
+     * - Aging prophecies and verifying time decreases
+     * - Killing prophecies and checking killed state
+     * - High accuracy (99) prophecy fulfillment with successful effect application
+     * - Verification of broadcast messages to both target and prophet
+     * - Effect duration expiration
+     * - Low accuracy (0) prophecy fulfillment with failure messaging
+     * - Prophecy fulfillment deferred when target is offline
+     * - Prophecy fulfillment when offline target reconnects
+     * - Prophecy fulfillment when prophet is offline (target still receives effect)
+     * - Prophecy not fulfilled if already killed before fulfill() call
+     *
+     * This is a mega test case to avoid non-deterministic test run order issues with JUnit 5.
+     */
+    @Test
+    void prophecyTest() {
+        Ollivanders2.debug = true;
+        String prophecyMessage = "test prophecy message";
+        O2EffectType prophecyEffect = O2EffectType.FAST_LEARNING;
+        int effectDuration = O2Effect.minDuration; // must be > 5
+
+        // test age()
+        O2Prophecy prophecy = new O2Prophecy(testPlugin, prophecyEffect, prophecyMessage, target.getUniqueId(), prophet.getUniqueId(), 10, effectDuration, 99);
+
+        long age = prophecy.getTime();
+        prophecy.age();
+        assertEquals((age - 1), prophecy.getTime(), "prophecy.age() did not reduce prophecy age by 1");
+
+        // test kill() and isKilled()
+        assertFalse(prophecy.isKilled(), "Prophecy set to killed when not expected");
+        prophecy.kill();
+        assertTrue(prophecy.isKilled(), "Prophecy not set to killed when expected");
+
+        // test fulfill
+        // a prophecy with max accuracy - so should succeed
+        prophecy = new O2Prophecy(testPlugin, prophecyEffect, prophecyMessage, target.getUniqueId(), prophet.getUniqueId(), 10, effectDuration, 99);
+        prophecy.fulfill();
+        mockServer.getScheduler().performTicks(5);
+
+        // prophecy sent a message to both the target and player
+        String targetReceivedMessage = target.nextMessage();
+        assertNotNull(targetReceivedMessage, "target did not receive a prophecy message");
+        String prophetReceivedMessage = prophet.nextMessage();
+        assertNotNull(prophetReceivedMessage, "prophet did not receive a prophecy message");
+
+        // target got the prophecy broadcast with the prophet's name and the prophecy message
+        assertTrue(targetReceivedMessage.contains(prophet.getName()), "prophecy broadcast did not contain prophet's name");
+        assertTrue(targetReceivedMessage.contains("And so came to pass the prophecy"), "Prophecy broadcast message does not contain 'And so came to pass the prophecy'");
+        assertTrue(targetReceivedMessage.contains(prophecyMessage), "prophecy broadcast did not contain expected prophecy message, expected: " + prophecyMessage + ", actual: " + targetReceivedMessage);
+
+        // prophet also got the prophecy broadcast
+        assertTrue(prophetReceivedMessage.contains("And so came to pass the prophecy"), "Prophet did not receive the prophecy success broadcast message");
+
+        // prophecy added the effect to the target
+        assertTrue(Ollivanders2API.getPlayers().playerEffects.hasEffect(target.getUniqueId(), prophecyEffect), "Target does not have prophecy effect");
+
+        // prophecy does not add the effect to the prophet
+        assertFalse(Ollivanders2API.getPlayers().playerEffects.hasEffect(prophet.getUniqueId(), prophecyEffect), "Prophet has the prophecy effect");
+
+        // effect duration is correct
+        mockServer.getScheduler().performTicks(effectDuration); // we've already done 5 ticks, doing effectDuration more should ensure the effect has been removed
+        assertFalse(Ollivanders2API.getPlayers().playerEffects.hasEffect(target.getUniqueId(), prophecyEffect), "Target still has the prophecy effect after expected duration");
+
+        // low accuracy prophecy sends failure message to prophet and nothing to target, no effect added to target
+        prophecyMessage = "low accuracy prophecy";
+        prophecy = new O2Prophecy(testPlugin, prophecyEffect, prophecyMessage, target.getUniqueId(), prophet.getUniqueId(), 10, 10, 0);
+        prophecy.fulfill();
+        prophetReceivedMessage = prophet.nextMessage();
+        assertNotNull(prophetReceivedMessage, "prophet did not receive a prophecy message");
+        assertTrue(prophetReceivedMessage.contains("did not come to pass"), "Prophet did not receive the prophecy failure message");
+        targetReceivedMessage = target.nextMessage();
+        assertNull(targetReceivedMessage, "Target received prophecy message when prophecy failed");
+        assertFalse(Ollivanders2API.getPlayers().playerEffects.hasEffect(target.getUniqueId(), prophecyEffect), "Target has the prophecy effect when prophecy failed");
+
+        // prophecy fulfillment deferred when target is offline
+        prophecy = new O2Prophecy(testPlugin, prophecyEffect, "test", target.getUniqueId(), prophet.getUniqueId(), 3, effectDuration, 99);
+        Ollivanders2API.getProphecies().addProphecy(prophecy); // add it to the prophecy manager so we can test the persistence
+        target.disconnect();
+        mockServer.getScheduler().performTicks(5); // advance the ticks past the delay time so O2Prophecies will call fulfill
+        prophetReceivedMessage = prophet.nextMessage();
+        assertNull(prophetReceivedMessage, "Prophet received prophecy message when target offline: " + prophetReceivedMessage);
+
+        // prophecy is fulfilled when target comes back online - technically this is testing O2Prophecies.java but it is easier to do here when we have the server in the right state.
+        target.reconnect();
+        mockServer.getScheduler().performTicks(5);
+        assertNotNull(prophet.nextMessage(), "Prophet did not receive prophecy message when target reconnected");
+        assertNotNull(target.nextMessage(), "Target did not receive prophecy message when they reconnected");
+        assertTrue(Ollivanders2API.getPlayers().playerEffects.hasEffect(target.getUniqueId(), prophecyEffect), "Target does not have prophecy effect");
+
+        // prophecies are fulfilled when prophets are offline
+        mockServer.getScheduler().performTicks(effectDuration); // expire the current effect
+        prophecy = new O2Prophecy(testPlugin, prophecyEffect, prophecyMessage, target.getUniqueId(), prophet.getUniqueId(), 10, 10, 99);
+        prophet.disconnect();
+        mockServer.getScheduler().performTicks(5);
+        prophecy.fulfill();
+        assertNotNull(target.nextMessage(), "Target did not receive prophecy message when they reconnected");
+        assertTrue(Ollivanders2API.getPlayers().playerEffects.hasEffect(target.getUniqueId(), prophecyEffect), "Target does not have prophecy effect");
+
+        // prophecies are not fulfilled if prophecy already killed
+        prophecyEffect = O2EffectType.BABBLING;
+        prophecy = new O2Prophecy(testPlugin, prophecyEffect, prophecyMessage, target.getUniqueId(), prophet.getUniqueId(), 10, 10, 99);
+        prophecy.kill();
+        prophecy.fulfill();
+        assertNull(target.nextMessage(), "target received prophecy message when prophecy was killed before fulfill()");
+        assertNull(prophet.nextMessage(), "prophet received prophecy message when prophecy was killed before fulfill()");
+        assertFalse(Ollivanders2API.getPlayers().playerEffects.hasEffect(target.getUniqueId(), prophecyEffect), "Target has the prophecy effect when prophecy was killed before fulfill()");
+    }
+
+    /**
+     * Global test teardown. Unmocks the MockBukkit server.
+     */
+    @AfterAll
+    static void globalTearDown () {
+        MockBukkit.unmock();
+        Ollivanders2.debug = false;
+    }
+}

--- a/Ollivanders/test/java/ollivanders/divination/OvomancyTest.java
+++ b/Ollivanders/test/java/ollivanders/divination/OvomancyTest.java
@@ -1,0 +1,12 @@
+package ollivanders.divination;
+
+import net.pottercraft.ollivanders2.divination.O2Divination;
+import net.pottercraft.ollivanders2.divination.OVOMANCY;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class OvomancyTest extends DivinationTestSuper {
+    O2Divination createDivination(@NotNull Player prophet, @NotNull Player target, int experience) {
+        return new OVOMANCY(testPlugin, prophet, target, experience);
+    }
+}

--- a/Ollivanders/test/java/ollivanders/divination/TasseomancyTest.java
+++ b/Ollivanders/test/java/ollivanders/divination/TasseomancyTest.java
@@ -1,0 +1,12 @@
+package ollivanders.divination;
+
+import net.pottercraft.ollivanders2.divination.O2Divination;
+import net.pottercraft.ollivanders2.divination.TASSEOMANCY;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class TasseomancyTest extends DivinationTestSuper {
+    O2Divination createDivination(@NotNull Player prophet, @NotNull Player target, int experience) {
+        return new TASSEOMANCY(testPlugin, prophet, target, experience);
+    }
+}

--- a/Ollivanders/test/java/ollivanders/testcommon/TestCommon.java
+++ b/Ollivanders/test/java/ollivanders/testcommon/TestCommon.java
@@ -9,12 +9,19 @@ import org.jetbrains.annotations.Nullable;
 import org.mockbukkit.mockbukkit.ServerMock;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Common functions for tests
  */
 public class TestCommon {
+    /**
+     * Number of ticks needed after server start to make sure the scheduler, etc are running
+     */
+    static public int startupTicks = 100;
+
     /**
      * Compare the message received by a player to the expected message. This needs a helper because
      * we need to strip chat color codes from the messages sent by the plugin.
@@ -52,7 +59,7 @@ public class TestCommon {
      * @return the server response for the command
      */
     @Nullable
-    public static String runCommand (PlayerMock player, String command, ServerMock mockServer) {
+    public static String runCommand (@NotNull PlayerMock player, @NotNull String command, @NotNull ServerMock mockServer) {
         assertTrue(player.performCommand(command), "Player cannot run the " + command + " command");
         mockServer.getScheduler().performTicks(10);
         String commandResponse = player.nextMessage();
@@ -66,7 +73,7 @@ public class TestCommon {
      * @param itemType the type to check for
      * @return true if found, false otherwise
      */
-    public static boolean isInPlayerInventory(PlayerMock player, Material itemType) {
+    public static boolean isInPlayerInventory(@NotNull PlayerMock player, @NotNull Material itemType) {
         for (ItemStack itemStack : player.getInventory().getContents()) {
             if (itemStack.getType() == itemType) {
                 return true;
@@ -84,7 +91,7 @@ public class TestCommon {
      * @param name the name the item needs to have
      * @return true if found, false otherwise
      */
-    public static boolean isInPlayerInventory(PlayerMock player, Material itemType, String name) {
+    public static boolean isInPlayerInventory(@NotNull PlayerMock player, @NotNull Material itemType, @NotNull String name) {
         for (ItemStack itemStack : player.getInventory().getContents()) {
             if (itemStack == null)
                 continue;
@@ -106,5 +113,19 @@ public class TestCommon {
         return false;
     }
 
+    /**
+     * Determine if any string in a list contains the specified substring.
+     *
+     * @param stringList the string list to check
+     * @param subString the substring to match
+     * @return true if found, false otherwise
+     */
+    static public boolean containsStringMatch(List<String> stringList, String subString) {
+        for (String string : stringList) {
+            if (string.contains(subString))
+                return true;
+        }
 
+        return false;
+    }
 }


### PR DESCRIPTION
* added tests for all classes in the divination package
* fixed books tests to advance the server ticks so the scheduler, etc are started
* made some functions and class variables public so the test can call them
* fixed bug in O2Prophecies using == and not .equals to compare UUIDs
* added resetProphecies() and activeProphecyCount() test hooks
* moved prophecy max accuracy to a static class variable
* fixed some javadoc and comments
* added missing @NotNull annotations in some test helper functions
* added TestCommon helper to find if a string in a list matches a substring