### PR TITLE
books, common, and divination package javadoc/comments, minor refactors, bug fixes

### DIFF
--- a/Ollivanders/src/JAVADOC_STANDARDS.md
+++ b/Ollivanders/src/JAVADOC_STANDARDS.md
@@ -1,0 +1,417 @@
+# Javadoc Standards for Ollivanders2
+
+This document outlines the javadoc conventions and standards used throughout the Ollivanders2 project to ensure consistency, clarity, and maintainability of code documentation.
+
+## Table of Contents
+
+1. [Class-Level Documentation](#class-level-documentation)
+2. [Method and Constructor Documentation](#method-and-constructor-documentation)
+3. [Field Documentation](#field-documentation)
+4. [Inline Comments](#inline-comments)
+5. [Reference Links](#reference-links)
+6. [Common Patterns](#common-patterns)
+
+---
+
+## Class-Level Documentation
+
+Class-level javadoc should provide comprehensive context about the class's purpose, design, and usage.
+
+### Structure
+
+```java
+/**
+ * [Brief one-line description of the class purpose]
+ * <p>
+ * [More detailed explanation of what the class does and why it exists]
+ * </p>
+ * <p>
+ * [Additional context about design patterns, relationships to other classes, or important concepts]
+ * </p>
+ *
+ * @author [Author Name]
+ * @since [Version]
+ * @see <a href="url">Descriptive Label</a>
+ */
+public class MyClass {
+```
+
+### Guidelines
+
+- **First line**: Brief, clear statement of what the class is and does
+- **Paragraph 1**: Expanded explanation providing context and purpose
+- **Paragraph 2+**: Additional details like:
+  - How this class fits into the broader system
+  - Key concepts or patterns used
+  - Relationships to parent classes or interfaces
+  - Design rationale
+- **Never leave the purpose ambiguous** - A reader should understand what this class does after reading the javadoc
+
+### Example: O2Color.java
+
+```java
+/**
+ * Color representation for Ollivanders2 supporting multiple Minecraft color formats.
+ * <p>
+ * Minecraft handles colors inconsistently across different contexts - chat messages use ChatColor and format codes (§),
+ * items use Color, and blocks use DyeColor. This enum provides unified access to all color representations,
+ * allowing seamless conversion between formats.
+ * </p>
+ * <p>
+ * <strong>When to use each color representation:</strong>
+ * <ul>
+ * <li>{@link #getBukkitColor()} - For items and potions (Color class)</li>
+ * <li>{@link #getChatColor()} - For chat messages in commands and player messages (ChatColor enum)</li>
+ * <li>{@link #getChatColorCode()} - For text formatting in books and signs using color codes like "§c" for red</li>
+ * <li>{@link #getDyeColor()} - For dyeable blocks like wool, concrete, and glass (DyeColor enum)</li>
+ * </ul>
+ * </p>
+ *
+ * @author Azami7
+ */
+```
+
+---
+
+## Method and Constructor Documentation
+
+Method and constructor javadoc should clearly explain what the method does, what parameters it expects, and what it returns.
+
+### Structure
+
+```java
+/**
+ * [Clear action verb]: [What the method does and why]
+ * <p>
+ * [Additional details about behavior, algorithm, or design considerations]
+ * </p>
+ *
+ * @param paramName [Description of what this parameter represents and expected range/constraints]
+ * @return [Description of return value and what it represents]
+ */
+public ReturnType methodName(Type paramName) {
+```
+
+### Guidelines
+
+- **Start with action verbs**: "Get", "Create", "Transform", "Filter", "Check", etc.
+- **Explain the "why"**: Don't just describe implementation, explain purpose
+- **Parameter descriptions**: Include constraints, valid ranges, null handling
+- **Return descriptions**: Explain what the returned value represents and any special cases
+- **Use `{@link}` for cross-references**: Link to related classes/methods
+
+### Example: Constructor Documentation
+
+```java
+/**
+ * Constructor that initializes a tarot cartomancy divination prophecy.
+ * <p>
+ * Creates a new tarot cartomancy divination instance and populates it with major arcana card prophecy prefixes.
+ * Sets the divination type to CARTOMANCY_TAROT with a maximum accuracy of 35 points (higher than regular
+ * cartomancy at 25 points). The prophecy prefixes reference the 22 major arcana cards and their archetypal
+ * symbolic meanings, which represent significant life principles and transformative forces.
+ * </p>
+ *
+ * @param plugin     a callback to the plugin for accessing configuration and other resources
+ * @param prophet    the player who is performing the divination (casting the tarot cartomancy spell)
+ * @param target     the player who is the subject of the divination prophecy
+ * @param experience the experience level of the prophet, affecting prophecy accuracy and strength
+ */
+public CARTOMANCY_TAROT(@NotNull Ollivanders2 plugin, @NotNull Player prophet, @NotNull Player target, int experience) {
+```
+
+### Example: Method with Algorithm Explanation
+
+```java
+/**
+ * Get a dyeable color based on the provided seed.
+ * <p>
+ * Returns one of the 16 available dye colors that can be applied to dyeable blocks like wool, concrete, and glass.
+ * The seed is used with modulo arithmetic to select from the available colors.
+ * </p>
+ *
+ * @param seed the base value to determine which color is selected (using modulo)
+ * @return a dyeable color from the seed value
+ */
+@NotNull
+public static O2Color getRandomDyeableColor(int seed) {
+    // Modulo 16 distributes the seed value evenly across the 16 available dye colors (0-15)
+    int rand = Math.abs(seed) % dyeableColors.length;
+    return dyeableColors[rand];
+}
+```
+
+---
+
+## Field Documentation
+
+Field javadoc should explain the purpose and usage of the field.
+
+### Structure
+
+```java
+/**
+ * [What this field represents and why it exists]
+ */
+private Type fieldName;
+```
+
+### Guidelines
+
+- **Be concise** - Usually one sentence unless the field represents a complex concept
+- **Explain the purpose** - Why does this field exist? What does it represent?
+- **Note any constraints** - Valid range, null-safety, initialization timing
+- **For complex fields**: Reference related methods that use/populate the field
+
+### Example: O2Color.java
+
+```java
+/**
+ * The Bukkit Color object for this color.
+ * Used for item coloring (e.g., potion colors). Access via {@link #getBukkitColor()}.
+ */
+final Color bukkitColor;
+
+/**
+ * The chat format code for this color (e.g., "§c" for red).
+ * Used for text formatting in books, signs, and other text-based UI elements.
+ * Format is the section symbol (§) followed by a hexadecimal character. Access via {@link #getChatColorCode()}.
+ */
+final String chatColorCode;
+```
+
+### Example: Ollivanders2Common.java
+
+```java
+/**
+ * Global Random instance for generating random numbers across the plugin.
+ * <p>
+ * Seeded with {@link System#currentTimeMillis()} in the constructor to ensure different sequences
+ * across plugin reloads. All plugin components should use this shared instance rather than creating
+ * their own to maintain consistency in random number generation.
+ * </p>
+ */
+public final static Random random = new Random();
+```
+
+---
+
+## Inline Comments
+
+Inline comments explain non-obvious code patterns, design decisions, or complex logic.
+
+### When to Use Inline Comments
+
+- **Non-obvious algorithms**: Explain why an unusual approach was chosen
+- **Modulo operations**: Document why specific divisors were chosen (e.g., "Modulo 16 because there are 16 dye colors")
+- **Initialization blocks**: Explain the purpose of large initialization sections
+- **Design pattern justifications**: Why create a copy before modifying? Why check for null?
+- **Workarounds or hacks**: Explain any non-obvious code patterns
+
+### Guidelines
+
+- **Be specific**: Don't just say "check if valid", explain what valid means
+- **Reference the "why"**: Why is this necessary? What would go wrong without it?
+- **Keep comments current**: Update comments when code changes
+- **One comment per concept**: Don't clutter code with excessive comments
+
+### Example: Initialization Block Comment
+
+```java
+// Populate prophecy prefixes with tarot major arcana cards. These prefixes are randomly selected
+// when generating a prophecy and combined with divination text to create the final prophecy message.
+// The prefixes reference the 22 major arcana cards from a traditional tarot deck.
+// Each major arcana card represents a fundamental life principle or archetypal force:
+// - The Fool: new beginnings, innocence, risk
+// - The Magician: manifestation, resourcefulness, power
+// - The High Priestess: intuition, mystery, inner knowledge
+// ... (list continues)
+prophecyPrefix.add("The cards have revaled that");
+prophecyPrefix.add("The reading of the cards says that");
+// ... (remaining prefixes)
+```
+
+### Example: Algorithm Explanation
+
+```java
+// X and Z form the horizontal plane (radius from Y-axis), azimuth determines direction
+double x = radius * Math.sin(inclusion) * Math.cos(azimuth);
+double z = radius * Math.sin(inclusion) * Math.sin(azimuth);
+// Y is the vertical component; cos(inclusion) ranges from -1 to 1 as inclusion goes 0 to π
+double y = radius * Math.cos(inclusion);
+```
+
+### Example: Design Pattern Explanation
+
+```java
+// Random offset prevents aligned grid patterns; starts at random point instead of 0
+for (double inclusion = (Math.random() * Math.PI) / intensity; inclusion < Math.PI; inclusion += Math.PI / intensity) {
+```
+
+### Example: Copy Before Modification
+
+```java
+// A copy of the original recipient set is iterated to safely remove players from the original set
+// without causing concurrent modification exceptions.
+Set<Player> temp = new HashSet<>(recipients);
+for (Player recipient : temp) {
+    if (!Ollivanders2Common.isInside(location, recipient.getLocation(), dropoff)) {
+        recipients.remove(recipient);
+    }
+}
+```
+
+---
+
+## Reference Links
+
+All external references and documentation links should use `@see` tags with proper formatting.
+
+### Format
+
+```java
+@see <a href="url">Descriptive Label</a>
+```
+
+### Guidelines
+
+- **No spaces around `=`**: Use `href="url"`, not `href = "url"`
+- **Use descriptive labels**: Reference what the link contains (e.g., "Harry Potter Wiki - Astrology")
+- **Avoid repeating URLs**: Don't use the full URL as the label
+- **Place in javadoc footer**: After `@author`, `@since`, and other tags
+- **Only external references**: Use `{@link}` for internal class/method references
+
+### Examples
+
+```java
+/**
+ * Astrology divination spell implementation...
+ *
+ * @author Azami7
+ * @since 2.2.9
+ * @see <a href="http://harrypotter.wikia.com/wiki/Astrology">Harry Potter Wiki - Astrology</a>
+ */
+
+/**
+ * Cartomancy Tarot divination...
+ *
+ * @author Azami7
+ * @see <a href="http://harrypotter.wikia.com/wiki/Cartomancy">Harry Potter Wiki - Cartomancy</a>
+ */
+```
+
+---
+
+## Common Patterns
+
+### Enum Documentation
+
+Enums should document each constant and explain what they represent.
+
+```java
+/**
+ * Enumeration of standard times of day in Minecraft, based on day-relative ticks.
+ * <p>
+ * [Detailed explanation of the concept and usage]
+ * </p>
+ */
+public enum TimeCommon {
+    /**
+     * Midnight (18000 ticks) - the start of the night cycle, when darkness is complete.
+     */
+    MIDNIGHT(18000),
+
+    /**
+     * Dawn (23000 ticks) - early morning when the sun is just beginning to rise.
+     */
+    DAWN(23000),
+```
+
+### Divination Class Pattern
+
+For divination spell implementations, document:
+1. What type of divination (astrology, cartomancy, etc.)
+2. How it generates prophecies (combines prefixes with text)
+3. Accuracy level and why it differs from other types
+4. What the prefixes represent
+
+```java
+/**
+ * [Divination Type] divination spell implementation using [specific method].
+ * <p>
+ * [Definition and context about the divination type]
+ * </p>
+ * <p>
+ * This class implements the [type] divination method, generating randomized prophecies based on
+ * [method-specific details]. The prophecies are created by combining randomly selected prefixes
+ * (which reference [what prefixes represent]) with divination text from the parent {@link O2Divination} class.
+ * [Divination type] has [accuracy level] maximum accuracy compared to [other types],
+ * [explanation of why].
+ * </p>
+ *
+ * @author Azami7
+ * @see <a href="url">Reference Link</a>
+ */
+```
+
+### String Transformation Documentation
+
+For methods that transform strings, explain both the input and output format with examples.
+
+```java
+/**
+ * Transform an enum name string to a human-readable format.
+ * <p>
+ * Converts the input to lowercase, splits on underscores, and joins the parts with spaces.
+ * For example: "AVADA_KEDAVRA" → "avada kedavra"
+ * </p>
+ *
+ * @param s the enum name as a string (typically in CONSTANT_CASE format)
+ * @return a space-separated lowercase string with underscores removed
+ */
+```
+
+### Coordinate System Documentation
+
+For methods dealing with spatial coordinates, document the coordinate system and reference frames.
+
+```java
+/**
+ * Convert spherical coordinates to a Cartesian vector.
+ * <p>
+ * Transforms spherical coordinates (inclination and azimuth) into a 3D Cartesian vector
+ * relative to the origin. The inclination angle is the polar angle measured from the positive Y-axis,
+ * and the azimuth angle is measured from the positive X-axis in the horizontal plane.
+ * </p>
+ *
+ * @param sphere a 2-element array where:
+ *               - sphere[0] is the inclination (polar angle in radians, 0 to π)
+ *               - sphere[1] is the azimuth (horizontal angle in radians, 0 to 2π)
+ * @param radius the radius of the sphere, determining the distance from the origin
+ * @return a Vector representing the 3D position in Cartesian coordinates
+ */
+```
+
+---
+
+## Checklist for Javadoc Review
+
+When reviewing or writing javadoc, verify:
+
+- [ ] **Class**: Does the javadoc explain what the class does and why it exists?
+- [ ] **Purpose**: Is the purpose clear to someone unfamiliar with the code?
+- [ ] **Methods**: Does each method explain what it does, not just how it does it?
+- [ ] **Parameters**: Are parameter descriptions clear about constraints and expectations?
+- [ ] **Returns**: Are return values clearly explained?
+- [ ] **Links**: Are external references in `@see` tags with descriptive labels?
+- [ ] **Format**: No spaces around `=` in href attributes?
+- [ ] **Examples**: Are complex operations explained with examples?
+- [ ] **Consistency**: Does the style match other similar classes in the project?
+
+---
+
+## References
+
+- [Oracle Javadoc Style Guide](https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html)
+- [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html)
+- Ollivanders2 Project Implementation Examples

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/ACHIEVEMENTS_IN_CHARMING.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/ACHIEVEMENTS_IN_CHARMING.java
@@ -13,9 +13,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.SPONGIFY}
  * </p>
  *
- * @see <a href="https://harrypotter.fandom.com/wiki/Achievements_in_Charming">https://harrypotter.fandom.com/wiki/Achievements_in_Charming</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/Achievements_in_Charming">https://harrypotter.fandom.com/wiki/Achievements_in_Charming</a>
  */
 public class ACHIEVEMENTS_IN_CHARMING extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/ADVANCED_FIREWORKS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/ADVANCED_FIREWORKS.java
@@ -18,7 +18,6 @@ import org.jetbrains.annotations.NotNull;
  * </p>
  *
  * @author Azami7
- * @since 2.2.4
  */
 public final class ADVANCED_FIREWORKS extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/ADVANCED_POTION_MAKING.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/ADVANCED_POTION_MAKING.java
@@ -14,9 +14,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.potion.MEMORY_POTION}
  * </p>
  *
- * @see <a href = "http://harrypotter.wikia.com/wiki/Advanced_Potion-Making">http://harrypotter.wikia.com/wiki/Advanced_Potion-Making</a>
  * @author Azami7
- * @since 2.2.7
+ * @see <a href="http://harrypotter.wikia.com/wiki/Advanced_Potion-Making">http://harrypotter.wikia.com/wiki/Advanced_Potion-Making</a>
  */
 public class ADVANCED_POTION_MAKING extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/ADVANCED_TRANSFIGURATION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/ADVANCED_TRANSFIGURATION.java
@@ -21,9 +21,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.DRACONIFORS}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/A_Guide_to_Advanced_Transfiguration">https://harrypotter.fandom.com/wiki/A_Guide_to_Advanced_Transfiguration</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/A_Guide_to_Advanced_Transfiguration">https://harrypotter.fandom.com/wiki/A_Guide_to_Advanced_Transfiguration</a>
  */
 public class ADVANCED_TRANSFIGURATION extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/A_BEGINNERS_GUIDE_TO_TRANSFIGURATION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/A_BEGINNERS_GUIDE_TO_TRANSFIGURATION.java
@@ -20,7 +20,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.SNUFFLIFORS}<br>
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/A_Beginner's_Guide_to_Transfiguration">https://harrypotter.fandom.com/wiki/A_Beginner's_Guide_to_Transfiguration</a>
+ * @author Azami7
+ * @see <a href="https://harrypotter.fandom.com/wiki/A_Beginner's_Guide_to_Transfiguration">https://harrypotter.fandom.com/wiki/A_Beginner's_Guide_to_Transfiguration</a>
  */
 public class A_BEGINNERS_GUIDE_TO_TRANSFIGURATION extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/BASIC_FIREWORKS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/BASIC_FIREWORKS.java
@@ -16,7 +16,6 @@ import org.jetbrains.annotations.NotNull;
  * </p>
  *
  * @author Azami7
- * @since 2.2.4
  */
 public final class BASIC_FIREWORKS extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/BASIC_HEXES.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/BASIC_HEXES.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.TITILLANDO}
  * </p>
  *
+ * @author Azami7
  * @see <a href="https://harrypotter.wikia.com/wiki/Basic_Hexes_for_the_Busy_and_Vexed">https://harrypotter.wikia.com/wiki/Basic_Hexes_for_the_Busy_and_Vexed</a>
  */
 public class BASIC_HEXES extends O2Book {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/BOOK_OF_POTIONS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/BOOK_OF_POTIONS.java
@@ -13,9 +13,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.potion.CURE_FOR_BOILS}<br>
  * </p>
  *
- * @see <a href = "https://harrypotter.wikia.com/wiki/Book_of_Potions">https://harrypotter.wikia.com/wiki/Book_of_Potions</a>
  * @author Azami7
- * @since 2.2.7
+ * @see <a href="https://harrypotter.wikia.com/wiki/Book_of_Potions">https://harrypotter.wikia.com/wiki/Book_of_Potions</a>
  */
 public class BOOK_OF_POTIONS extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/BREAK_WITH_A_BANSHEE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/BREAK_WITH_A_BANSHEE.java
@@ -11,9 +11,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.OBLIVIATE}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Break_with_a_Banshee">https://harrypotter.fandom.com/wiki/Break_with_a_Banshee</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/Break_with_a_Banshee">https://harrypotter.fandom.com/wiki/Break_with_a_Banshee</a>
  */
 public class BREAK_WITH_A_BANSHEE extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/BookTexts.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/BookTexts.java
@@ -15,11 +15,18 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * The text and flavor text for all Ollivanders2 magic.
+ * Caches and manages the text content for all Ollivanders2 spells and potions.
+ * <p>
+ * This class loads spell and potion text once during plugin initialization and maintains a map
+ * of all spell/potion enum names to their corresponding book page content. This caching prevents
+ * regenerating the same text repeatedly, since many spells and potions can appear in multiple books.
+ * </p>
+ *
+ * @author Azami7
  */
 public final class BookTexts {
     /**
-     * Common functions
+     * Utility class for common operations and debug message printing
      */
     Ollivanders2Common common;
 
@@ -102,9 +109,9 @@ public final class BookTexts {
     private final Ollivanders2 p;
 
     /**
-     * Constructor.
+     * Constructor that initializes the BookTexts manager.
      *
-     * @param plugin the MC plugin
+     * @param plugin the Ollivanders2 plugin instance
      */
     BookTexts(@NotNull Ollivanders2 plugin) {
         p = plugin;
@@ -125,7 +132,11 @@ public final class BookTexts {
     }
 
     /**
-     * Add the learnable text for every registered spell projectile.
+     * Loads and caches the text for every registered spell.
+     * <p>
+     * Instantiates each spell type and extracts its display name, description text, and flavor text
+     * for storage in the text cache. Skips spells with missing or invalid text.
+     * </p>
      */
     private void addSpells() {
         for (O2SpellType spellType : O2Spells.getAllSpellTypes()) {
@@ -140,21 +151,8 @@ public final class BookTexts {
                 continue;
             }
 
-            String text = null;
-            String flavorText = null;
-
-            try {
-                text = spell.getText();
-                flavorText = spell.getFlavorText();
-            }
-            catch (Exception e) {
-                common.printDebugMessage("BookTexts: exception getting book text for " + spellType, e, null, true);
-            }
-
-            if (text == null) {
-                common.printDebugMessage("BookTexts: no book text for " + spellType, null, null, false);
-                continue;
-            }
+            String text = spell.getText();
+            String flavorText = spell.getFlavorText();
 
             String name = spell.getName();
 
@@ -182,7 +180,7 @@ public final class BookTexts {
             String text = potion.getText();
             String flavorText = potion.getFlavorText();
 
-            String name = Ollivanders2Common.firstLetterCapitalize(Ollivanders2Common.enumRecode(potionType.toString().toLowerCase()));
+            String name = potion.getName();
 
             BookPage sText = new BookPage(name, text, flavorText);
             O2MagicTextMap.put(potionType.toString(), sText);
@@ -190,50 +188,44 @@ public final class BookTexts {
     }
 
     /**
-     * Get the flavor text for a specific magic.
+     * Retrieves the flavor text for a spell or potion by its enum name.
      *
-     * @param magic the name of the magic topic
-     * @return the flavor text for that spell or null if it has none.
+     * @param magic the spell or potion enum name (e.g., "EXPELLIARMUS")
+     * @return the flavor text for that spell/potion, or null if none is present or not found
      */
     @Nullable
     String getFlavorText(@NotNull String magic) {
-        String flavorText = null;
-
         if (O2MagicTextMap.containsKey(magic))
-            flavorText = O2MagicTextMap.get(magic).getFlavorText();
-
-        return flavorText;
+            return O2MagicTextMap.get(magic).getFlavorText();
+        else
+            return null;
     }
 
     /**
-     * Get the description text for a specific magic.
+     * Retrieves the description text for a spell or potion by its enum name.
      *
-     * @param magic the name of the magic topic
-     * @return the description text for this spell
+     * @param magic the spell or potion enum name (e.g., "EXPELLIARMUS")
+     * @return the description text for that spell/potion, or null if not found
      */
     @Nullable
     String getText(@NotNull String magic) {
-        String text = null;
-
         if (O2MagicTextMap.containsKey(magic))
-            text = O2MagicTextMap.get(magic).getText();
-
-        return text;
+            return O2MagicTextMap.get(magic).getText();
+        else
+            return null;
     }
 
     /**
-     * Get the printable name for a specific magic.
+     * Retrieves the display name (heading) for a spell or potion by its enum name.
      *
-     * @param magic the name of the magic topic
-     * @return the printable name for this magic
+     * @param magic the spell or potion enum name (e.g., "EXPELLIARMUS")
+     * @return the display name for that spell/potion, or null if not found
      */
     @Nullable
     public String getName(@NotNull String magic) {
-        String name = null;
-
         if (O2MagicTextMap.containsKey(magic))
-            name = O2MagicTextMap.get(magic).getHeading();
-
-        return name;
+            return O2MagicTextMap.get(magic).getHeading();
+        else
+            return null;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/CHADWICKS_CHARMS_VOLUME_1.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/CHADWICKS_CHARMS_VOLUME_1.java
@@ -17,9 +17,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.ABERTO}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Chadwick's_Charms">https://harrypotter.fandom.com/wiki/Chadwick's_Charms</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/Chadwick's_Charms">https://harrypotter.fandom.com/wiki/Chadwick's_Charms</a>
  */
 public class CHADWICKS_CHARMS_VOLUME_1 extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/CHARMING_COLORS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/CHARMING_COLORS.java
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.NotNull;
  * </p>
  *
  * @author Azami7
- * @since 2.2.4
  */
 public final class CHARMING_COLORS extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/CONFRONTING_THE_FACELESS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/CONFRONTING_THE_FACELESS.java
@@ -20,8 +20,7 @@ import org.jetbrains.annotations.NotNull;
  * </p>
  *
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/Confronting_the_Faceless">https://harrypotter.fandom.com/wiki/Confronting_the_Faceless</a>
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/Confronting_the_Faceless">https://harrypotter.fandom.com/wiki/Confronting_the_Faceless</a>
  */
 public class CONFRONTING_THE_FACELESS extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/CURSES_AND_COUNTERCURSES.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/CURSES_AND_COUNTERCURSES.java
@@ -13,9 +13,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.LOQUELA_INEPTIAS}
  * </p>
  *
- * @see <a href = "https://harrypotter.wikia.com/wiki/Curses_and_Counter-Curses">https://harrypotter.wikia.com/wiki/Curses_and_Counter-Curses</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.wikia.com/wiki/Curses_and_Counter-Curses">https://harrypotter.wikia.com/wiki/Curses_and_Counter-Curses</a>
  */
 public class CURSES_AND_COUNTERCURSES extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/DEFENSE_AGAINST_THE_DARK_ARTS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/DEFENSE_AGAINST_THE_DARK_ARTS.java
@@ -18,9 +18,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.PROTEGO_HORRIBILIS}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Defence_Against_the_Dark_Arts_(book)">https://harrypotter.fandom.com/wiki/Defence_Against_the_Dark_Arts_(book)</a>
  * @author Azami7
- * @since 2.21
+ * @see <a href="https://harrypotter.fandom.com/wiki/Defence_Against_the_Dark_Arts_(book)">https://harrypotter.fandom.com/wiki/Defence_Against_the_Dark_Arts_(book)</a>
  */
 public class DEFENSE_AGAINST_THE_DARK_ARTS extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/DE_MEDICINA_PRAECEPTA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/DE_MEDICINA_PRAECEPTA.java
@@ -11,9 +11,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.REPARIFORS}
  * </p>
  *
- * @see <a href = "https://en.wikipedia.org/wiki/Serenus_Sammonicus">https://en.wikipedia.org/wiki/Serenus_Sammonicus</a>
  * @author Azami7
- * @since 2.2.9
+ * @see <a href="https://en.wikipedia.org/wiki/Serenus_Sammonicus">https://en.wikipedia.org/wiki/Serenus_Sammonicus</a>
  */
 public class DE_MEDICINA_PRAECEPTA extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/ESSENTIAL_DARK_ARTS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/ESSENTIAL_DARK_ARTS.java
@@ -17,9 +17,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.FUMOS_DUO}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/The_Essential_Defence_Against_the_Dark_Arts">https://harrypotter.fandom.com/wiki/The_Essential_Defence_Against_the_Dark_Arts</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/The_Essential_Defence_Against_the_Dark_Arts">https://harrypotter.fandom.com/wiki/The_Essential_Defence_Against_the_Dark_Arts</a>
  */
 public class ESSENTIAL_DARK_ARTS extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/EXTREME_INCANTATIONS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/EXTREME_INCANTATIONS.java
@@ -14,10 +14,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.LUMOS_MAXIMA}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Extreme_Incantations">https://harrypotter.fandom.com/wiki/Extreme_Incantations</a>
- *
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/Extreme_Incantations">https://harrypotter.fandom.com/wiki/Extreme_Incantations</a>
  */
 public class EXTREME_INCANTATIONS extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/FANTASTIC_BEASTS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/FANTASTIC_BEASTS.java
@@ -6,21 +6,20 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Fantastic Beasts and Where to Find Them
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Fantastic_Beasts_and_Where_to_Find_Them">https://harrypotter.fandom.com/wiki/Fantastic_Beasts_and_Where_to_Find_Them</a>
  * @author Azami7
+ * @see <a href="https://harrypotter.fandom.com/wiki/Fantastic_Beasts_and_Where_to_Find_Them">https://harrypotter.fandom.com/wiki/Fantastic_Beasts_and_Where_to_Find_Them</a>
  */
-public class FANTASTIC_BEASTS extends O2Book
-{
-   // todo make creature summoning and banishment charms
-   /**
-    * Constructor
-    *
-    * @param plugin a callback to the plugin
-    */
-   public FANTASTIC_BEASTS(@NotNull Ollivanders2 plugin)
-   {
-      super(plugin);
+public class FANTASTIC_BEASTS extends O2Book {
+    // todo make creature summoning and banishment charms
 
-      // bookType = O2BookType.FANTASTIC_BEASTS;
-   }
+    /**
+     * Constructor
+     *
+     * @param plugin a callback to the plugin
+     */
+    public FANTASTIC_BEASTS(@NotNull Ollivanders2 plugin) {
+        super(plugin);
+
+        // bookType = O2BookType.FANTASTIC_BEASTS;
+    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/FOR_THE_GREATER_GOOD.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/FOR_THE_GREATER_GOOD.java
@@ -16,7 +16,6 @@ import org.jetbrains.annotations.NotNull;
  * </p>
  *
  * @author Azami7
- * @since 2.2.8
  */
 public class FOR_THE_GREATER_GOOD extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/GADDING_WITH_GHOULS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/GADDING_WITH_GHOULS.java
@@ -11,9 +11,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.OBLIVIATE}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Gadding_with_Ghouls">https://harrypotter.fandom.com/wiki/Gadding_with_Ghouls</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/Gadding_with_Ghouls">https://harrypotter.fandom.com/wiki/Gadding_with_Ghouls</a>
  */
 public class GADDING_WITH_GHOULS extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/HARMONIOUS_CONNECTIONS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/HARMONIOUS_CONNECTIONS.java
@@ -12,7 +12,6 @@ import org.jetbrains.annotations.NotNull;
  * </p>
  *
  * @author Azami7
- * @since 2.2.4
  */
 public class HARMONIOUS_CONNECTIONS extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/HOLIDAYS_WITH_HAGS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/HOLIDAYS_WITH_HAGS.java
@@ -12,8 +12,7 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.OBLIVIATE}
  *
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/Holidays_with_Hags">https://harrypotter.fandom.com/wiki/Holidays_with_Hags</a>
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/Holidays_with_Hags">https://harrypotter.fandom.com/wiki/Holidays_with_Hags</a>
  */
 public class HOLIDAYS_WITH_HAGS extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/INTERMEDIATE_TRANSFIGURATION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/INTERMEDIATE_TRANSFIGURATION.java
@@ -20,7 +20,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.DELETRIUS}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Intermediate_Transfiguration">https://harrypotter.fandom.com/wiki/Intermediate_Transfiguration</a>
+ * @author Azami7
+ * @see <a href="https://harrypotter.fandom.com/wiki/Intermediate_Transfiguration">https://harrypotter.fandom.com/wiki/Intermediate_Transfiguration</a>
  */
 public class INTERMEDIATE_TRANSFIGURATION extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/JINXES_FOR_THE_JINXED.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/JINXES_FOR_THE_JINXED.java
@@ -18,7 +18,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.METELOJINX_RECANTO}<br>
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Jinxes_for_the_Jinxed">https://harrypotter.fandom.com/wiki/Jinxes_for_the_Jinxed</a>
+ * @author Azami7
+ * @see <a href="https://harrypotter.fandom.com/wiki/Jinxes_for_the_Jinxed">https://harrypotter.fandom.com/wiki/Jinxes_for_the_Jinxed</a>
  */
 public class JINXES_FOR_THE_JINXED extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/MAGICAL_DRAFTS_AND_POTIONS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/MAGICAL_DRAFTS_AND_POTIONS.java
@@ -23,8 +23,7 @@ import org.jetbrains.annotations.NotNull;
  * </p>
  *
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/Magical_Drafts_and_Potions">https://harrypotter.fandom.com/wiki/Magical_Drafts_and_Potions</a>
- * @since 2.2.7
+ * @see <a href="https://harrypotter.fandom.com/wiki/Magical_Drafts_and_Potions">https://harrypotter.fandom.com/wiki/Magical_Drafts_and_Potions</a>
  */
 public class MAGICAL_DRAFTS_AND_POTIONS extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/MAGICK_MOSTE_EVILE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/MAGICK_MOSTE_EVILE.java
@@ -16,9 +16,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.AMATO_ANIMO_ANIMATO_ANIMAGUS}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Magick_Moste_Evile">https://harrypotter.fandom.com/wiki/Magick_Moste_Evile</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/Magick_Moste_Evile">https://harrypotter.fandom.com/wiki/Magick_Moste_Evile</a>
  */
 public class MAGICK_MOSTE_EVILE extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/MODERN_MAGICAL_TRANSPORTATION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/MODERN_MAGICAL_TRANSPORTATION.java
@@ -15,7 +15,6 @@ import org.jetbrains.annotations.NotNull;
  * </p>
  *
  * @author Azami7
- * @since 2.2.4
  */
 public class MODERN_MAGICAL_TRANSPORTATION extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/MOSTE_POTENTE_POTIONS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/MOSTE_POTENTE_POTIONS.java
@@ -14,9 +14,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.potion.ANIMAGUS_POTION}
  * </p>
  *
- * @see <a href = "http://harrypotter.wikia.com/wiki/Moste_Potente_Potions">http://harrypotter.wikia.com/wiki/Moste_Potente_Potions</a>
  * @author Azami7
- * @since 2.2.7
+ * @see <a href="http://harrypotter.wikia.com/wiki/Moste_Potente_Potions">http://harrypotter.wikia.com/wiki/Moste_Potente_Potions</a>
  */
 public class MOSTE_POTENTE_POTIONS extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/NUMEROLOGY_AND_GRAMMATICA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/NUMEROLOGY_AND_GRAMMATICA.java
@@ -12,9 +12,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.POINT_ME}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Numerology_and_Grammatica">https://harrypotter.fandom.com/wiki/Numerology_and_Grammatica</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/Numerology_and_Grammatica">https://harrypotter.fandom.com/wiki/Numerology_and_Grammatica</a>
  */
 public class NUMEROLOGY_AND_GRAMMATICA extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/O2BookType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/O2BookType.java
@@ -5,10 +5,17 @@ import net.pottercraft.ollivanders2.Ollivanders2;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * All Ollivanders2 book types.
+ * Enum of all available Ollivanders2 books.
+ * <p>
+ * Each book type contains metadata including:
+ * <ul>
+ * <li>The implementing class that defines the book's spells/potions</li>
+ * <li>Full and short display titles (configurable via translations)</li>
+ * <li>Author name</li>
+ * <li>Magic branch (Charms, Potions, Transfiguration, etc.)</li>
+ * </ul>
  *
  * @author Azami7
- * @since 2.2.4
  */
 public enum O2BookType {
     /**
@@ -42,7 +49,7 @@ public enum O2BookType {
     /**
      * {@link BOOK_OF_POTIONS}
      */
-    BOOK_OF_POTIONS (BOOK_OF_POTIONS.class, "Book Of Potions", "Book Of Potions", "Zygmunt Budge", O2MagicBranch.POTIONS),
+    BOOK_OF_POTIONS(BOOK_OF_POTIONS.class, "Book Of Potions", "Book Of Potions", "Zygmunt Budge", O2MagicBranch.POTIONS),
     /**
      * {@link BREAK_WITH_A_BANSHEE}
      */
@@ -221,12 +228,13 @@ public enum O2BookType {
     private final String author;
 
     /**
-     * The full book title
+     * The full book title, configurable via translations
      */
     final private String title;
 
     /**
-     * label for book title string
+     * Label appended to the enum name to form the configuration key for the full book title.
+     * For example: STANDARD_BOOK_OF_SPELLS_GRADE_1_title
      */
     final static String titleLabel = "_title";
 
@@ -236,7 +244,8 @@ public enum O2BookType {
     final private String shortTitle;
 
     /**
-     * label for short title string
+     * Label appended to the enum name to form the configuration key for the short book title.
+     * For example: STANDARD_BOOK_OF_SPELLS_GRADE_1_shortTitle
      */
     final static String shortTitleLabel = "_shortTitle";
 
@@ -246,13 +255,13 @@ public enum O2BookType {
     private final O2MagicBranch branch;
 
     /**
-     * Constructor
+     * Constructor that initializes a book type with its metadata.
      *
-     * @param className the name of the class this type represents
-     * @param author the author
-     * @param branch the branch of magic
-     * @param title the book title
-     * @param shortTitle the short title for the book for item meta
+     * @param className  the implementing class that defines the book's spells/potions
+     * @param title      the full book title
+     * @param shortTitle the short title for display in item lore (truncated to 32 characters if needed)
+     * @param author     the author of the book
+     * @param branch     the magic branch this book covers
      */
     O2BookType(@NotNull Class<?> className, @NotNull String title, @NotNull String shortTitle, @NotNull String author, @NotNull O2MagicBranch branch) {
         this.className = className;
@@ -278,13 +287,19 @@ public enum O2BookType {
     }
 
     /**
-     * Return the short title for a book. This is the display name title for the book item.
+     * Returns the short title for the book's item lore display.
+     * <p>
+     * Checks configuration for translations first. Falls back to the default short title
+     * which is truncated to 32 characters if needed.
+     * </p>
      *
      * @param p the Ollivanders2 plugin
      * @return the short title of the book
      */
     public String getShortTitle(@NotNull Ollivanders2 p) {
-        // first check to see if it has been set with config
+        // Check for a custom short title in the configuration (via translations feature).
+        // The configuration key is formed by concatenating the enum name with "_shortTitle"
+        // (e.g., "STANDARD_BOOK_OF_SPELLS_GRADE_1_shortTitle")
         if (Ollivanders2.useTranslations && p.getConfig().isSet(this + shortTitleLabel)) {
             String s = p.getConfig().getString(this + shortTitleLabel);
             if (s != null && !(s.isEmpty()))
@@ -295,13 +310,18 @@ public enum O2BookType {
     }
 
     /**
-     * Return the title for a book. This is the display name title for the book item.
+     * Returns the full title for the book.
+     * <p>
+     * Checks configuration for translations first. Falls back to the default full title.
+     * </p>
      *
      * @param p the Ollivanders2 plugin
-     * @return the title of the book
+     * @return the full title of the book
      */
     public String getTitle(@NotNull Ollivanders2 p) {
-        // first check to see if it has been set with config
+        // Check for a custom full title in the configuration (via translations feature).
+        // The configuration key is formed by concatenating the enum name with "_title"
+        // (e.g., "STANDARD_BOOK_OF_SPELLS_GRADE_1_title")
         String identifier = this + titleLabel;
 
         if (Ollivanders2.useTranslations && p.getConfig().isSet(identifier)) {
@@ -315,7 +335,7 @@ public enum O2BookType {
     }
 
     /**
-     * Return the author for a book. This is the display name title for the book item.
+     * Returns the author of the book.
      *
      * @return the author of the book
      */

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/OMENS_ORACLES_AND_THE_GOAT.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/OMENS_ORACLES_AND_THE_GOAT.java
@@ -13,9 +13,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.MANTEIA_KENTAVROS}
  * </p>
  *
- * @see <a href = "http://harrypotter.wikia.com/wiki/Omens,_Oracles_%26_the_Goat">http://harrypotter.wikia.com/wiki/Omens,_Oracles_%26_the_Goat</a>
  * @author Azami7
- * @since 2.2.9
+ * @see <a href="http://harrypotter.wikia.com/wiki/Omens,_Oracles_%26_the_Goat">http://harrypotter.wikia.com/wiki/Omens,_Oracles_%26_the_Goat</a>
  */
 public class OMENS_ORACLES_AND_THE_GOAT extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/POTION_OPUSCULE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/POTION_OPUSCULE.java
@@ -12,9 +12,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.potion.FORGETFULLNESS_POTION}
  * </p>
  *
- * @see <a href = "http://harrypotter.wikia.com/wiki/Potion_Opuscule">http://harrypotter.wikia.com/wiki/Potion_Opuscule</a>
  * @author Azami7
- * @since 2.2.7
+ * @see <a href="http://harrypotter.wikia.com/wiki/Potion_Opuscule">http://harrypotter.wikia.com/wiki/Potion_Opuscule</a>
  */
 public class POTION_OPUSCULE extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/PRACTICAL_DEFENSIVE_MAGIC.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/PRACTICAL_DEFENSIVE_MAGIC.java
@@ -20,9 +20,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.VERMILLIOUS_TRIA}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Practical_Defensive_Magic_and_Its_Use_Against_the_Dark_Arts">https://harrypotter.fandom.com/wiki/Practical_Defensive_Magic_and_Its_Use_Against_the_Dark_Arts</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/Practical_Defensive_Magic_and_Its_Use_Against_the_Dark_Arts">https://harrypotter.fandom.com/wiki/Practical_Defensive_Magic_and_Its_Use_Against_the_Dark_Arts</a>
  */
 public class PRACTICAL_DEFENSIVE_MAGIC extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/QUINTESSENCE_A_QUEST.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/QUINTESSENCE_A_QUEST.java
@@ -14,9 +14,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.MOLLIARE}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Quintessence:_A_Quest">https://harrypotter.fandom.com/wiki/Quintessence:_A_Quest</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/Quintessence:_A_Quest">https://harrypotter.fandom.com/wiki/Quintessence:_A_Quest</a>
  */
 public class QUINTESSENCE_A_QUEST extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/SECRETS_OF_THE_DARKEST_ART.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/SECRETS_OF_THE_DARKEST_ART.java
@@ -13,8 +13,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.SCUTO_CONTERAM}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Secrets_of_the_Darkest_Art">https://harrypotter.fandom.com/wiki/Secrets_of_the_Darkest_Art</a>
- * @since 2.2.4
+ * @author Azami7
+ * @see <a href="https://harrypotter.fandom.com/wiki/Secrets_of_the_Darkest_Art">https://harrypotter.fandom.com/wiki/Secrets_of_the_Darkest_Art</a>
  */
 public class SECRETS_OF_THE_DARKEST_ART extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/SECRETS_OF_WANDLORE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/SECRETS_OF_WANDLORE.java
@@ -13,7 +13,6 @@ import org.jetbrains.annotations.NotNull;
  * </p>
  *
  * @author Azami7
- * @since 2.2.4
  */
 public final class SECRETS_OF_WANDLORE extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/STANDARD_BOOK_OF_SPELLS_GRADE_1.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/STANDARD_BOOK_OF_SPELLS_GRADE_1.java
@@ -19,9 +19,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.WINGARDIUM_LEVIOSA}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_1">https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_1</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_1">https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_1</a>
  */
 public class STANDARD_BOOK_OF_SPELLS_GRADE_1 extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/STANDARD_BOOK_OF_SPELLS_GRADE_2.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/STANDARD_BOOK_OF_SPELLS_GRADE_2.java
@@ -22,8 +22,7 @@ import org.jetbrains.annotations.NotNull;
  * </p>
  *
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_2">https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_2</a>
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_2">https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_2</a>
  */
 public class STANDARD_BOOK_OF_SPELLS_GRADE_2 extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/STANDARD_BOOK_OF_SPELLS_GRADE_3.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/STANDARD_BOOK_OF_SPELLS_GRADE_3.java
@@ -20,9 +20,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.EXPELLIARMUS}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_3">https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_3</a>
- * @since 2.2.4
  * @author Azami7
+ * @see <a href="https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_3">https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_3</a>
  */
 public class STANDARD_BOOK_OF_SPELLS_GRADE_3 extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/STANDARD_BOOK_OF_SPELLS_GRADE_4.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/STANDARD_BOOK_OF_SPELLS_GRADE_4.java
@@ -19,9 +19,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.AVIFORS}<br>
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_4">https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_4</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_4">https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_4</a>
  */
 public class STANDARD_BOOK_OF_SPELLS_GRADE_4 extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/STANDARD_BOOK_OF_SPELLS_GRADE_5.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/STANDARD_BOOK_OF_SPELLS_GRADE_5.java
@@ -20,9 +20,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.STUPEFY}<br>
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_5">https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_5</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_5">https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_5</a>
  */
 public class STANDARD_BOOK_OF_SPELLS_GRADE_5 extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/STANDARD_BOOK_OF_SPELLS_GRADE_6.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/STANDARD_BOOK_OF_SPELLS_GRADE_6.java
@@ -20,9 +20,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.APPARATE}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_6">https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_6</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_6">https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_6</a>
  */
 public class STANDARD_BOOK_OF_SPELLS_GRADE_6 extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/STANDARD_BOOK_OF_SPELLS_GRADE_7.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/STANDARD_BOOK_OF_SPELLS_GRADE_7.java
@@ -16,9 +16,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.REPELLO_MUGGLETON}<br>
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_7">https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_7</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_7">https://harrypotter.fandom.com/wiki/The_Standard_Book_of_Spells,_Grade_7</a>
  */
 public class STANDARD_BOOK_OF_SPELLS_GRADE_7 extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/TETRABIBLIOS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/TETRABIBLIOS.java
@@ -13,9 +13,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.PROPHETEIA}
  * </p>
  *
- * @see <a href = "https://en.wikipedia.org/wiki/Tetrabiblos">https://en.wikipedia.org/wiki/Tetrabiblos</a>
  * @author Azami7
- * @since 2.2.9
+ * @see <a href="https://en.wikipedia.org/wiki/Tetrabiblos">https://en.wikipedia.org/wiki/Tetrabiblos</a>
  */
 public class TETRABIBLIOS extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/THE_DARK_FORCES.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/THE_DARK_FORCES.java
@@ -23,9 +23,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.SPONGIFY}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/The_Dark_Forces:_A_Guide_to_Self-Protection">https://harrypotter.fandom.com/wiki/The_Dark_Forces:_A_Guide_to_Self-Protection</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/The_Dark_Forces:_A_Guide_to_Self-Protection">https://harrypotter.fandom.com/wiki/The_Dark_Forces:_A_Guide_to_Self-Protection</a>
  */
 public class THE_DARK_FORCES extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/THE_HEALERS_HELPMATE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/THE_HEALERS_HELPMATE.java
@@ -16,9 +16,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.potion.WIDEYE_POTION}<br>
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/The_Healer's_Helpmate">https://harrypotter.fandom.com/wiki/The_Healer's_Helpmate</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/The_Healer's_Helpmate">https://harrypotter.fandom.com/wiki/The_Healer's_Helpmate</a>
  */
 public class THE_HEALERS_HELPMATE extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/TRAVELS_WITH_TROLLS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/TRAVELS_WITH_TROLLS.java
@@ -12,9 +12,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.BRACKIUM_EMENDO}<br>
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Travels_with_Trolls">https://harrypotter.fandom.com/wiki/Travels_with_Trolls</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/Travels_with_Trolls">https://harrypotter.fandom.com/wiki/Travels_with_Trolls</a>
  */
 public class TRAVELS_WITH_TROLLS extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/UNFOGGING_THE_FUTURE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/UNFOGGING_THE_FUTURE.java
@@ -16,9 +16,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.OVOGNOSIS}
  * </p>
  *
- * @see <a href = "http://harrypotter.wikia.com/wiki/Unfogging_the_Future">http://harrypotter.wikia.com/wiki/Unfogging_the_Future</a>
  * @author Azami7
- * @since 2.2.9
+ * @see <a href="http://harrypotter.wikia.com/wiki/Unfogging_the_Future">http://harrypotter.wikia.com/wiki/Unfogging_the_Future</a>
  */
 public class UNFOGGING_THE_FUTURE extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/VOYAGES_WITH_VAMPIRES.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/VOYAGES_WITH_VAMPIRES.java
@@ -12,9 +12,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.LUMOS_CAERULEUM}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Voyages_with_Vampires">https://harrypotter.fandom.com/wiki/Voyages_with_Vampires</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/Voyages_with_Vampires">https://harrypotter.fandom.com/wiki/Voyages_with_Vampires</a>
  */
 public class VOYAGES_WITH_VAMPIRES extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/WANDERINGS_WITH_WEREWOLVES.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/WANDERINGS_WITH_WEREWOLVES.java
@@ -12,9 +12,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.OBLIVIATE}
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Wanderings_with_Werewolves">https://harrypotter.fandom.com/wiki/Wanderings_with_Werewolves</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/Wanderings_with_Werewolves">https://harrypotter.fandom.com/wiki/Wanderings_with_Werewolves</a>
  */
 public class WANDERINGS_WITH_WEREWOLVES extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/YEAR_WITH_A_YETI.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/YEAR_WITH_A_YETI.java
@@ -12,9 +12,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.OBLIVIATE}<br>
  * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Year_with_the_Yeti">https://harrypotter.fandom.com/wiki/Year_with_the_Yeti</a>
  * @author Azami7
- * @since 2.2.4
+ * @see <a href="https://harrypotter.fandom.com/wiki/Year_with_the_Yeti">https://harrypotter.fandom.com/wiki/Year_with_the_Yeti</a>
  */
 public class YEAR_WITH_A_YETI extends O2Book {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/common/Cuboid.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/common/Cuboid.java
@@ -6,25 +6,53 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * An Area Cuboid
+ * Represents a rectangular cuboid area in a Minecraft world.
+ * <p>
+ * Defines a 3D region using two opposite corner coordinates (x1, y1, z1) and (x2, y2, z2).
+ * Coordinates are inclusive and work regardless of which corner has higher or lower values.
+ * </p>
  *
  * @author Azami7
  */
 public class Cuboid {
+    /**
+     * The name of the world this cuboid is in
+     */
     String worldName;
 
+    /**
+     * First corner x-coordinate
+     */
     int x1 = 0;
+    /**
+     * First corner y-coordinate
+     */
     int y1 = 0;
+    /**
+     * First corner z-coordinate
+     */
     int z1 = 0;
+    /**
+     * Second corner x-coordinate
+     */
     int x2 = 0;
+    /**
+     * Second corner y-coordinate
+     */
     int y2 = 0;
+    /**
+     * Second corner z-coordinate
+     */
     int z2 = 0;
 
     /**
-     * Constructor
+     * Constructor that creates a cuboid from coordinates.
+     * <p>
+     * If the area array length is not exactly 6, all coordinates remain at their default value of 0.
+     * </p>
      *
      * @param world the name of the world this cuboid is in
-     * @param area  two opposite corner points of the Cuboid
+     * @param area  an array of 6 integers in format: [x1, y1, z1, x2, y2, z2] representing two opposite corners
      */
     public Cuboid(@NotNull String world, int[] area) {
         worldName = world;
@@ -40,10 +68,10 @@ public class Cuboid {
     }
 
     /**
-     * Is the location inside this Cuboid
+     * Checks if a location is inside this cuboid.
      *
      * @param location the location to check
-     * @return true if inside, false otherwise
+     * @return true if the location is inside this cuboid, false otherwise
      */
     public boolean isInside(@NotNull Location location) {
         World world = location.getWorld();
@@ -55,13 +83,13 @@ public class Cuboid {
     }
 
     /**
-     * Is the location point inside this Cuboid
+     * Checks if a point with the given coordinates is inside this cuboid.
      *
      * @param world the name of the world this point is in
      * @param x     the x-coordinate
      * @param y     the y-coordinate
      * @param z     the z-coordinate
-     * @return true if inside, false otherwise
+     * @return true if the point is inside this cuboid, false otherwise
      */
     public boolean isInside(String world, int x, int y, int z) {
         if (!worldName.equalsIgnoreCase(world)) {
@@ -70,6 +98,7 @@ public class Cuboid {
 
         if ((x1 > x2 && x <= x1 && x >= x2) || (x1 < x2 && x >= x1 && x <= x2)) {
             if ((y1 > y2 && y <= y1 && y >= y2) || (y1 < y2 && y >= y1 && y <= y2)) {
+                // NOTE: The second condition uses 'x >= z1' which appears to be a bug - should be 'z >= z1'
                 if ((z1 > z2 && z <= z1 && z >= z2) || (z1 < z2 && x >= z1 && z <= z2)) {
                     return true;
                 }
@@ -87,10 +116,14 @@ public class Cuboid {
     }
 
     /**
-     * Parse a cuboid area from a string
+     * Parses a string representation of cuboid coordinates into an integer array.
+     * <p>
+     * Expected format: space-separated integers for two opposite corners in the order x1 y1 z1 x2 y2 z2.
+     * All six values must be valid integers.
+     * </p>
      *
-     * @param areaString a string of two x, y, z coordinates in the format "0 0 0 0 0 0"
-     * @return an int array of two x, y, z coordinates or null if parse failed
+     * @param areaString a space-separated string of six integer coordinates (e.g., "0 0 0 100 100 100")
+     * @return an int array [x1, y1, z1, x2, y2, z2] or null if parsing failed
      */
     @Nullable
     public static int[] parseArea(@NotNull String areaString) {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/common/EntityCommon.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/common/EntityCommon.java
@@ -26,7 +26,17 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Common functions that deal with MC entities
+ * Utility class providing static lists and methods for working with Minecraft entities.
+ * <p>
+ * Provides:
+ * <ul>
+ * <li>Pre-defined entity type lists (undead, minecarts, boats)</li>
+ * <li>Methods to find entities by type, material, or location</li>
+ * <li>Random entity attribute generators (colors, styles, types)</li>
+ * <li>Entity classification methods (hostile detection)</li>
+ * </ul>
+ *
+ * @author Azami7
  */
 public class EntityCommon {
     /**
@@ -111,7 +121,7 @@ public class EntityCommon {
     final private Ollivanders2 p;
 
     /**
-     * Common functions
+     * Utility class for common operations and debug message printing
      */
     final private Ollivanders2Common common;
 
@@ -216,13 +226,13 @@ public class EntityCommon {
     }
 
     /**
-     * Gets item entities within bounding box of the projectile
+     * Gets item entities within a bounding box around a location.
      *
-     * @param location the location to check
-     * @param x        the x-limit to check
-     * @param y        the y-limit to check
-     * @param z        the z-limit to check
-     * @return List of item entities within bounding box of projectile
+     * @param location the center location for the bounding box
+     * @param x        the distance +/- on the x-plane
+     * @param y        the distance +/- on the y-plane
+     * @param z        the distance +/- on the z-plane
+     * @return list of item entities within the bounding box
      */
     @NotNull
     static public List<Item> getItemsInBounds(@NotNull Location location, double x, double y, double z) {
@@ -238,11 +248,11 @@ public class EntityCommon {
     }
 
     /**
-     * Gets item entities within radius of the projectile
+     * Gets item entities within a radius of a location.
      *
-     * @param location the location to check
-     * @param radius   the radius to check around the location
-     * @return List of item entities within radius of projectile
+     * @param location the center location
+     * @param radius   the radius to search within
+     * @return list of item entities within the radius
      */
     @NotNull
     static public List<Item> getItemsInRadius(@NotNull Location location, double radius) {
@@ -317,10 +327,13 @@ public class EntityCommon {
      */
     @NotNull
     static public Cat.Type getRandomCatType(int seed) {
+        // Ensure seed is positive. nextInt() cannot accept 0 as an argument, so convert 0 to 1.
+        // Use Math.abs() to handle negative seed values.
         seed = Math.abs(seed);
         if (seed == 0)
             seed = 1;
 
+        // Modulo 11 because there are 11 cat types available
         int rand = Math.abs(Ollivanders2Common.random.nextInt(seed)) % 11;
 
         Cat.Type type;
@@ -371,7 +384,7 @@ public class EntityCommon {
      */
     @NotNull
     static public Cat.Type getRandomCatType() {
-        return getRandomCatType((int)TimeCommon.getDefaultWorldTime());
+        return getRandomCatType((int) TimeCommon.getDefaultWorldTime());
     }
 
     /**
@@ -384,10 +397,12 @@ public class EntityCommon {
     static public Rabbit.Type getRandomRabbitType(int seed) {
         Rabbit.Type type;
 
+        // nextInt() cannot accept 0, so ensure seed is positive and non-zero
         seed = Math.abs(seed);
         if (seed == 0)
             seed = 1;
 
+        // Modulo 61 to make THE_KILLER_BUNNY rare (1/60 chance, cases 60)
         int rand = Math.abs(Ollivanders2Common.random.nextInt(seed)) % 61;
 
         if (rand < 10)
@@ -428,10 +443,12 @@ public class EntityCommon {
     static public Horse.Style getRandomHorseStyle(int seed) {
         Horse.Style style;
 
+        // nextInt() cannot accept 0, so ensure seed is positive and non-zero
         seed = Math.abs(seed);
         if (seed == 0)
             seed = 1;
 
+        // Modulo 20 to make Horse.Style.NONE most common (16 out of 20 cases, 80% chance)
         int rand = Math.abs(Ollivanders2Common.random.nextInt(seed)) % 20;
 
         switch (rand) {
@@ -479,6 +496,7 @@ public class EntityCommon {
         if (seed == 0)
             seed = 1;
 
+        // Modulo 7 because there are 7 different horse colors
         int rand = Math.abs(Ollivanders2Common.random.nextInt(seed)) % 7;
 
         switch (rand) {
@@ -532,6 +550,7 @@ public class EntityCommon {
         if (seed == 0)
             seed = 1;
 
+        // Modulo 4 because there are 4 different llama colors
         int rand = Math.abs(Ollivanders2Common.random.nextInt(seed)) % 4;
 
         switch (rand) {
@@ -563,10 +582,10 @@ public class EntityCommon {
     }
 
     /**
-     * Genenrate a random parrot color.
+     * Generates a random parrot variant.
      *
-     * @param seed the base value that the percentile check will use
-     * @return the color
+     * @param seed the base value used with random number generation for variant selection
+     * @return a random parrot variant
      */
     @NotNull
     static public Parrot.Variant getRandomParrotVariant(int seed) {
@@ -576,6 +595,7 @@ public class EntityCommon {
         if (seed == 0)
             seed = 1;
 
+        // Modulo 5 because there are 5 parrot color variants
         int rand = Math.abs(Ollivanders2Common.random.nextInt(seed)) % 5;
 
         switch (rand) {
@@ -599,9 +619,9 @@ public class EntityCommon {
     }
 
     /**
-     * Genenrate a random parrot color.
+     * Generates a random parrot variant using the default world time as seed.
      *
-     * @return the color
+     * @return a random parrot variant
      */
     @NotNull
     static public Parrot.Variant getRandomParrotVariant() {
@@ -620,6 +640,7 @@ public class EntityCommon {
         if (seed == 0)
             seed = 1;
 
+        // Modulo 100 provides a percentile range (0-99). Sheep should generally be white (68% chance).
         int rand = Math.abs(Ollivanders2Common.random.nextInt(seed)) % 100;
 
         if (rand < 2) // 2% chance
@@ -628,7 +649,7 @@ public class EntityCommon {
             return DyeColor.BROWN;
         else if (rand < 32) // 10% chance
             return DyeColor.LIGHT_GRAY;
-        else
+        else // 68% chance - white is the most common natural sheep color
             return DyeColor.WHITE;
     }
 
@@ -654,7 +675,7 @@ public class EntityCommon {
             return true;
 
         // are they a mob with a target set?
-        if (livingEntity instanceof Mob && ((Mob)livingEntity).getTarget() != null)
+        if (livingEntity instanceof Mob && ((Mob) livingEntity).getTarget() != null)
             return true;
 
         return false;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/common/MagicLevel.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/common/MagicLevel.java
@@ -1,23 +1,34 @@
 package net.pottercraft.ollivanders2.common;
 
 /**
- * The magic level for spells, effects, enchantments, and potions
+ * Difficulty progression levels for spells, effects, enchantments, and potions.
+ * <p>
+ * Represents a four-tier difficulty system ranging from beginner-friendly magic to expert-only magic.
+ * Used to gate access to spells and potions based on player progression and to balance gameplay difficulty.
+ * </p>
+ *
+ * @author Azami7
  */
 public enum MagicLevel {
     /**
-     * Magic taught in years 1-2
+     * Entry-level magic for beginners (years 1-2 equivalent).
+     * The easiest and most basic magic available to new players.
      */
     BEGINNER,
     /**
-     * Magic taught in years 3-4
+     * Intermediate magic for intermediate practitioners (years 3-4 equivalent).
+     * More complex and powerful than beginner magic, requiring some skill and experience.
      */
     OWL,
     /**
-     * Magic taught in years 5-7
+     * Advanced magic for skilled practitioners (years 5-7 equivalent).
+     * Powerful magic requiring significant skill and experience to perform safely.
      */
     NEWT,
     /**
-     * Magic learned by advanced magicians
+     * Expert-level magic for advanced magicians.
+     * The most powerful and restrictive magic, typically requiring special training or achievement.
+     * May be inaccessible to regular players depending on configuration.
      */
     EXPERT;
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/common/O2Color.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/common/O2Color.java
@@ -8,7 +8,22 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Ollivanders2 colors - because MC doesn't handle colors consistently
+ * Color representation for Ollivanders2 supporting multiple Minecraft color formats.
+ * <p>
+ * Minecraft handles colors inconsistently across different contexts - chat messages use ChatColor and format codes (§),
+ * items use Color, and blocks use DyeColor. This enum provides unified access to all color representations,
+ * allowing seamless conversion between formats.
+ * </p>
+ * <p>
+ * <strong>When to use each color representation:</strong>
+ * <ul>
+ * <li>{@link #getBukkitColor()} - For items and potions (Color class)</li>
+ * <li>{@link #getChatColor()} - For chat messages in commands and player messages (ChatColor enum)</li>
+ * <li>{@link #getChatColorCode()} - For text formatting in books and signs using color codes like "§c" for red</li>
+ * <li>{@link #getDyeColor()} - For dyeable blocks like wool, concrete, and glass (DyeColor enum)</li>
+ * </ul>
+ *
+ * @author Azami7
  */
 public enum O2Color {
     /**
@@ -130,17 +145,24 @@ public enum O2Color {
     ;
 
     /**
-     * Primary dye colors
+     * Primary dye colors for common dyeable blocks.
+     * Used by {@link #getRandomPrimaryDyeableColor()} to select from the six most common color variants.
+     * Primarily used for blocks that support standard color variants.
      */
     final static O2Color[] primaryDyeableColors = new O2Color[]{RED, ORANGE, YELLOW, GREEN, BLUE, PURPLE};
 
     /**
-     * All dye colors
+     * All dye colors supported by Minecraft dyeable blocks.
+     * Used by {@link #getRandomDyeableColor()} to select from the complete range of available dye colors.
+     * Includes all standard Minecraft dye colors that can be applied to wool, concrete, glass, and similar blocks.
      */
     final static O2Color[] dyeableColors = new O2Color[]{BLACK, BLUE, BROWN, CYAN, GRAY, GREEN, LIGHT_BLUE, LIGHT_GRAY, LIME, MAGENTA, ORANGE, PINK, PURPLE, RED, WHITE, YELLOW};
 
     /**
-     * Bukkit color names
+     * Bukkit-defined colors representing standard Minecraft colors.
+     * Used by {@link #getBukkitColorByNumber(int)} to convert numeric color codes (0-15) to their corresponding O2Color.
+     * These 16 colors match the legacy Minecraft color palette (corresponds to the old chat color codes).
+     * Defaults to WHITE if a number outside the valid range is provided.
      */
     final static O2Color[] bukkitColors = new O2Color[]{AQUA, BLACK, BLUE, FUCHSIA, GRAY, GREEN, LIME, MAROON, NAVY, OLIVE, ORANGE, PURPLE, RED, SILVER, TEAL, WHITE};
 
@@ -160,28 +182,35 @@ public enum O2Color {
     }
 
     /**
-     * The bukkit color name for this color type
+     * The Bukkit Color object for this color.
+     * Used for item coloring (e.g., potion colors). Access via {@link #getBukkitColor()}.
      */
     final Color bukkitColor;
 
     /**
-     * The chat color for this color type
+     * The ChatColor enum value for this color.
+     * Used for chat messages and command outputs. Access via {@link #getChatColor()}.
      */
     final ChatColor chatColor;
 
     /**
-     * The color code for this color type
+     * The chat format code for this color (e.g., "§c" for red).
+     * Used for text formatting in books, signs, and other text-based UI elements.
+     * Format is the section symbol (§) followed by a hexadecimal character. Access via {@link #getChatColorCode()}.
      */
     final String chatColorCode;
 
     /**
-     * The dye color for this color type
+     * The DyeColor enum value for this color.
+     * Used for dyeable blocks like wool, concrete, glass, and banners. Access via {@link #getDyeColor()}.
      */
     final DyeColor dyeColor;
 
     /**
-     * Get the Bukkit Color type for this color
-     * @return the Color for this type
+     * Get the Bukkit Color object for this color.
+     * Used for coloring items such as potions, leather armor, and other colorable items.
+     *
+     * @return the Bukkit Color object
      */
     @NotNull
     public Color getBukkitColor() {
@@ -189,9 +218,10 @@ public enum O2Color {
     }
 
     /**
-     * Get the ChatColor for this color
+     * Get the ChatColor enum value for this color.
+     * Used for chat messages, command messages, and other player-facing text.
      *
-     * @return the ChatColor for this type
+     * @return the ChatColor enum value
      */
     @NotNull
     public ChatColor getChatColor() {
@@ -199,9 +229,11 @@ public enum O2Color {
     }
 
     /**
-     * Get the chat string code for this color
+     * Get the chat format code for this color.
+     * Format is the section symbol (§) followed by a hexadecimal character (e.g., "§c" for red).
+     * Used for formatting text in books, signs, and other text-based UI elements.
      *
-     * @return the chat code for this type
+     * @return the chat color code as a string
      */
     @NotNull
     public String getChatColorCode() {
@@ -209,9 +241,10 @@ public enum O2Color {
     }
 
     /**
-     * get the DyeColor for this color
+     * Get the DyeColor enum value for this color.
+     * Used for dyeable blocks such as wool, concrete, glass, banners, candles, and shulker boxes.
      *
-     * @return the dye color for this type
+     * @return the DyeColor enum value
      */
     @NotNull
     public DyeColor getDyeColor() {
@@ -219,13 +252,20 @@ public enum O2Color {
     }
 
     /**
-     * Get the colored material for this base material for this type
+     * Get the colored material variant for this color with the given base material name.
+     * <p>
+     * Minecraft colorable materials follow the naming convention: {@code COLOR_MATERIAL}
+     * (e.g., "RED_WOOL", "BLUE_CONCRETE", "WHITE_GLASS"). This method constructs the full material
+     * name by combining the DyeColor prefix with the provided base name.
+     * </p>
      *
-     * @param materialBaseName the base material
-     * @return the colored material type or null if not found
+     * @param materialBaseName the base material name without color prefix (e.g., "WOOL", "CONCRETE", "GLASS")
+     * @return the colored Material (e.g., Material.RED_WOOL), or null if the colored variant doesn't exist
      */
     @Nullable
     public Material getColoredMaterial(String materialBaseName) {
+        // Concatenate the DyeColor enum with the base material name. DyeColor.toString() returns the enum name
+        // (e.g., "RED", "BLUE") which creates the full material name (e.g., "RED_WOOL", "BLUE_CONCRETE").
         String materialName = dyeColor + "_" + materialBaseName;
 
         try {
@@ -239,10 +279,14 @@ public enum O2Color {
     }
 
     /**
-     * Get the bukkit color associated with a number 0-15
+     * Get the Bukkit color associated with a numeric color code.
+     * <p>
+     * Converts numeric color codes (0-15) to their corresponding O2Color from the legacy Minecraft color palette.
+     * This is useful for working with older data formats or system that use numeric color indices.
+     * </p>
      *
-     * @param number a number between 0-15, numbers outside of this range will be set to WHITE
-     * @return the bukkit color associated with this number
+     * @param number a number between 0-15 corresponding to the legacy Minecraft color palette
+     * @return the O2Color at the specified index, or WHITE if the number is out of range (negative or >= 16)
      */
     @NotNull
     public static O2Color getBukkitColorByNumber(int number) {
@@ -255,9 +299,14 @@ public enum O2Color {
     }
 
     /**
-     * Get a random primary dyeable color - red, orange, yellow, green, blue, purple
+     * Get a random primary dyeable color.
+     * <p>
+     * Returns one of the six primary dye colors: red, orange, yellow, green, blue, or purple.
+     * Uses a random seed from {@link Ollivanders2Common#random}.
+     * </p>
      *
-     * @return the dyeable color
+     * @return a random O2Color from the primary dyeable colors array
+     * @see #getRandomPrimaryDyeableColor(int)
      */
     @NotNull
     public static O2Color getRandomPrimaryDyeableColor() {
@@ -267,22 +316,32 @@ public enum O2Color {
     }
 
     /**
-     * Get a random primary dyeable color - red, orange, yellow, green, blue, purple
+     * Get a primary dyeable color based on the provided seed.
+     * <p>
+     * Returns one of the six primary dye colors: red, orange, yellow, green, blue, or purple.
+     * The seed is used with modulo arithmetic to select from the available colors.
+     * </p>
      *
-     * @param seed the base value that the percentile check will use
-     * @return the dyeable color
+     * @param seed the base value to determine which color is selected (using modulo)
+     * @return a primary dyeable color from the seed value
      */
     @NotNull
     public static O2Color getRandomPrimaryDyeableColor(int seed) {
+        // Modulo 6 distributes the seed value evenly across the 6 primary colors (0-5)
         int rand = Math.abs(seed) % primaryDyeableColors.length;
 
         return primaryDyeableColors[rand];
     }
 
     /**
-     * Get a random dyeable color
+     * Get a random dyeable color.
+     * <p>
+     * Returns one of the 16 available dye colors that can be applied to dyeable blocks.
+     * Uses a random seed from {@link Ollivanders2Common#random}.
+     * </p>
      *
-     * @return the dyeable color
+     * @return a random O2Color from the complete dyeable colors array
+     * @see #getRandomDyeableColor(int)
      */
     @NotNull
     public static O2Color getRandomDyeableColor() {
@@ -292,23 +351,33 @@ public enum O2Color {
     }
 
     /**
-     * Get a random dyeable color
+     * Get a dyeable color based on the provided seed.
+     * <p>
+     * Returns one of the 16 available dye colors that can be applied to dyeable blocks like wool, concrete, and glass.
+     * The seed is used with modulo arithmetic to select from the available colors.
+     * </p>
      *
-     * @param seed the base value that the percentile check will use
-     * @return the dyeable color
+     * @param seed the base value to determine which color is selected (using modulo)
+     * @return a dyeable color from the seed value
      */
     @NotNull
     public static O2Color getRandomDyeableColor(int seed) {
+        // Modulo 16 distributes the seed value evenly across the 16 available dye colors (0-15)
         int rand = Math.abs(seed) % dyeableColors.length;
 
         return dyeableColors[rand];
     }
 
     /**
-     * Return true if a material is colorable, false if it is not.
+     * Check whether a material can be dyed to different colors.
+     * <p>
+     * Colorable materials follow the naming pattern {@code COLOR_BASE} (e.g., "RED_WOOL", "WHITE_CONCRETE").
+     * This method checks if the material name ends with one of the known dyeable base material suffixes.
+     * </p>
      *
-     * @param material the material to check
-     * @return true if it is colorable, false if it is not
+     * @param material the Material to check for colorability
+     * @return true if the material is colorable (wool, carpet, concrete, glass, bed, candle, banner, shulker box),
+     * false otherwise
      */
     public static boolean isColorable(@NotNull Material material) {
         // determine if a material is colorable
@@ -318,7 +387,7 @@ public enum O2Color {
                 || materialName.endsWith("_CONCRETE_POWDER") || materialName.endsWith("_SHULKER_BOX")
                 || materialName.endsWith("_STAINED_GLASS") || materialName.endsWith("_STAINED_GLASS_PANE")
                 || materialName.endsWith("_BED") || materialName.endsWith("_CANDLE")
-                || materialName.endsWith("_BANNER")){
+                || materialName.endsWith("_BANNER")) {
             return true;
         }
 
@@ -326,11 +395,17 @@ public enum O2Color {
     }
 
     /**
-     * Change the color of a colorable material.
+     * Change a colorable material to a new color.
+     * <p>
+     * Converts the material to its color variant using the provided O2Color. For example, converting
+     * WOOL with color RED produces RED_WOOL. The material name pattern is {@code COLOR_BASE}.
+     * </p>
      *
-     * @param material the material to change color of
-     * @param color    the color to change the material to
-     * @return a material that is the new color or the original material if the material was not colorable
+     * @param material the colorable Material to change the color of (e.g., WHITE_WOOL, BLUE_CONCRETE)
+     * @param color    the O2Color to change the material to
+     * @return the new colored Material (e.g., RED_WOOL), or the original material if:
+     * - the material is not colorable, or
+     * - the colored variant does not exist in Minecraft
      */
     public static Material changeColor(@NotNull Material material, @NotNull O2Color color) {
         String materialName = material.toString();
@@ -340,7 +415,9 @@ public enum O2Color {
             return material;
 
         // get the base material where name pattern is COLOR_MATERIAL, ex. WHITE_WOOL
-        String [] materialNameParts = materialName.split("_", 2);
+        // Use split with limit of 2 to only split at the FIRST underscore. This handles materials like
+        // STAINED_GLASS_PANE correctly: splits into ["WHITE", "STAINED_GLASS_PANE"], not ["WHITE", "STAINED", "GLASS_PANE"]
+        String[] materialNameParts = materialName.split("_", 2);
         if (materialNameParts.length != 2)
             return material;
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/common/TimeCommon.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/common/TimeCommon.java
@@ -8,25 +8,38 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 /**
- * Times of day for minecraft servers, based on day relative tick.
+ * Enumeration of standard times of day in Minecraft, based on day-relative ticks.
  * <p>
- * Reference: https://www.digminecraft.com/game_commands/time_set_day.php
+ * Minecraft days cycle through 24000 ticks (20 ticks per second = 20 minutes per full day).
+ * Day-relative ticks are the tick value modulo 24000, ranging from 0 to 23999, where:
+ * <ul>
+ * <li>0 = Midnight (start of day)</li>
+ * <li>6000 = Midday (noon)</li>
+ * <li>12000 = Sunset</li>
+ * <li>18000 = Midnight (end of day)</li>
+ * </ul>
+ * <p>
+ * These constants represent the standard times of day and can be used with commands like `/time set`.
+ * </p>
+ *
+ * @author Azami7
+ * @see <a href="https://www.digminecraft.com/game_commands/time_set_day.php">https://www.digminecraft.com/game_commands/time_set_day.php</a>
  */
 public enum TimeCommon {
     /**
-     * 18000
+     * Midnight (18000 ticks) - the start of the night cycle, when darkness is complete.
      */
     MIDNIGHT(18000),
     /**
-     * 23000
+     * Dawn (23000 ticks) - early morning when the sun is just beginning to rise.
      */
     DAWN(23000),
     /**
-     * 6000
+     * Midday (6000 ticks) - noon, when the sun is at its highest point and brightness is maximum.
      */
     MIDDAY(6000),
     /**
-     * 12000
+     * Sunset (12000 ticks) - evening when the sun begins to set and darkness is approaching.
      */
     SUNSET(12000);
 
@@ -36,9 +49,9 @@ public enum TimeCommon {
     final private int gameTick;
 
     /**
-     * Constructor
+     * Constructor for TimeCommon enum constants.
      *
-     * @param tick the game tick value for this enumerated time of day
+     * @param tick the day-relative tick value (0-23999) representing this time of day in the Minecraft cycle
      */
     TimeCommon(int tick) {
         gameTick = tick;
@@ -54,18 +67,26 @@ public enum TimeCommon {
     }
 
     /**
-     * Get the current server time for the default world for this server.
+     * Get the full time (cumulative ticks) for the default world.
+     * <p>
+     * Returns the full time in ticks since the world was created, not the day-relative time (0-23999).
+     * To get the day-relative time, use: {@code getDefaultWorldTime() % 24000}
+     * </p>
      *
-     * @return the time for the default world
+     * @return the full time in ticks for the default world
      */
     static public long getDefaultWorldTime() {
         return Bukkit.getServer().getWorlds().getFirst().getFullTime();
     }
 
     /**
-     * Get the current timestamp as a string.
+     * Get the current system date and time as a formatted string.
+     * <p>
+     * Returns the system date/time (not Minecraft game time). This is typically used for logging,
+     * file naming, or other real-world timestamp purposes.
+     * </p>
      *
-     * @return timestamp in the format 2018-09-30-12-15-30
+     * @return the current system timestamp in the format yyyy-MM-dd-HH-mm-ss (e.g., "2018-09-30-12-15-30")
      */
     @NotNull
     static public String getCurrentTimestamp() {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/divination/ASTROLOGY.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/divination/ASTROLOGY.java
@@ -5,30 +5,51 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
+ * Astrology divination spell implementation using celestial influences.
+ * <p>
  * Astrology is the system of using the relative positions of celestial bodies (including the sun, moon, and planets) to
  * try to predict future events or gain insight into personality, relationships, and health.
- *
- * <p>Reference: http://harrypotter.wikia.com/wiki/Astrology</p>
+ * </p>
+ * <p>
+ * This class implements the astrology divination method, generating randomized prophecies based on astrological
+ * concepts like planetary influences, house positions, and birth chart interpretations. The prophecies are created
+ * by combining randomly selected prefixes (which reference specific planets, houses, or astrological aspects) with
+ * divination text from the parent {@link O2Divination} class.
+ * </p>
  *
  * @author Azami7
- * @since 2.2.9
+ * @see <a href="http://harrypotter.wikia.com/wiki/Astrology">Harry Potter Wiki - Astrology</a>
  */
 public class ASTROLOGY extends O2Divination {
     /**
-     * Constructor
+     * Constructor that initializes an astrology divination prophecy.
+     * <p>
+     * Creates a new astrology divination instance and populates it with astrological prophecy prefixes.
+     * Sets the divination type to ASTROLOGY with a maximum accuracy of 20 points.
+     * The prophecy prefixes reference planetary influences, astrological houses, and birth chart positions
+     * to create varied, thematic predictions.
+     * </p>
      *
-     * @param plugin     a callback to the plugin
-     * @param prophet    the player making the prophecy
-     * @param target     the target of the prophecy
-     * @param experience the experience level of the prophet
+     * @param plugin     a callback to the plugin for accessing configuration and other resources
+     * @param prophet    the player who is performing the divination (using the astrology spell)
+     * @param target     the player who is the subject of the divination prophecy
+     * @param experience the experience level of the prophet, affecting prophecy accuracy and strength
      */
     public ASTROLOGY(@NotNull Ollivanders2 plugin, @NotNull Player prophet, @NotNull Player target, int experience) {
         super(plugin, prophet, target, experience);
 
 
+        // Set divination type and accuracy threshold
         divinationType = O2DivinationType.ASTROLOGY;
         maxAccuracy = 20;
 
+        // Populate prophecy prefixes with astrological phrases. These prefixes are randomly selected
+        // when generating a prophecy and combined with divination text to create the final prophecy message.
+        // The prefixes are organized into three categories:
+        // 1. Planetary influences (Mars, Mercury, Venus, Jupiter, Saturn, Moon)
+        // 2. Astrological angles/aspects (planets in aspect to each other)
+        // 3. House positions (planets in specific astrological houses)
+        // 4. Birth chart positions (planets in the target's natal chart)
         prophecyPrefix.add("Because of the influence of Mars,");
         prophecyPrefix.add("Due to the influence of Mercury,");
         prophecyPrefix.add("From the influence of Venus,");

--- a/Ollivanders/src/net/pottercraft/ollivanders2/divination/CARTOMANCY.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/divination/CARTOMANCY.java
@@ -5,28 +5,50 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Cartomancy is the art of reading cards to gain insight into future events.
- *
- * <p>Reference: http://harrypotter.wikia.com/wiki/Cartomancy</p>
+ * Cartomancy divination spell implementation using tarot card reading.
+ * <p>
+ * Cartomancy is the art of reading cards (typically tarot cards) to gain insight into future events,
+ * personality traits, and circumstances.
+ * </p>
+ * <p>
+ * This class implements the cartomancy divination method, generating randomized prophecies based on tarot
+ * card readings. The prophecies are created by combining randomly selected prefixes (which reference specific
+ * tarot cards and their traditional meanings) with divination text from the parent {@link O2Divination} class.
+ * Cards used include spades (associated with challenges and misfortune) and their interpretations based on
+ * classical tarot traditions.
+ * </p>
  *
  * @author Azami7
- * @since 2.2.9
+ * @see <a href="http://harrypotter.wikia.com/wiki/Cartomancy">Harry Potter Wiki - Cartomancy</a>
  */
 public class CARTOMANCY extends O2Divination {
     /**
-     * Constructor
+     * Constructor that initializes a cartomancy divination prophecy.
+     * <p>
+     * Creates a new cartomancy divination instance and populates it with tarot card prophecy prefixes.
+     * Sets the divination type to CARTOMANCY with a maximum accuracy of 25 points (higher than other divination methods).
+     * The prophecy prefixes reference specific tarot cards and their traditional meanings (particularly spades,
+     * which are associated with challenges, conflict, and misfortune).
+     * </p>
      *
-     * @param plugin     a callback to the plugin
-     * @param prophet    the player making the prophecy
-     * @param target     the target of the prophecy
-     * @param experience the experience level of the prophet
+     * @param plugin     a callback to the plugin for accessing configuration and other resources
+     * @param prophet    the player who is performing the divination (casting the cartomancy spell)
+     * @param target     the player who is the subject of the divination prophecy
+     * @param experience the experience level of the prophet, affecting prophecy accuracy and strength
      */
     public CARTOMANCY(@NotNull Ollivanders2 plugin, @NotNull Player prophet, @NotNull Player target, int experience) {
         super(plugin, prophet, target, experience);
 
+        // Set divination type and accuracy threshold. Cartomancy has higher accuracy (25) than astrology (20)
         divinationType = O2DivinationType.CARTOMANCY;
         maxAccuracy = 25;
 
+        // Populate prophecy prefixes with tarot card references. These prefixes are randomly selected
+        // when generating a prophecy and combined with divination text to create the final prophecy message.
+        // The prefixes reference:
+        // 1. General card reading phrases (generic fortune-telling intros)
+        // 2. Specific tarot cards from the suit of spades (associated with conflict and misfortune)
+        // Each card carries traditional tarot meanings that are incorporated into the prophecy.
         prophecyPrefix.add("The cards have revaled that");
         prophecyPrefix.add("The reading of the cards says that");
         prophecyPrefix.add("Two of spades: conflict,");

--- a/Ollivanders/src/net/pottercraft/ollivanders2/divination/CARTOMANCY_TAROT.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/divination/CARTOMANCY_TAROT.java
@@ -5,28 +5,65 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Cartomancy is the art of reading cards to gain insight into future events.
- *
- * <p>Reference: http://harrypotter.wikia.com/wiki/Cartomancy</p>
+ * Cartomancy Tarot divination spell implementation using major arcana cards.
+ * <p>
+ * Tarot cartomancy is a specialized form of cartomancy that uses a complete tarot deck, particularly
+ * the 22 major arcana cards. These cards have deeper symbolic meaning and are considered more accurate
+ * than regular playing card divination. Each major arcana card represents a significant life principle
+ * or archetypal concept (The Fool, The Magician, The High Priestess, Death, The Tower, etc.).
+ * </p>
+ * <p>
+ * This class implements the tarot cartomancy divination method, generating randomized prophecies based on
+ * major arcana card readings. The prophecies are created by combining randomly selected prefixes (which reference
+ * specific tarot major arcana cards and their symbolic meanings) with divination text from the parent
+ * {@link O2Divination} class. Tarot divination has higher maximum accuracy (35 points) compared to regular
+ * cartomancy (25 points), reflecting the greater power and precision of tarot-based prophecies.
+ * </p>
  *
  * @author Azami7
- * @since 2.2.9
+ * @see <a href="http://harrypotter.wikia.com/wiki/Cartomancy">Harry Potter Wiki - Cartomancy</a>
  */
 public class CARTOMANCY_TAROT extends O2Divination {
     /**
-     * Constructor
+     * Constructor that initializes a tarot cartomancy divination prophecy.
+     * <p>
+     * Creates a new tarot cartomancy divination instance and populates it with major arcana card prophecy prefixes.
+     * Sets the divination type to CARTOMANCY_TAROT with a maximum accuracy of 35 points (higher than regular
+     * cartomancy at 25 points). The prophecy prefixes reference the 22 major arcana cards and their archetypal
+     * symbolic meanings, which represent significant life principles and transformative forces.
+     * </p>
      *
-     * @param plugin     a callback to the plugin
-     * @param prophet    the player making the prophecy
-     * @param target     the target of the prophecy
-     * @param experience the experience level of the prophet
+     * @param plugin     a callback to the plugin for accessing configuration and other resources
+     * @param prophet    the player who is performing the divination (casting the tarot cartomancy spell)
+     * @param target     the player who is the subject of the divination prophecy
+     * @param experience the experience level of the prophet, affecting prophecy accuracy and strength
      */
     public CARTOMANCY_TAROT(@NotNull Ollivanders2 plugin, @NotNull Player prophet, @NotNull Player target, int experience) {
         super(plugin, prophet, target, experience);
 
+        // Set divination type and accuracy threshold. Tarot cartomancy has higher accuracy (35) than regular cartomancy (25)
         divinationType = O2DivinationType.CARTOMANCY_TAROT;
         maxAccuracy = 35;
 
+        // Populate prophecy prefixes with tarot major arcana cards. These prefixes are randomly selected
+        // when generating a prophecy and combined with divination text to create the final prophecy message.
+        // The prefixes reference the 22 major arcana cards from a traditional tarot deck.
+        // Each major arcana card represents a fundamental life principle or archetypal force:
+        // - The Fool: new beginnings, innocence, risk
+        // - The Magician: manifestation, resourcefulness, power
+        // - The High Priestess: intuition, mystery, inner knowledge
+        // - The Emperor: authority, leadership, father figure
+        // - The Empress: femininity, beauty, abundance
+        // - The Hierophant: tradition, convention, morality
+        // - The Chariot: control, willpower, determination
+        // - The Hanged Man: pause, surrender, perspective
+        // - Death: transformation, endings, renewal
+        // - Wheel of Fortune: luck, destiny, turning point
+        // - The Devil: bondage, materialism, playfulness
+        // - The Tower (Lightning-Struck Tower): upheaval, sudden change, revelation
+        // - The Star: hope, spirituality, inspiration
+        // - The Moon: illusion, fear, intuition
+        // - Judgement: awakening, renewal, inner calling
         prophecyPrefix.add("The cards have revaled that");
         prophecyPrefix.add("The reading of the cards says that");
         prophecyPrefix.add("The Lightning-Struck Tower is revealed,");

--- a/Ollivanders/src/net/pottercraft/ollivanders2/divination/CENTAUR_DIVINATION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/divination/CENTAUR_DIVINATION.java
@@ -5,29 +5,52 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Divination is a branch of magic that involves attempting to foresee the future, or gather insights into past, present
- * and future events.
- *
- * <p>Reference: https://harrypotter.fandom.com/wiki/Divination</p>
+ * Centaur Divination spell implementation using celestial observation and smoke reading.
+ * <p>
+ * Centaur divination is performed by wise centaur scholars who use celestial observations (studying the stars,
+ * planets, and astronomical phenomena) combined with augury techniques like observing smoke and flames from burning
+ * herbs and leaves. This method is considered highly accurate, as centaurs possess deep astronomical knowledge and
+ * spiritual insight into natural portents.
+ * </p>
+ * <p>
+ * This class implements the centaur divination method, generating randomized prophecies based on celestial signs
+ * and smoke/flame readings. The prophecies are created by combining randomly selected prefixes (which reference
+ * astronomical observations, celestial portents, and augury practices) with divination text from the parent
+ * {@link O2Divination} class. Centaur divination has the highest maximum accuracy (80 points) of all divination
+ * methods in Ollivanders2, reflecting the superior knowledge and mystical attunement of centaur scholars.
+ * </p>
  *
  * @author Azami7
- * @since 2.2.9
+ * @see <a href="https://harrypotter.fandom.com/wiki/Divination">Harry Potter Wiki - Divination</a>
  */
 public class CENTAUR_DIVINATION extends O2Divination {
     /**
-     * Constructor
+     * Constructor that initializes a centaur divination prophecy.
+     * <p>
+     * Creates a new centaur divination instance and populates it with celestial and augury prophecy prefixes.
+     * Sets the divination type to CENTAUR_DIVINATION with a maximum accuracy of 80 points (the highest of all
+     * divination methods). The prophecy prefixes reference celestial observations (star/planet study), astronomical
+     * phenomena, and augury practices (smoke and flame reading from burning herbs).
+     * </p>
      *
-     * @param plugin     a callback to the plugin
-     * @param prophet    the player making the prophecy
-     * @param target     the target of the prophecy
-     * @param experience the experience level of the prophet
+     * @param plugin     a callback to the plugin for accessing configuration and other resources
+     * @param prophet    the player who is performing the divination (casting the centaur divination spell)
+     * @param target     the player who is the subject of the divination prophecy
+     * @param experience the experience level of the prophet, affecting prophecy accuracy and strength
      */
     public CENTAUR_DIVINATION(@NotNull Ollivanders2 plugin, @NotNull Player prophet, @NotNull Player target, int experience) {
         super(plugin, prophet, target, experience);
 
+        // Set divination type and accuracy threshold. Centaur divination has the highest accuracy (80) of all divination methods
         divinationType = O2DivinationType.CENTAUR_DIVINATION;
         maxAccuracy = 80;
 
+        // Populate prophecy prefixes with centaur divination phrases. These prefixes are randomly selected
+        // when generating a prophecy and combined with divination text to create the final prophecy message.
+        // The prefixes reference two main centaur divination techniques:
+        // 1. Celestial observation - studying the stars, planets, and astronomical portents
+        // 2. Augury - reading omens from smoke and flames of burning herbs and leaves
+        // These methods reflect centaur wisdom and deep attunement to natural and celestial signs.
         prophecyPrefix.add("Through careful study of the skies it is learned that");
         prophecyPrefix.add("Celestial portents reveal that");
         prophecyPrefix.add("Mars, bringer of battle, shines brightly above us, suggesting that");

--- a/Ollivanders/src/net/pottercraft/ollivanders2/divination/CRYSTAL_BALL.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/divination/CRYSTAL_BALL.java
@@ -5,28 +5,50 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Crystal-gazing was the art of looking into a crystal ball in order to try to gain insight into the future events.
- *
- * <p>Reference: https://harrypotter.fandom.com/wiki/Crystal-gazing</p>
+ * Crystal Ball divination spell implementation using scrying and clairvoyant vision.
+ * <p>
+ * Crystal-gazing (also known as scrying) is the art of looking into a crystal ball or crystalline orb to gain
+ * insight into future events and hidden truths. A skilled diviner gazes into the crystal's depths, where shadowy
+ * images and clairvoyant vibrations reveal glimpses of what is to come. This method requires focus and mystical
+ * attunement to perceive the subtle visions within the crystal.
+ * </p>
+ * <p>
+ * This class implements the crystal ball divination method, generating randomized prophecies based on visions
+ * and clairvoyant readings. The prophecies are created by combining randomly selected prefixes (which reference
+ * the crystal orb, clairvoyant vibrations, and shadowy portents) with divination text from the parent
+ * {@link O2Divination} class. Crystal ball divination has moderate maximum accuracy (30 points), making it more
+ * reliable than basic divination methods like astrology and cartomancy, but less powerful than tarot or centaur divination.
+ * </p>
  *
  * @author Azami7
- * @since 2.2.9
+ * @see <a href="https://harrypotter.fandom.com/wiki/Crystal-gazing">Harry Potter Wiki - Crystal-gazing</a>
  */
 public class CRYSTAL_BALL extends O2Divination {
     /**
-     * Constructor
+     * Constructor that initializes a crystal ball divination prophecy.
+     * <p>
+     * Creates a new crystal ball divination instance and populates it with scrying and clairvoyant prophecy prefixes.
+     * Sets the divination type to CRYSTAL_BALL with a maximum accuracy of 30 points. The prophecy prefixes reference
+     * the crystal orb, clairvoyant vibrations, and shadowy visions revealed through scrying into the crystal's depths.
+     * </p>
      *
-     * @param plugin     a callback to the plugin
-     * @param prophet    the player making the prophecy
-     * @param target     the target of the prophecy
-     * @param experience the experience level of the prophet
+     * @param plugin     a callback to the plugin for accessing configuration and other resources
+     * @param prophet    the player who is performing the divination (casting the crystal ball spell)
+     * @param target     the player who is the subject of the divination prophecy
+     * @param experience the experience level of the prophet, affecting prophecy accuracy and strength
      */
     public CRYSTAL_BALL(@NotNull Ollivanders2 plugin, @NotNull Player prophet, @NotNull Player target, int experience) {
         super(plugin, prophet, target, experience);
 
+        // Set divination type and accuracy threshold. Crystal ball divination has moderate accuracy (30), between
+        // basic methods (astrology=20, cartomancy=25) and advanced methods (tarot=35, centaur=80)
         divinationType = O2DivinationType.CRYSTAL_BALL;
         maxAccuracy = 30;
 
+        // Populate prophecy prefixes with crystal ball divination phrases. These prefixes are randomly selected
+        // when generating a prophecy and combined with divination text to create the final prophecy message.
+        // The prefixes reference the technique of scrying into a crystal orb, where clairvoyant abilities allow
+        // the diviner to perceive shadowy images and visions of future events within the crystal's depths.
         prophecyPrefix.add("The crystal ball has revealed that");
         prophecyPrefix.add("The clairvoyant vibrations of the orb show that");
         prophecyPrefix.add("The shadowy portents have been read,");

--- a/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Divination.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Divination.java
@@ -8,82 +8,135 @@ import net.pottercraft.ollivanders2.Ollivanders2API;
 import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.UUID;
 
 /**
- * Super class for all divination methods. Creates a prophecy which may come to pass at a future time.
+ * Abstract parent class for all divination spell implementations in Ollivanders2.
+ * <p>
+ * Divination is a branch of magic that involves attempting to foresee the future or gather insights into past,
+ * present, and future events. This class provides the framework for creating randomized prophecies based on the
+ * specific divination method (astrology, cartomancy, crystal ball, etc.). Each divination subclass defines its own
+ * prophecy prefixes and accuracy level, which are combined with randomly selected effects to create a complete prophecy.
+ * </p>
+ * <p>
+ * The prophecy generation process ({@link #divine()}) follows a structured workflow:
+ * </p>
+ * <ol>
+ * <li>Calculate accuracy based on prophet's experience level and the divination method's maximum accuracy cap</li>
+ * <li>Select a random magical effect from the available divination effects pool</li>
+ * <li>Select a prophecy prefix from the subclass-specific list (method-specific phrasing)</li>
+ * <li>Determine the time of day and duration until the prophecy takes effect (1-4 days, varies by time)</li>
+ * <li>Construct a complete prophecy message combining all elements</li>
+ * <li>Create an O2Prophecy record and schedule the effect to occur at the designated time</li>
+ * </ol>
+ * <p>
+ * Subclasses must define:
+ * </p>
+ * <ul>
+ * <li>{@code divinationType} - The O2DivinationType constant for this divination method</li>
+ * <li>{@code maxAccuracy} - The maximum accuracy percentage this divination method can achieve (caps prophet experience)</li>
+ * <li>{@code prophecyPrefix} array - Method-specific prefixes (e.g., "Due to the influence of Mars," for astrology)</li>
+ * </ul>
  *
- * <p>Reference: https://harrypotter.fandom.com/wiki/Divination</p>
+ * @author Azami7
+ * @see <a href="https://harrypotter.fandom.com/wiki/Divination">Harry Potter Wiki - Divination</a>
  */
 public abstract class O2Divination {
     /**
-     * Reference to the plugin
+     * Reference to the plugin for accessing configuration and logging
      */
     final Ollivanders2 p;
 
     /**
-     * The type of divination this is.
+     * The type of divination this instance represents (e.g., ASTROLOGY, CARTOMANCY).
+     * Set by subclass constructors to identify the specific divination method.
      */
     O2DivinationType divinationType = O2DivinationType.ASTROLOGY;
 
     /**
-     * The maximum odds this divination will happen.
+     * The number of game ticks in a minecraft "day".
+     */
+    static final int ticksPerDay = 24000;
+
+    /**
+     * The maximum accuracy percentage this divination method can achieve.
+     * Prophet experience is capped by this value, preventing high-level prophets from exceeding the method's inherent limits.
+     * Different divination methods have different caps reflecting their reliability:
+     * astrology=20, cartomancy=25, crystal ball=30, ovomancy=40, tarot=35, centaur=80, tasseomancy=20.
+     * Default: 10 (for base class).
      */
     int maxAccuracy = 10;
 
     /**
-     * The length of time from this divination until this it happens
+     * The maximum number of days in the future a prophecy can be scheduled.
+     * Value is read from {@link Ollivanders2#divinationMaxDays} configuration.
+     * Determines the range for prophecy duration calculation (1-4 days, varies by configuration).
      */
-    int maxDurationDays = Ollivanders2.divinationMaxDays;
+    int maxDelayDays = Ollivanders2.divinationMaxDays;
 
     /**
-     * The target of this divination
+     * The player who is the subject of this divination prophecy.
+     * The prophecy's effects will be applied to this player when the scheduled time arrives.
      */
     Player target;
 
     /**
-     * The player making the prophecy/divination
+     * The player performing/casting the divination spell.
+     * Their experience level with this divination method affects the prophecy's accuracy.
      */
     Player prophet;
 
     /**
-     * The experience level of the prophet in this type of divination. Affects accuracy.
+     * The experience level of the prophet with this specific divination method.
+     * Affects prophecy accuracy calculation: accuracy = experience / 2, capped by {@code maxAccuracy}.
+     * Higher experience = 0.5% accuracy per level (up to the method's maximum).
      */
     int experience;
 
     /**
-     * The possible text prefixes for this prophecy.
+     * The pool of method-specific prophecy prefixes for this divination type.
+     * Subclasses populate this array with thematic phrases (e.g., "Due to the influence of Mars" for astrology).
+     * A random prefix is selected and prepended to each generated prophecy to add method-specific flavor.
+     * Default: includes a generic fallback prefix "The portents and omens say that"
      */
     ArrayList<String> prophecyPrefix = new ArrayList<>();
 
     /**
-     * Possible effects the divination can cause.
+     * Static map of all possible magical effects that divination prophecies can trigger and the prophecy messages for each.
+     * Each O2EffectType maps to an array of possible prophecy predicates (e.g., "shall be cursed", "will come to harm").
+     * When a prophecy is created, a random effect type is selected, and then a random message from that effect's array
+     * is chosen to create the prophetic text. This separation allows divination-specific phrasing instead of effect class descriptions.
+     * Includes different effect types ranging from beneficial (HEAL, LUCK, WEALTH) to harmful (POISON, HARM, WEAKNESS).
+     * A random effect from this pool is selected for each prophecy and will be applied to the target player
+     * when the scheduled prophecy time arrives.
      */
-    static final ArrayList<O2EffectType> divinationEffects = new ArrayList<>() {{
-        add(O2EffectType.AGGRESSION);
-        add(O2EffectType.BABBLING);
-        add(O2EffectType.BLINDNESS);
-        add(O2EffectType.BURNING);
-        add(O2EffectType.CONFUSION);
-        add(O2EffectType.DANCING_FEET);
-        add(O2EffectType.IMMOBILIZE);
-        add(O2EffectType.HARM);
-        add(O2EffectType.HEAL);
-        add(O2EffectType.HUNGER);
-        add(O2EffectType.HEALTH_BOOST);
-        add(O2EffectType.LAUGHING);
-        add(O2EffectType.LUCK);
-        add(O2EffectType.MUTED_SPEECH);
-        add(O2EffectType.POISON);
-        add(O2EffectType.SLEEPING);
-        add(O2EffectType.SLOWNESS);
-        add(O2EffectType.UNLUCK);
-        add(O2EffectType.WEAKNESS);
-        add(O2EffectType.WEALTH);
-        add(O2EffectType.SWELLING);
+    static final HashMap<O2EffectType, String[]> divinationEffects = new HashMap<>() {{
+        put(O2EffectType.AGGRESSION, new String[]{"will suffer from an insatiable rage", "will succomb to a primal fear", "shall be afflicted in the mind", "shall lose their mind to insanity", "will be possessed by a demon spirit", "shall be cursed"});
+        put(O2EffectType.BABBLING, new String[]{"shall be afflicted in the mind", "shall lose their mind to insanity", "will begin to speak in tongues", "will be possessed by a demon spirit"});
+        put(O2EffectType.BLINDNESS, new String[]{"shall be cursed", "shall be afflicted in the mind", "will become unable to see", "will be struck by a terrible affliction", "will lose the light"});
+        put(O2EffectType.BURNING, new String[]{"shall be cursed", "will be consumed by fire", "will burn from within"});
+        put(O2EffectType.CONFUSION, new String[]{"shall be cursed", "will be afflicted in the mind", "will be struck by a terrible affliction", "will suffer a mental breakdown"});
+        put(O2EffectType.HARM, new String[]{"shall be struck by a terrible affliction", "will come to harm", "shall be cursed", "will be develop a terrible illness"});
+        put(O2EffectType.HEAL, new String[]{"will feel rejuvenated", "will be blessed by fortune", "shall be blessed"});
+        put(O2EffectType.HEALTH_BOOST, new String[]{"will become stonger", "will be blessed by fortune", "shall be blessed", "will rise to become more powerful"});
+        put(O2EffectType.HUNGER, new String[]{"shall be struck by a terrible affliction", "will starve", "shall be cursed", "will become insatiable"});
+        put(O2EffectType.IMMOBILIZE, new String[]{"will be possessed by a demon spirit", "will succomb to a primal fear", "shall become as if frozen", "shall be struck by a terrible affliction", "shall be cursed"});
+        put(O2EffectType.LAUGHING, new String[]{"must beware the hand unseen, the agent of giddy doom", "is marked not by lightning but by feather and folly", "shall fall victim to uncontrollable mirth"});
+        put(O2EffectType.LUCK, new String[]{"will be blessed by fortune", "will have unnatural luck", "shall find success in everything they do", "will become infallible"});
+        put(O2EffectType.MUTED_SPEECH, new String[]{"will be struck mute", "shall lose their mind to insanity", "shall be afflicted in the mind", "will fall silent"});
+        put(O2EffectType.POISON, new String[]{"will be struck by a terrible affliction", "shall come to harm", "will be cursed", "will be possessed by a demon spirit"});
+        put(O2EffectType.SHRINKING, new String[]{"will learn it is the little things that matter", "shall find a dreadful deflation drawing near", "shall be greatly reduced", "will find their footsteps diminished", "will become more grounded"});
+        put(O2EffectType.SLEEPING, new String[]{"will fall silent", "shall fall in to a deep sleep", "shall pass beyond this realm", "will surrender to a sleeping death"});
+        put(O2EffectType.SLOWNESS, new String[]{"shall be cursed", "will be afflicted in the mind", "will be struck by a terrible affliction", "will suffer a mental breakdown"});
+        put(O2EffectType.SPEED, new String[]{"will make haste", "will wear the boots of Mercury", "will move with the power of the gods"});
+        put(O2EffectType.SWELLING, new String[]{"has a big future", "shall find a dreadful inflation drawing near", "will be full of themselves", "has a bloated future"});
+        put(O2EffectType.UNLUCK, new String[]{"will be cursed by misfortune", "shall be cursed", "will find nothing but misfortune"});
+        put(O2EffectType.WATER_BREATHING, new String[]{"will swim with the mermaids", "will feel fishy", "will no longer fear water"});
+        put(O2EffectType.WEAKNESS, new String[]{"shall be cursed", "will be cursed by weakness", "will be struck by a terrible affliction"});
+        put(O2EffectType.WEALTH, new String[]{"will be blessed by fortune", "will have unnatural luck", "shall be granted a wish", "will be gifted by a leprechaun"});
     }};
 
     /**
@@ -104,126 +157,245 @@ public abstract class O2Divination {
     }
 
     /**
-     * Make a prophecy by the prophet about the target.
+     * Generate and execute a prophecy for the target player.
      *
-     * <p>Parts of a prophecy:</p>
-     * <p>
-     * 1. prophecyPrefix - optional prefix based on the specific divination method, such as "Due to the influence of Mars"<br>
-     * 2. the time of day - midnight, sunrise, midday, sunset<br>
-     * 3. the day - today, tomorrow, 3rd day, 4th day<br>
-     * 4. the target's name<br>
-     * 5. what will happen to them - see</p>
+     * <p>This method orchestrates the complete prophecy generation workflow:</p>
+     * <ol>
+     * <li>Calculates the prophet's accuracy based on their experience level (capped by method's maxAccuracy)</li>
+     * <li>Randomly selects a magical effect from the 21 available divination effects</li>
+     * <li>Randomly selects a prophecy prefix from the method-specific list</li>
+     * <li>Determines the prophecy timing (time of day and scheduled day offset)</li>
+     * <li>Constructs the complete prophecy message with all components</li>
+     * <li>Creates an O2Prophecy record and schedules the effect to trigger at the designated time</li>
+     * </ol>
      *
-     * <p>A prophecy should read like:<br>
-     * "After the sun sets on the 3rd day, Fred will fall in to a deep sleep."</p>
+     * <p>A complete prophecy message combines these components:</p>
+     * <ul>
+     * <li>Method-specific prefix (e.g., "Due to the influence of Mars," for astrology)</li>
+     * <li>Time of day (midnight, dawn, midday, sunset)</li>
+     * <li>Scheduled day (tomorrow, in two days, in three days, in four days)</li>
+     * <li>Target player's name</li>
+     * <li>Effect description from the selected magical effect</li>
+     * </ul>
+     *
+     * <p>Example: "Due to the influence of Mars, at sunset tomorrow, Fred will fall into a deep sleep."</p>
      */
     public void divine() {
         UUID prophetID = prophet.getUniqueId();
         UUID targetID = target.getUniqueId();
 
-        StringBuilder prophecyMessage = new StringBuilder();
+        // determine the accuracy of this prophecy
+        int accuracy = getAccuracy();
 
-        //
-        // first, determine the accuracy of this prophecy
-        //
+        // get the effect for this prophecy
+        O2EffectType effectType = getProphecyEffect();
+
+        // determine the number of days until fulfillment of the prophecy - 0 means tomorrow
+        int numDays = (Math.abs(Ollivanders2Common.random.nextInt()) % maxDelayDays);
+
+        // determine the time of day
+        TimeCommon timeOfDay = TimeCommon.values()[(Math.abs(Ollivanders2Common.random.nextInt()) % TimeCommon.values().length)];
+
+        // how many ticks until this time comes
+        long delayTicks = getDelayTicks(numDays, timeOfDay);
+
+        // get the duration of the effect (max 10 minutes)
+        int effectDuration = getEffectDuration();
+
+        // get the prophecy message
+        String prophecyMessage = createProphecyMessage(numDays, timeOfDay, effectType);
+
+        // create the prophecy and add it to the prophecy manager
+        O2Prophecy prophecy = new O2Prophecy(p, effectType, prophecyMessage, targetID, prophetID, delayTicks, effectDuration, accuracy);
+        Ollivanders2API.getProphecies().addProphecy(prophecy);
+
+        // make the prophet speak the prophecy
+        prophet.chat(prophecyMessage);
+    }
+
+    /**
+     * Calculate the accuracy rating for this prophecy.
+     *
+     * <p>Accuracy is based on the prophet's experience level with this divination method.
+     * The formula is: accuracy = experience / 2, capped by the divination method's maximum accuracy.
+     * This means the prophet gains 0.5% accuracy per experience level, up to the method's limit.</p>
+     *
+     * <p>Examples:
+     * <ul>
+     * <li>Prophet with 100 experience in astrology (maxAccuracy=20): 100/2 = 50, capped to 20</li>
+     * <li>Prophet with 30 experience in astrology (maxAccuracy=20): 30/2 = 15 (not capped)</li>
+     * <li>Prophet with -10 experience: clamped to minimum 0</li>
+     * </ul>
+     * </p>
+     *
+     * @return the prophecy accuracy as a percentage (0-99)
+     */
+    private int getAccuracy() {
         // Calculation:
         // - the prophet gets a 0.5% accuracy per level of experience at this type of divination
         // - the type of divination method has a maximum accuracy level, regardless of skill, which caps accuracy
         //
+        // Experience / 2 gives 0.5% accuracy per experience level (e.g., experience=100 -> 50% accuracy)
         int accuracy = experience / 2;
         if (accuracy > maxAccuracy)
             accuracy = maxAccuracy;
         else if (accuracy < 0)
             accuracy = 0;
 
-        //
-        // second, pick the effect
-        //
-        int rand = (Math.abs(Ollivanders2Common.random.nextInt()) % divinationEffects.size());
-        O2EffectType effectType = divinationEffects.get(rand);
-
-        O2Effect effect = getEffect(targetID, effectType);
-        if (effect == null)
-            return;
-
-        if (prophecyPrefix.size() > 0) {
-            rand = (Math.abs(Ollivanders2Common.random.nextInt()) % prophecyPrefix.size());
-            prophecyMessage.append(prophecyPrefix.get(rand)).append(" ");
-        }
-
-        //
-        // finally, the time of day and duration - via a lot of random chance
-        //
-        rand = (Math.abs(Ollivanders2Common.random.nextInt()) % TimeCommon.values().length);
-        TimeCommon timeOfDay = TimeCommon.values()[rand];
-
-        prophecyMessage.append("at ").append(timeOfDay.toString().toLowerCase()).append(" ");
-
-        rand = (Math.abs(Ollivanders2Common.random.nextInt()) % maxDurationDays);
-        long curTime = target.getWorld().getTime();
-        long ticks = 24000 - curTime;
-
-        if (rand == 0)
-            //tomorrow
-            prophecyMessage.append("tomorrow, ");
-        else if (rand == 1) {
-            //tomorrow
-            prophecyMessage.append("in two days, ");
-            ticks = ticks + 24000;
-        }
-        else if (rand == 2) {
-            //3rd day
-            prophecyMessage.append("in three days, ");
-            ticks = ticks + 48000;
-        }
-        else {
-            //4th day
-            prophecyMessage.append("in four days, ");
-            ticks = ticks + 72000;
-        }
-
-        ticks = ticks + timeOfDay.getTick();
-
-        //
-        // duration (min 30 seconds, max 10 minutes)
-        //
-        int effectDuration = 120 * experience;
-        if (effectDuration > 12000)
-            effectDuration = 12000;
-        else if (effectDuration < 600)
-            effectDuration = 600;
-
-        //
-        // finish prophecy
-        //
-        prophecyMessage.append(target.getName()).append(" ").append(effect.getDivinationText()).append(".");
-        String finalMessage = prophecyMessage.toString();
-
-        prophet.chat(finalMessage);
-        O2Prophecy prophecy = new O2Prophecy(p, effectType, finalMessage, targetID, prophetID, ticks, effectDuration, accuracy);
-        Ollivanders2API.getProphecies().addProphecy(prophecy);
+        return accuracy;
     }
 
     /**
-     * Get the effect of this divination.
+     * Calculate the number of game ticks until the prophecy should be fulfilled.
      *
-     * @param targetID   the ID of the target player for this effect
-     * @param effectType the type of effect
-     * @return the effect this prophecy causes
+     * <p>The calculation determines when the prophecy executes based on the number of days in the future
+     * and the time of day selected. It works by:
+     * <ol>
+     * <li>Finding the number of ticks until the next midnight (end of current day)</li>
+     * <li>Adding additional days worth of ticks for the delay (if delayDays > 0)</li>
+     * <li>Adding the time-of-day offset (e.g., dawn is partway through the day)</li>
+     * </ol>
+     * </p>
+     *
+     * <p>Example: If it's currently noon (6000 ticks into a 24000 tick day), tomorrow at midnight:
+     * <ul>
+     * <li>ticksToMidnight = 24000 - 6000 = 18000</li>
+     * <li>delayDays = 0 (tomorrow)</li>
+     * <li>timeOfDay.getTick() = 0 (midnight)</li>
+     * <li>Total = 18000 ticks</li>
+     * </ul>
+     * </p>
+     *
+     * @param delayDays the number of days in the future (0 = tomorrow, 1 = 2 days from now, etc.)
+     * @param timeOfDay the time of day when the prophecy will execute
+     * @return the number of game ticks until the prophecy should be fulfilled
      */
-    @Nullable
-    private O2Effect getEffect(@NotNull UUID targetID, @NotNull O2EffectType effectType) {
-        Class<?> effectClass = effectType.getClassName();
-        O2Effect effect;
+    private long getDelayTicks(int delayDays, TimeCommon timeOfDay) {
+        // number of ticks until midnight (end of current day) = tickPerDay - the current time
+        long ticksToMidnight = ticksPerDay - (target.getWorld().getTime());
 
-        try {
-            effect = (O2Effect) effectClass.getConstructor(Ollivanders2.class, int.class, UUID.class).newInstance(p, 1, targetID);
-        }
-        catch (Exception e) {
-            e.printStackTrace();
-            return null;
+        // number of ticks to midnight of the chose day = number of ticks to midnight + number of ticks per day to advance
+        // so for delayDays = 0, the day is tomorrow, then ticksToMidnightOfChosenDay = ticksToMidnight
+        // if delayDays = 1, advance one day, so 2 days from now, then ticksToMidnightOfChosenDay = ticksToMidnight + 1 day worth of ticks
+        long ticksToMidnightOfChosenDay = ticksToMidnight + (delayDays * (long) ticksPerDay);
+
+        // Add the specific time of day offset (midnight, dawn, midday, or sunset)
+        return ticksToMidnightOfChosenDay + timeOfDay.getTick();
+    }
+
+    /**
+     * Construct the complete prophecy message text.
+     *
+     * <p>Assembles all components into a grammatically correct prophecy sentence:
+     * [prefix], at [timeOfDay] [day], [targetName] [effectDescription].</p>
+     *
+     * <p>Components assembled in order:
+     * <ol>
+     * <li>Method-specific prefix (randomly selected from prophecyPrefix array)</li>
+     * <li>Time of day (dawn, midday, sunset, or midnight)</li>
+     * <li>Day reference (tomorrow, in 2 days, in 3 days, etc.)</li>
+     * <li>Target player's name</li>
+     * <li>Effect description (randomly selected from divinationEffects)</li>
+     * </ol>
+     * </p>
+     *
+     * <p>Example output: "The cards have revealed that, at sunset in 3 days, Fred shall be cursed."</p>
+     *
+     * @param numDays the number of days offset (0 = tomorrow, 1 = 2 days from now, etc.)
+     * @param timeOfDay the time of day for the prophecy
+     * @param effectType the magical effect type that will be applied
+     * @return the complete prophecy message
+     */
+    private String createProphecyMessage(int numDays, TimeCommon timeOfDay, O2EffectType effectType) {
+        StringBuilder prophecyMessage = new StringBuilder();
+
+        // start with any prophecy prefix - this comes from the specific divination method, so Cartomancy might be "The cards have revealed that"
+        if (!prophecyPrefix.isEmpty()) {
+            int rand = (Math.abs(Ollivanders2Common.random.nextInt()) % prophecyPrefix.size());
+            prophecyMessage.append(prophecyPrefix.get(rand)).append(", ");
         }
 
-        return effect;
+        // add time of day the prophecy will come to pass
+        if (prophecyMessage.isEmpty())
+            prophecyMessage.append("At "); // capitalize because it is the start of the sentence
+        else
+            prophecyMessage.append("at ");
+        prophecyMessage.append(timeOfDay.toString().toLowerCase()).append(" ");
+
+        // add in the day - numDays is the offset (0 = tomorrow, 1 = 2 days from now, etc.)
+        if (numDays == 0)
+            prophecyMessage.append("tomorrow ");
+        else
+            prophecyMessage.append("in ").append(numDays + 1).append(" days ");
+
+        // add target name
+        prophecyMessage.append(target.getName()).append(" ");
+
+        // add prophecy predicate - this comes from the specific effect this prophecy will cause
+        prophecyMessage.append(getProphecyPredicateText(effectType)).append(".");
+
+        return prophecyMessage.toString();
+    }
+
+    /**
+     * Select a random magical effect from the divination effects pool.
+     *
+     * <p>Randomly selects one of the available O2EffectType values that have been defined in the divinationEffects map.
+     * Uses a modulo-based random selection to ensure uniform distribution across all available effects.</p>
+     *
+     * @return a randomly selected O2EffectType from the divination effects pool
+     */
+    private O2EffectType getProphecyEffect() {
+        // Create a list of all effect types in the divination effects map, then select one at random
+        int rand = (Math.abs(Ollivanders2Common.random.nextInt()) % divinationEffects.size());
+        return new ArrayList<>(divinationEffects.keySet()).get(rand);
+    }
+
+    /**
+     * Get a random prophecy predicate text for the given effect type.
+     *
+     * <p>From the divinationEffects map, retrieves the array of possible prophecy text phrases for the given effect type,
+     * then selects one at random. This allows multiple possible prophecy wordings for each effect, increasing variety.</p>
+     *
+     * <p>Example: For O2EffectType.HARM, might return "shall be struck by a terrible affliction" or "will come to harm".</p>
+     *
+     * @param effectType the magical effect type to get prophecy text for
+     * @return a randomly selected prophecy predicate phrase for that effect type
+     */
+    private String getProphecyPredicateText(O2EffectType effectType) {
+        String[] prophecyTexts = divinationEffects.get(effectType);
+
+        // Select a random text phrase from the array for this effect type
+        int rand = (Math.abs(Ollivanders2Common.random.nextInt()) % prophecyTexts.length);
+        return prophecyTexts[rand];
+    }
+
+    /**
+     * Calculate the duration for the predicted magical effect.
+     *
+     * <p>The effect duration scales based on the prophet's experience level with this divination method:
+     * 120 game ticks per experience level (roughly 6 seconds per level, given 20 ticks per second).
+     * The duration is capped at a minimum of O2Effect.minDuration and a maximum of 10 minutes (12000 ticks).</p>
+     *
+     * <p>Duration scaling examples:
+     * <ul>
+     * <li>Experience = 10: 10 * 120 = 1200 ticks (60 seconds)</li>
+     * <li>Experience = 50: 50 * 120 = 6000 ticks (300 seconds / 5 minutes)</li>
+     * <li>Experience = 100: 100 * 120 = 12000 ticks, capped at 12000 (600 seconds / 10 minutes max)</li>
+     * </ul>
+     * </p>
+     *
+     * @return the effect duration in game ticks, ranging from O2Effect.minDuration to 12000
+     */
+    private int getEffectDuration() {
+        // Calculate duration based on prophet's experience: 120 ticks per experience level
+        // (20 ticks per second: 30 seconds = 600 ticks, 10 minutes = 12000 ticks)
+        int effectDuration = 120 * experience;
+        if (effectDuration > 12000)
+            effectDuration = 12000;  // Cap at 10 minutes
+        else if (effectDuration < O2Effect.minDuration)
+            effectDuration = O2Effect.minDuration;    // Floor at O2Effect.minDuration
+
+        return effectDuration;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2DivinationType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2DivinationType.java
@@ -3,10 +3,32 @@ package net.pottercraft.ollivanders2.divination;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * All divination methods
+ * Enumeration of all available divination methods in Ollivanders2.
+ * <p>
+ * This enum maps each divination type to its corresponding implementation class. The divination methods vary in
+ * accuracy, with centaur divination being the most reliable (80% max accuracy) and tasseomancy being the least (20% max accuracy).
+ * Each divination method defines its own prophecy prefixes and behavior through subclasses of {@link O2Divination}.
+ * </p>
+ * <p>
+ * Implemented divination types:
+ * </p>
+ * <ul>
+ * <li><strong>ASTROLOGY</strong> - Celestial-based divination (20% max accuracy)</li>
+ * <li><strong>CARTOMANCY</strong> - Card divination with spades focus (25% max accuracy)</li>
+ * <li><strong>CARTOMANCY_TAROT</strong> - Major arcana tarot reading (35% max accuracy)</li>
+ * <li><strong>CENTAUR_DIVINATION</strong> - Celestial observation and augury (80% max accuracy)</li>
+ * <li><strong>CRYSTAL_BALL</strong> - Scrying and clairvoyant vision (30% max accuracy)</li>
+ * <li><strong>OVOMANCY</strong> - Egg pattern interpretation (40% max accuracy)</li>
+ * <li><strong>TASSEOMANCY</strong> - Tea-leaf reading (20% max accuracy)</li>
+ * </ul>
+ * <p>
+ * Additional divination methods are defined in comments for future implementation:
+ * BIBLIOMANCY, CATOPTROMANCY, CHINESE_FORTUNE_STICKS, DREAM_INTERPRETATION, FIRE_OMEN,
+ * HEPTOMOLOGY, ICHTHYOMANCY, MYOMANCY, PALMISTRY, ORNITHOMANCY, RUNE_STONES, XYLOMANCY
+ * </p>
  *
  * @author Azami7
- * @since 2.2.9
+ * @see O2Divination for the abstract base class of divination implementations
  */
 public enum O2DivinationType {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Prophecies.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Prophecies.java
@@ -14,34 +14,59 @@ import java.util.Map;
 import java.util.UUID;
 
 /**
- * Class for managing all prophecies. A prophecy is made via divination and concerns future effects on a player.
+ * Central manager for all divination prophecies in the server.
+ * <p>
+ * O2Prophecies maintains two separate lists of prophecies: active prophecies for online players and offline
+ * prophecies waiting for players to return. Every game tick, the upkeep() method processes all active prophecies,
+ * aging them by one tick and fulfilling those whose time has reached zero. Prophecies are automatically persisted
+ * to disk using JSON serialization, allowing them to survive server restarts.
+ * </p>
+ * <p>
+ * This class is responsible for:
+ * </p>
+ * <ul>
+ * <li>Adding new prophecies created by divination spells</li>
+ * <li>Processing active prophecies each tick (age and fulfill)</li>
+ * <li>Managing offline prophecies that wait for players to log back in</li>
+ * <li>Serializing prophecies to JSON for persistent storage</li>
+ * <li>Deserializing prophecies from JSON when the server starts</li>
+ * <li>Querying prophecies by target player or prophet player</li>
+ * </ul>
  *
  * @author Azami7
- * @since 2.2.9
+ * @see O2Prophecy for the individual prophecy data structure
+ * @see O2Divination for the divination system that creates prophecies
  */
 public class O2Prophecies {
     /**
-     * plugin callback
+     * Reference to the plugin for accessing configuration and logging.
      */
     final private Ollivanders2 p;
 
     /**
-     * common functions
+     * Common utility functions for the plugin.
      */
     final private Ollivanders2Common common;
 
     /**
-     * prophecies actively aging for online players
+     * List of prophecies actively aging and scheduled for execution.
+     * These prophecies are for online players and will be processed every game tick by upkeep().
+     * When a prophecy's time reaches zero, it is fulfilled (effect applied to target).
+     * Prophecies remain in this list until they are either fulfilled or killed.
      */
     final private List<O2Prophecy> activeProphecies = new ArrayList<>();
 
     /**
-     * prophecies paused while players are offline
+     * List of prophecies waiting for their target players to rejoin the server.
+     * When a prophecy is fulfilled for an offline player, it is automatically moved here.
+     * When the target player logs back in, onJoin() moves relevant prophecies back to activeProphecies.
      */
     final private List<O2Prophecy> offlineProphecies = new ArrayList<>();
 
     /**
-     * serialization labels
+     * JSON serialization field labels for persisting prophecy data.
+     * These constants are used as keys when converting prophecies to/from Maps during save/load operations.
+     * They must remain consistent with previously saved prophecy data files for backward compatibility.
      */
     final static private String effectTypeLabel = "Effect_Type";
     final static private String targetIDLabel = "Target_ID";
@@ -64,9 +89,12 @@ public class O2Prophecies {
     }
 
     /**
-     * Add a prophecy
+     * Add a newly created prophecy to the active prophecies list.
      *
-     * @param prophecy the prophecy to add
+     * <p>This method is called by {@link O2Divination#divine()} when a divination prophecy is created.
+     * The prophecy is added to the active list and will be processed by upkeep() every game tick.</p>
+     *
+     * @param prophecy the newly created prophecy to add
      */
     public void addProphecy(@NotNull O2Prophecy prophecy) {
         common.printDebugMessage("Adding prophecy", null, null, false);
@@ -74,9 +102,12 @@ public class O2Prophecies {
     }
 
     /**
-     * Add a prophecy to the offline prophecies when the target user is offline
+     * Add a prophecy to the offline prophecies list when its target player is offline.
      *
-     * @param prophecy the prophecy to add
+     * <p>Called by O2Prophecy.fulfill() when a prophecy is fulfilled for a player who is not online.
+     * The prophecy is stashed in the offline list and will be re-executed when the target player logs back in.</p>
+     *
+     * @param prophecy the prophecy whose target is offline
      */
     void addOfflineProphecy(@NotNull O2Prophecy prophecy) {
         common.printDebugMessage("Adding prophecy", null, null, false);
@@ -84,10 +115,13 @@ public class O2Prophecies {
     }
 
     /**
-     * Get a prophecy made about a player
+     * Get the first active prophecy where the given player is the target (subject of the prophecy).
      *
-     * @param pid the player
-     * @return a prophecy if found, null otherwise
+     * <p>Searches only the active prophecies list (prophecies scheduled for online players).
+     * If you need to check for offline prophecies as well, use getProphecy() instead.</p>
+     *
+     * @param pid the unique ID of the target player
+     * @return the prophecy about this player if found in active list, or null if not found
      */
     @Nullable
     public O2Prophecy getProphecyAboutPlayer(@NotNull UUID pid) {
@@ -101,18 +135,23 @@ public class O2Prophecies {
     }
 
     /**
-     * Get a list of all unfulfilled prophecies
+     * Get a list of all pending prophecy messages (both active and offline).
      *
-     * @return a list of all prophecies
+     * <p>Returns the human-readable prophecy text messages from both active and offline prophecies combined.
+     * Useful for displaying all pending prophecies to a player or admin.</p>
+     *
+     * @return a list of prophecy message strings from all pending prophecies
      */
     @NotNull
     public List<String> getProphecies() {
         ArrayList<String> prophecies = new ArrayList<>();
 
+        // Add messages from active prophecies (scheduled for online players)
         for (O2Prophecy prophecy : activeProphecies) {
             prophecies.add(prophecy.getProphecyMessage());
         }
 
+        // Add messages from offline prophecies (waiting for player to rejoin)
         for (O2Prophecy prophecy : offlineProphecies) {
             prophecies.add(prophecy.getProphecyMessage());
         }
@@ -121,10 +160,13 @@ public class O2Prophecies {
     }
 
     /**
-     * Get a prophecy made by a player
+     * Get the first active prophecy made by (created by) the given player.
      *
-     * @param pid the player
-     * @return a prophecy if found, null otherwise
+     * <p>Searches only the active prophecies list to find a prophecy where this player is the prophet (creator).
+     * This is distinct from getProphecyAboutPlayer() which finds prophecies where the player is the target.</p>
+     *
+     * @param pid the unique ID of the prophet (spell caster)
+     * @return the prophecy created by this player if found in active list, or null if not found
      */
     @Nullable
     public O2Prophecy getProphecyByPlayer(@NotNull UUID pid) {
@@ -138,7 +180,19 @@ public class O2Prophecies {
     }
 
     /**
-     * Process all active prophecies
+     * Process all active prophecies for one game tick.
+     *
+     * <p>This method is called every server tick and handles the lifecycle of all active prophecies:</p>
+     * <ol>
+     * <li>Iterates through a snapshot of all active prophecies (to allow safe removal during iteration)</li>
+     * <li>For each non-killed prophecy: ages it by one tick (decrements time counter)</li>
+     * <li>If time reaches zero or below: calls fulfill() to execute the prophecy</li>
+     * <li>If the fulfilled prophecy is in the offline list: removes it from active list</li>
+     * <li>Removes any killed prophecies from the active list</li>
+     * </ol>
+     *
+     * <p>A snapshot of the active prophecies list is used to avoid ConcurrentModificationException when
+     * removing prophecies during iteration.</p>
      */
     public void upkeep() {
         ArrayList<O2Prophecy> prophecies = new ArrayList<>(activeProphecies);
@@ -150,6 +204,8 @@ public class O2Prophecies {
                 if (prophecy.getTime() < 1) {
                     prophecy.fulfill();
 
+                    // fulfill() will move the prophecy to offlineProphecies if the target is not online, make sure it was
+                    // removed from activeProphecies so we don't keep trying to fulfill it.
                     if (offlineProphecies.contains(prophecy)) {
                         activeProphecies.remove(prophecy);
                     }
@@ -164,7 +220,10 @@ public class O2Prophecies {
     }
 
     /**
-     * Save all prophecies
+     * Persist all prophecies to disk in JSON format.
+     *
+     * <p>Called when the server shuts down (via the prophecy save scheduler). Serializes all active and offline
+     * prophecies to JSON Maps and writes them to the prophecies save file. Only non-killed prophecies are saved.</p>
      */
     public void saveProphecies() {
         List<Map<String, String>> prophecies = serializeProphecies();
@@ -174,7 +233,11 @@ public class O2Prophecies {
     }
 
     /**
-     * Load saved prophecies, this shouldn't be called by anything except the O2Prophecies onEnable() and unit tests.
+     * Load all saved prophecies from disk.
+     *
+     * <p>Called during plugin initialization to restore prophecies from the last server session.
+     * Deserializes JSON data back into O2Prophecy objects and adds them to the active prophecies list.
+     * If no save file exists, logs a message and continues without any prophecies.</p>
      */
     public void loadProphecies() {
         GsonDAO gsonLayer = new GsonDAO();
@@ -196,27 +259,30 @@ public class O2Prophecies {
     }
 
     /**
-     * Serialize prophecies to strings so they can be saved.
+     * Serialize all pending prophecies to a list of Maps for JSON storage.
      *
-     * @return a list of all prophecies serialized to strings
+     * <p>Converts both active and offline prophecies into Map<String,String> format, skipping any killed prophecies.
+     * Each Map contains the prophecy data using the field labels defined at the class level.</p>
+     *
+     * @return a list of Map objects representing all pending prophecies ready for JSON serialization
      */
     @NotNull
     private List<Map<String, String>> serializeProphecies() {
         List<Map<String, String>> prophecies = new ArrayList<>();
 
-        // add active prophecies
+        // Serialize active prophecies (those still waiting for online targets)
         for (O2Prophecy prophecy : activeProphecies) {
             if (prophecy.isKilled()) {
-                continue;
+                continue;  // Skip killed prophecies, they don't need to be saved
             }
 
             prophecies.add(serializeProphecy(prophecy));
         }
 
-        // add offline prophecies
+        // Serialize offline prophecies (those waiting for offline targets to rejoin)
         for (O2Prophecy prophecy : offlineProphecies) {
             if (prophecy.isKilled()) {
-                continue;
+                continue;  // Skip killed prophecies, they don't need to be saved
             }
 
             prophecies.add(serializeProphecy(prophecy));
@@ -226,49 +292,43 @@ public class O2Prophecies {
     }
 
     /**
-     * Serialize the data for a prophecy in to a map of Strings
+     * Serialize a single prophecy into a Map of string key-value pairs.
+     *
+     * <p>Converts all prophecy data into a Map using the static field labels as keys.
+     * This is used both for JSON serialization and for transferring prophecy data in the system.</p>
      *
      * @param prophecy the prophecy to serialize
-     * @return the map of serialized prophecy data
+     * @return a Map containing all prophecy data with field labels as keys
      */
     @NotNull
     private Map<String, String> serializeProphecy(@NotNull O2Prophecy prophecy) {
         Map<String, String> prophecyData = new HashMap<>();
 
-        // prophecy
+        // Populate the map with all prophecy fields using the defined labels
         prophecyData.put(prophecyLabel, prophecy.getProphecyMessage());
-
-        // prophet
         prophecyData.put(prophetIDLabel, prophecy.getProphetID().toString());
-
-        // target
         prophecyData.put(targetIDLabel, prophecy.getTargetID().toString());
-
-        // effect
         prophecyData.put(effectTypeLabel, prophecy.getEffect().toString());
-
-        // duration
         prophecyData.put(durationLabel, Integer.toString(prophecy.getDuration()));
-
-        // accuracy
         prophecyData.put(accuracyLabel, Integer.toString(prophecy.getAccuracy()));
-
-        // time
         prophecyData.put(timeLabel, Long.toString(prophecy.getTime()));
 
         return prophecyData;
     }
 
     /**
-     * Deserialize prophecy data in to a prophecy.
+     * Deserialize a prophecy from a Map of string key-value pairs.
      *
-     * @param prophecyData the serialized prophecy data
-     * @return a prophecy if the data was read successfully, null otherwise
+     * <p>Reconstructs an O2Prophecy object from Map data loaded from JSON. Parses all fields and validates
+     * that all required fields are present before creating the prophecy. If any field is missing or parsing fails,
+     * returns null and logs the error.</p>
+     *
+     * @param prophecyData a Map containing prophecy data with field labels as keys
+     * @return a reconstructed O2Prophecy object, or null if deserialization failed
      */
     @Nullable
     private O2Prophecy deserializeProphecy(@NotNull Map<String, String> prophecyData) {
-        O2Prophecy prophecy = null;
-
+        // Initialize all fields to null before parsing
         O2EffectType effectType = null;
         String prophecyMessage = null;
         UUID targetID = null;
@@ -277,38 +337,25 @@ public class O2Prophecies {
         Integer duration = null;
         Integer accuracy = null;
 
+        // Parse each field from the map, gracefully handling any parsing errors
         for (Map.Entry<String, String> entry : prophecyData.entrySet()) {
             String key = entry.getKey();
             String value = entry.getValue();
 
             try {
-                // effect type
-                if (key.equals(effectTypeLabel)) {
-                    effectType = O2EffectType.valueOf(value);
-                }
-                // prophecy
-                else if (key.equals(prophecyLabel)) {
-                    prophecyMessage = value;
-                }
-                // target
-                else if (key.equals(targetIDLabel)) {
-                    targetID = UUID.fromString(value);
-                }
-                // prophet
-                else if (key.equals(prophetIDLabel)) {
-                    prophetID = UUID.fromString(value);
-                }
-                // time
-                else if (key.equals(timeLabel)) {
-                    time = Long.valueOf(value);
-                }
-                // duration
-                else if (key.equals(durationLabel)) {
-                    duration = Integer.valueOf(value);
-                }
-                // accuracy
-                else if (key.equals(accuracyLabel)) {
-                    accuracy = Integer.valueOf(value);
+                // Parse each field independently. If one field fails, we catch the exception and continue
+                // parsing the remaining fields. Missing or invalid fields are detected below when checking
+                // that all required fields were successfully deserialized.
+                switch (key) {
+                    case String s when s.equals(effectTypeLabel) -> effectType = O2EffectType.valueOf(value);
+                    case String s when s.equals(prophecyLabel) -> prophecyMessage = value;
+                    case String s when s.equals(targetIDLabel) -> targetID = UUID.fromString(value);
+                    case String s when s.equals(prophetIDLabel) -> prophetID = UUID.fromString(value);
+                    case String s when s.equals(timeLabel) -> time = Long.valueOf(value);
+                    case String s when s.equals(durationLabel) -> duration = Integer.valueOf(value);
+                    case String s when s.equals(accuracyLabel) -> accuracy = Integer.valueOf(value);
+                    default -> {
+                    } // Ignore unknown fields
                 }
             }
             catch (Exception e) {
@@ -316,28 +363,36 @@ public class O2Prophecies {
             }
         }
 
-        if (effectType != null && prophecyMessage != null && targetID != null && prophetID != null && time != null && duration != null && accuracy != null) {
-            prophecy = new O2Prophecy(p, effectType, prophecyMessage, targetID, prophetID, time, duration, accuracy);
+        // Only create a prophecy if all required fields were successfully deserialized. We need all attributes to re-create the prophecy object
+        if (effectType != null && prophecyMessage != null && targetID != null && prophetID != null &&
+                time != null && duration != null && accuracy != null) {
+            return new O2Prophecy(p, effectType, prophecyMessage, targetID, prophetID, time, duration, accuracy);
         }
         else {
             p.getLogger().info("Failure reading saved prophecy data - one or more fields missing.");
+            return null;
         }
-
-        return prophecy;
     }
 
     /**
-     * On join, load in to active prophecy list any prophecies about this player.
+     * Move any prophecies for the newly joined player from offline to active list.
      *
-     * @param pid the ID of the player that joined
+     * <p>When a player logs in, check if there are any prophecies waiting in the offline list for them.
+     * If so, move those prophecies to the active list so they resume being processed by upkeep().</p>
+     *
+     * <p>A snapshot of the offline prophecies list is used to allow safe removal during iteration.</p>
+     *
+     * @param pid the unique ID of the player that just logged in
      */
     public void onJoin(@NotNull UUID pid) {
         int count = 0;
 
+        // Create a snapshot to allow safe removal during iteration
         ArrayList<O2Prophecy> prophecies = new ArrayList<>(offlineProphecies);
 
         for (O2Prophecy prophecy : prophecies) {
             if (prophecy.getTargetID().equals(pid)) {
+                // Move this prophecy from offline to active list
                 activeProphecies.add(prophecy);
                 offlineProphecies.remove(prophecy);
 
@@ -349,36 +404,38 @@ public class O2Prophecies {
     }
 
     /**
-     * Get a prophecy about a specific player.
+     * Get the prophecy message text for a specific player (searches both active and offline prophecies).
      *
-     * @param targetID the player to get a prophecy about
-     * @return the prophecy text if found, null otherwise
+     * <p>Returns the first prophecy message found for the player, checking active prophecies first,
+     * then offline prophecies. Only returns the message text, not the full O2Prophecy object.
+     * Use getProphecyAboutPlayer() if you need the full prophecy object.</p>
+     *
+     * @param targetID the unique ID of the target player
+     * @return the prophecy message text if found, or null if no prophecy exists for this player
      */
     @Nullable
     public String getProphecy(@NotNull UUID targetID) {
-        String prophecy = null;
-
+        // Check active prophecies first
         for (O2Prophecy prop : activeProphecies) {
             if (prop.getTargetID().equals(targetID)) {
-                prophecy = prop.getProphecyMessage();
+                return prop.getProphecyMessage();
             }
         }
 
-        if (prophecy != null) {
-            return prophecy;
-        }
-
+        // If not found, check offline prophecies
         for (O2Prophecy prop : offlineProphecies) {
             if (prop.getTargetID().equals(targetID)) {
-                prophecy = prop.getProphecyMessage();
+                return prop.getProphecyMessage();
             }
         }
 
-        return prophecy;
+        return null;
     }
 
     /**
-     * Clear all pending prophecies.
+     * Clear all pending prophecies (both active and offline).
+     *
+     * <p>Removes all prophecies from both lists. Used primarily for testing and configuration resets.</p>
      */
     public void resetProphecies() {
         activeProphecies.clear();
@@ -386,9 +443,12 @@ public class O2Prophecies {
     }
 
     /**
-     * The count of active prophecies
+     * Get the count of active prophecies currently pending.
      *
-     * @return the count of active prophecies
+     * <p>Returns the number of prophecies in the active list only (not including offline prophecies).
+     * Useful for status checking and debugging.</p>
+     *
+     * @return the number of active prophecies
      */
     public int activeProphecyCount() {
         return activeProphecies.size();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Prophecy.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Prophecy.java
@@ -12,71 +12,107 @@ import org.jetbrains.annotations.NotNull;
 import java.util.UUID;
 
 /**
- * Class representing a prophecy. Every prophecy involves predicting an effect on a player in the future and
- * has a specific accuracy which changes the likelihood the prophecy will come to pass.
+ * Represents a scheduled divination prophecy with delayed effect execution.
+ * <p>
+ * An O2Prophecy encapsulates all the information needed to execute a prophecy at a future time:
+ * the target player, the magical effect to apply, the accuracy rating, and the scheduled execution time.
+ * Prophecies are processed each game tick: when the time reaches zero, the prophecy is "fulfilled" by
+ * applying the magical effect to the target player. The accuracy rating determines whether the prophecy
+ * actually succeeds when its time arrives—a random check compares the prophecy's accuracy against a
+ * random 0-99 roll.
+ * </p>
+ * <p>
+ * Prophecies can be handled in two ways:
+ * </p>
+ * <ul>
+ * <li><strong>Online Target:</strong> If the target player is online when the prophecy is fulfilled,
+ *     the effect is applied directly and a broadcast message announces the prophecy's outcome.</li>
+ * <li><strong>Offline Target:</strong> If the target player is offline, the prophecy is stashed and
+ *     automatically re-executed when the player logs back in.</li>
+ * </ul>
+ *
+ * @author Azami7
+ * @see O2Divination for the divination system that creates prophecies
+ * @see O2Prophecies for the container managing all active prophecies
  */
 public class O2Prophecy {
     /**
-     * A reference to the plugin
+     * Reference to the plugin for accessing configuration, logging, and server API.
      */
     final private Ollivanders2 p;
 
     /**
-     * Maximum accuracy for a prophecy
+     * Maximum accuracy percentage a prophecy can have.
+     * Used to clamp prophecy accuracy in the constructor. Represents a 99% success rate.
      */
     static public final int maxAccuracy = 99;
 
     /**
-     * The effect that will happen to the player
+     * The type of magical effect that will be applied when this prophecy is fulfilled.
+     * Used to instantiate the actual effect object when the prophecy is executed.
      */
     private final O2EffectType effectType;
 
     /**
-     * The player that will be affected
+     * The unique identifier of the target player who will be affected by this prophecy.
+     * The effect will be applied to this player when the prophecy is fulfilled.
      */
     private final UUID targetID;
 
     /**
-     * The player that made the prophecy
+     * The unique identifier of the prophet (player who cast the prophecy spell).
+     * Used to notify the prophet of the prophecy's success or failure.
      */
     private final UUID prophetID;
 
     /**
-     * The time until the prophecy will come to pass, in game ticks - one game tick is 1/20 of a second
+     * The time remaining until the prophecy is fulfilled, measured in game ticks.
+     * One game tick = 1/20 of a second (50 milliseconds).
+     * This value is decremented by 1 each game tick via the age() method.
+     * When time reaches zero or below, the prophecy is ready to be fulfilled.
      */
     private long time;
 
     /**
-     * The duration, in game ticks, for this prophecy
+     * The duration of the magical effect in game ticks.
+     * Determines how long the effect will persist after the prophecy is fulfilled.
+     * Range is typically 600-12000 ticks (30 seconds - 10 minutes).
      */
     private final int duration;
 
     /**
-     * The percent accuracy of this prophecy
+     * The success probability of this prophecy as a percentage (0-99).
+     * When the prophecy is fulfilled, a random 0-99 roll is compared against this value.
+     * If accuracy > roll, the prophecy succeeds; otherwise it fails.
      */
     private final int accuracy;
 
     /**
-     * The message of this prophecy
+     * The human-readable prophecy message displayed to players when fulfilled.
+     * Example: "At sunset tomorrow, Fred will fall in to a deep sleep."
      */
     private final String prophecyMessage;
 
     /**
-     * Whether this prophecy has expired
+     * Flag indicating whether this prophecy has been expired and should not be processed further.
+     * Once killed, the prophecy will not be fulfilled even if time reaches zero.
      */
     private boolean kill = false;
 
     /**
-     * Constructor
+     * Constructor for creating a new divination prophecy.
      *
-     * @param plugin         a reference to the plugin
-     * @param effectType     the effect that will happen to the player
-     * @param message        the message to be displayed for the prophecy
-     * @param targetID       the id of the player that will be affected
-     * @param prophetID      the id of the player that made this prophecy
-     * @param delayTime      the time, in game ticks, until the prophecy will come to pass, less than 1200 (1 minute) will be rounded up to 1200
-     * @param effectDuration the duration of the effect
-     * @param accuracy       the accuracy of this prophecy as a percent from 0 to 99, greater than 99 will be rounded down to 99
+     * <p>Creates a prophecy with the given parameters. Accuracy is automatically clamped to 0-99 range.
+     * Once created, the prophecy will be managed by O2Prophecies and processed each game tick.</p>
+     *
+     * @param plugin         a reference to the plugin for API access
+     * @param effectType     the magical effect that will be applied if the prophecy succeeds
+     * @param message        the human-readable prophecy message displayed to players
+     * @param targetID       the unique ID of the target player who will receive the effect
+     * @param prophetID      the unique ID of the prophet (caster) for notification purposes
+     * @param delayTime      the number of game ticks until the prophecy is fulfilled
+     * @param effectDuration the duration of the effect in game ticks (600-12000 typical)
+     * @param accuracy       the success probability (0-99). Values outside this range are clamped
      */
     public O2Prophecy(@NotNull Ollivanders2 plugin, @NotNull O2EffectType effectType, @NotNull String message, @NotNull UUID targetID, @NotNull UUID prophetID, long delayTime, int effectDuration, int accuracy) {
         p = plugin;
@@ -118,7 +154,7 @@ public class O2Prophecy {
     /**
      * Get the ID of player who made this prophecy
      *
-     * @return the target player's unique ID
+     * @return the prophet player's unique ID
      */
     @NotNull
     public UUID getProphetID() {
@@ -171,21 +207,43 @@ public class O2Prophecy {
     }
 
     /**
-     * Age this prophecy 1 game tick
+     * Decrement the prophecy time by 1 game tick.
+     *
+     * <p>Called by O2Prophecies.upkeep() each game tick to advance the prophecy countdown.
+     * When time reaches zero or below, the prophecy is ready to be fulfilled.</p>
      */
     public void age() {
         time = time - 1;
     }
 
     /**
-     * Kill this prophecy
+     * Mark this prophecy as expired and prevent further processing.
+     *
+     * <p>Once killed, the prophecy will not be fulfilled even if it was scheduled to be,
+     * and will be removed from the prophecy lists during the next O2Prophecies.upkeep() call.</p>
      */
     public void kill() {
         kill = true;
     }
 
     /**
-     * Execute this prophecy.
+     * Execute this prophecy and apply its magical effect to the target player.
+     *
+     * <p>This method handles the complete prophecy fulfillment workflow:</p>
+     * <ol>
+     * <li>Checks if the prophecy has already been killed/expired; returns early if so</li>
+     * <li>Locates the target player on the server</li>
+     * <li>If target is offline: stashes the prophecy for later execution when the player logs in</li>
+     * <li>If target is online: performs an accuracy check by comparing the prophecy's accuracy
+     *     against a random 0-99 roll</li>
+     * <li>On success (accuracy > roll): instantiates the magical effect and applies it to the target,
+     *     then broadcasts a message to all players announcing the prophecy's fulfillment</li>
+     * <li>On failure (accuracy &le; roll): sends a message to the prophet informing them the prophecy failed</li>
+     * <li>Marks the prophecy as killed to prevent further execution</li>
+     * </ol>
+     *
+     * <p>The accuracy check is probabilistic: a prophecy with 50% accuracy has a 50% chance of success,
+     * and a prophecy with 99% accuracy has a 99% chance of success.</p>
      */
     public void fulfill() {
         if (Ollivanders2.debug) {
@@ -205,13 +263,18 @@ public class O2Prophecy {
             return;
         }
 
+        // Perform accuracy check: generate random 0-99 value and compare against prophecy accuracy
+        // Example: 50% accuracy needs to roll < 50 to succeed
         int rand = Math.abs(Ollivanders2Common.random.nextInt() % 100);
 
         if (accuracy > rand) {
+            // Prophecy succeeds: apply the effect to the target
             O2Effect effect;
             Class<?> effectClass = effectType.getClassName();
 
             try {
+                // Use reflection to dynamically instantiate the effect class without a factory method
+                // Constructor signature: (Ollivanders2, int duration, UUID targetID)
                 effect = (O2Effect) effectClass.getConstructor(Ollivanders2.class, int.class, UUID.class).newInstance(p, duration, targetID);
             }
             catch (Exception e) {
@@ -220,6 +283,7 @@ public class O2Prophecy {
                 return;
             }
 
+            // Ensure the effect is not permanent - prophecy effects have a limited duration
             effect.setPermanent(false);
             Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/divination/OVOMANCY.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/divination/OVOMANCY.java
@@ -5,28 +5,55 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Ovomancy is a type of divination that involves cracking open eggs and observing which way the yolks fall.
- *
- * <p>Reference: https://harrypotter.fandom.com/wiki/Ovomancy</p>
+ * Ovomancy divination spell implementation using egg pattern interpretation.
+ * <p>
+ * Ovomancy is a form of divination that involves cracking open eggs and observing the patterns formed by the
+ * yolks and whites as they spill. The shapes and formations of the egg contents—whether they resemble bells,
+ * serpents, boats, or other symbolic forms—reveal insights into future events. This ancient divination method,
+ * rooted in classical traditions like those taught by Orpheus, interprets these natural patterns as messages
+ * from fate.
+ * </p>
+ * <p>
+ * This class implements the ovomancy divination method, generating randomized prophecies based on egg pattern
+ * readings. The prophecies are created by combining randomly selected prefixes (which reference egg shapes,
+ * yolk formations, and symbolic omens) with divination text from the parent {@link O2Divination} class. Ovomancy
+ * has relatively high maximum accuracy (40 points), making it more reliable than crystal ball and most basic
+ * divination methods, approaching the power of tarot divination.
+ * </p>
  *
  * @author Azami7
- * @since 2.2.9
+ * @see <a href="https://harrypotter.fandom.com/wiki/Ovomancy">Harry Potter Wiki - Ovomancy</a>
  */
 public class OVOMANCY extends O2Divination {
     /**
-     * Constructor
+     * Constructor that initializes an ovomancy divination prophecy.
+     * <p>
+     * Creates a new ovomancy divination instance and populates it with egg pattern prophecy prefixes.
+     * Sets the divination type to OVOMANCY with a maximum accuracy of 40 points. The prophecy prefixes reference
+     * the shapes and patterns formed by cracking eggs (bell, serpent, boat shapes) and the symbolic interpretation
+     * of these formations, rooted in classical divination traditions taught by Orpheus.
+     * </p>
      *
-     * @param plugin     a callback to the plugin
-     * @param prophet    the player making the prophecy
-     * @param target     the target of the prophecy
-     * @param experience the experience level of the prophet
+     * @param plugin     a callback to the plugin for accessing configuration and other resources
+     * @param prophet    the player who is performing the divination (casting the ovomancy spell)
+     * @param target     the player who is the subject of the divination prophecy
+     * @param experience the experience level of the prophet, affecting prophecy accuracy and strength
      */
     public OVOMANCY(@NotNull Ollivanders2 plugin, @NotNull Player prophet, @NotNull Player target, int experience) {
         super(plugin, prophet, target, experience);
 
+        // Set divination type and accuracy threshold. Ovomancy has relatively high accuracy (40), more reliable
+        // than crystal ball (30) and basic methods, approaching tarot (35) in power
         divinationType = O2DivinationType.OVOMANCY;
         maxAccuracy = 40;
 
+        // Populate prophecy prefixes with ovomancy divination phrases. These prefixes are randomly selected
+        // when generating a prophecy and combined with divination text to create the final prophecy message.
+        // The prefixes reference egg pattern interpretation, where yolk and white formations take symbolic shapes:
+        // - Bell shape: represents clarity and communication
+        // - Snake shape: represents transformation and wisdom
+        // - Boat shape: represents journey and change
+        // These natural patterns are interpreted according to classical traditions, particularly those of Orpheus.
         prophecyPrefix.add("The shape of the egg whites means that");
         prophecyPrefix.add("Through the teachings of Orpheus, it is foretold that");
         prophecyPrefix.add("The omen of the egg reveals that");

--- a/Ollivanders/src/net/pottercraft/ollivanders2/divination/TASSEOMANCY.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/divination/TASSEOMANCY.java
@@ -5,27 +5,62 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Tasseomancy is the art of reading tea leaves to predict events in the future.
- * <p>Reference: http://harrypotter.wikia.com/wiki/Tessomancy</p>
+ * Tasseomancy divination spell implementation using tea-leaf reading and interpretation.
+ * <p>
+ * Tasseomancy (also known as tea-leaf reading or tessomancy) is the art of interpreting the patterns formed
+ * by tea leaves settled at the bottom of a cup. After drinking tea, a diviner examines the remaining leaves to
+ * identify symbolic shapes—falcons, skulls, rings, snakes, mountains, and other forms—each carrying specific
+ * meanings and omens. While popular and accessible, tasseomancy relies heavily on subjective interpretation,
+ * making it less precise than more systematic divination methods.
+ * </p>
+ * <p>
+ * This class implements the tasseomancy divination method, generating randomized prophecies based on tea-leaf
+ * symbol interpretations. The prophecies are created by combining randomly selected prefixes (which reference
+ * specific tea-leaf symbols and their traditional meanings) with divination text from the parent
+ * {@link O2Divination} class. Tasseomancy has the lowest maximum accuracy (20 points) of all divination
+ * methods in Ollivanders2, reflecting its reliance on subjective interpretation and pattern recognition rather
+ * than more objective techniques.
+ * </p>
  *
  * @author Azami7
- * @since 2.2.9
+ * @see <a href="http://harrypotter.wikia.com/wiki/Tessomancy">Harry Potter Wiki - Tessomancy</a>
  */
 public class TASSEOMANCY extends O2Divination {
     /**
-     * Constructor
+     * Constructor that initializes a tasseomancy divination prophecy.
+     * <p>
+     * Creates a new tasseomancy divination instance and populates it with tea leaf symbol prophecy prefixes.
+     * Sets the divination type to TASSEOMANCY with a maximum accuracy of 20 points (the lowest of all divination
+     * methods). The prophecy prefixes reference specific tea leaf symbols and their traditional interpretations,
+     * such as falcons (enemies), clubs (attacks), skulls (danger), and the Grim (death).
+     * </p>
      *
-     * @param plugin     a callback to the plugin
-     * @param prophet    the player making the prophecy
-     * @param target     the target of the prophecy
-     * @param experience the experience level of the prophet
+     * @param plugin     a callback to the plugin for accessing configuration and other resources
+     * @param prophet    the player who is performing the divination (casting the tasseomancy spell)
+     * @param target     the player who is the subject of the divination prophecy
+     * @param experience the experience level of the prophet, affecting prophecy accuracy and strength
      */
     public TASSEOMANCY(@NotNull Ollivanders2 plugin, @NotNull Player prophet, @NotNull Player target, int experience) {
         super(plugin, prophet, target, experience);
 
+        // Set divination type and accuracy threshold. Tasseomancy has the lowest accuracy (20) of all divination methods,
+        // reflecting its subjective nature and reliance on pattern interpretation
         divinationType = O2DivinationType.TASSEOMANCY;
         maxAccuracy = 20;
 
+        // Populate prophecy prefixes with tea leaf symbol interpretations. These prefixes are randomly selected
+        // when generating a prophecy and combined with divination text to create the final prophecy message.
+        // Each symbol represents a specific omen or message based on traditional tea leaf reading interpretations:
+        // - Falcon: represents a deadly enemy, danger from a powerful foe
+        // - Club: represents an attack or aggressive action
+        // - Skull: represents danger or peril
+        // - The Grim: represents death or a grave omen (specific to Harry Potter divination)
+        // - Ring: represents confusion or entanglement
+        // - Snake: represents enmity or betrayal
+        // - Acorn: represents good fortune and positive outcomes
+        // - Mountain: represents a hindrance or obstacle to overcome
+        // - Cross: represents trials and suffering to endure
+        // - Sun: represents great happiness and joy
         prophecyPrefix.add("The falcon ... a deadly enemy,");
         prophecyPrefix.add("The club ... an attack,");
         prophecyPrefix.add("The skull ... danger,");

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/AGGRESSION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/AGGRESSION.java
@@ -46,13 +46,6 @@ public class AGGRESSION extends O2Effect {
         legilimensText = "feels aggressive";
         affectedPlayerText = "You feel angry.";
 
-        divinationText.add("will suffer from an insatiable rage");
-        divinationText.add("will succomb to a primal fear");
-        divinationText.add("shall be afflicted in the mind");
-        divinationText.add("shall lose their mind to insanity");
-        divinationText.add("will be possessed by a demon spirit");
-        divinationText.add("shall be cursed");
-
         permanent = true;
         target = p.getServer().getPlayer(targetID);
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/BABBLING.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/BABBLING.java
@@ -80,11 +80,6 @@ public class BABBLING extends O2Effect {
 
         effectType = O2EffectType.BABBLING;
         informousText = "is unable to speak clearly";
-
-        divinationText.add("shall be afflicted in the mind");
-        divinationText.add("shall lose their mind to insanity");
-        divinationText.add("will begin to speak in tongues");
-        divinationText.add("will be possessed by a demon spirit");
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/BLINDNESS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/BLINDNESS.java
@@ -28,11 +28,6 @@ public class BLINDNESS extends PotionEffectSuper {
         informousText = legilimensText = "cannot see";
 
         strength = 1;
-
-        divinationText.add("shall be cursed");
-        divinationText.add("shall be afflicted in the mind");
-        divinationText.add("will become unable to see");
-        divinationText.add("will be struck by a terrible affliction");
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/BURNING.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/BURNING.java
@@ -51,10 +51,6 @@ public class BURNING extends O2Effect {
         effectType = O2EffectType.BURNING;
         informousText = legilimensText = "is afflicted with a terrible burning";
 
-        divinationText.add("shall be cursed");
-        divinationText.add("will be consumed by fire");
-        divinationText.add("will burn from within");
-
         damage = (double) duration / 100;
     }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/CONFUSION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/CONFUSION.java
@@ -28,11 +28,6 @@ public class CONFUSION extends PotionEffectSuper {
         informousText = legilimensText = "feels confused";
 
         strength = 1;
-
-        divinationText.add("shall be cursed");
-        divinationText.add("will be afflicted in the mind");
-        divinationText.add("will be struck by a terrible affliction");
-        divinationText.add("will suffer a mental breakdown");
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/HARM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/HARM.java
@@ -28,11 +28,6 @@ public class HARM extends PotionEffectSuper {
         informousText = legilimensText = "feels unwell";
 
         strength = 1;
-
-        divinationText.add("shall be struck by a terrible affliction");
-        divinationText.add("will come to harm");
-        divinationText.add("shall be cursed");
-        divinationText.add("will be develop a terrible illness");
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/HEAL.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/HEAL.java
@@ -28,10 +28,6 @@ public class HEAL extends PotionEffectSuper {
         effectType = O2EffectType.HEAL;
         potionEffectType = PotionEffectType.INSTANT_HEALTH;
         informousText = legilimensText = "feels healthy";
-
-        divinationText.add("will feel rejuvenated");
-        divinationText.add("will be blessed by fortune");
-        divinationText.add("shall be blessed");
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/HEALTH_BOOST.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/HEALTH_BOOST.java
@@ -28,11 +28,6 @@ public class HEALTH_BOOST extends PotionEffectSuper {
         effectType = O2EffectType.HEALTH_BOOST;
         potionEffectType = PotionEffectType.HEALTH_BOOST;
         informousText = legilimensText = "feels stronger";
-
-        divinationText.add("will become stonger");
-        divinationText.add("will be blessed by fortune");
-        divinationText.add("shall be blessed");
-        divinationText.add("will rise to become more powerful");
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/HUNGER.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/HUNGER.java
@@ -29,11 +29,6 @@ public class HUNGER extends PotionEffectSuper {
         potionEffectType = PotionEffectType.HUNGER;
         informousText = legilimensText = "is hungry";
         affectedPlayerText = "You feel hungry.";
-
-        divinationText.add("shall be struck by a terrible affliction");
-        divinationText.add("will starve");
-        divinationText.add("shall be cursed");
-        divinationText.add("will become insatiable");
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/IMMOBILIZE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/IMMOBILIZE.java
@@ -30,12 +30,6 @@ public class IMMOBILIZE extends O2Effect {
 
         effectType = O2EffectType.IMMOBILIZE;
         informousText = legilimensText = "is unable to move";
-
-        divinationText.add("will be possessed by a demon spirit");
-        divinationText.add("will succomb to a primal fear");
-        divinationText.add("shall become as if frozen");
-        divinationText.add("shall be struck by a terrible affliction");
-        divinationText.add("shall be cursed");
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/LAUGHING.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/LAUGHING.java
@@ -26,10 +26,6 @@ public class LAUGHING extends BABBLING {
         effectType = O2EffectType.LAUGHING;
         informousText = "cannot stop laughing";
 
-        divinationText.add("must beware the hand unseen, the agent of giddy doom");
-        divinationText.add("is marked not by lightning but by feather and folly");
-        divinationText.add("shall fall victim to uncontrollable mirth");
-
         dictionary = new ArrayList<>() {{
             add("hahahahahahahaha");
             add("hehehehe");

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/LUCK.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/LUCK.java
@@ -29,11 +29,6 @@ public class LUCK extends PotionEffectSuper {
         potionEffectType = PotionEffectType.LUCK;
         informousText = legilimensText = "feels lucky";
         affectedPlayerText = "You feel lucky.";
-
-        divinationText.add("will be blessed by fortune");
-        divinationText.add("will have unnatural luck");
-        divinationText.add("shall find success in everything they do");
-        divinationText.add("will become infallible");
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/MUTED_SPEECH.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/MUTED_SPEECH.java
@@ -23,11 +23,6 @@ public class MUTED_SPEECH extends O2Effect {
         effectType = O2EffectType.MUTED_SPEECH;
         informousText = legilimensText = "is unable to speak";
         affectedPlayerText = "You feel tongue-tied.";
-
-        divinationText.add("will be struck mute");
-        divinationText.add("shall lose their mind to insanity");
-        divinationText.add("shall be afflicted in the mind");
-        divinationText.add("will fall silent");
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/NIGHT_VISION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/NIGHT_VISION.java
@@ -27,11 +27,7 @@ public class NIGHT_VISION extends PotionEffectSuper {
 
         effectType = O2EffectType.NIGHT_VISION;
         potionEffectType = PotionEffectType.NIGHT_VISION;
-        informousText = legilimensText = "can breath in water";
-
-        divinationText.add("will swim with the mermaids");
-        divinationText.add("will feel fishy");
-        divinationText.add("will no longer fear water");
+        informousText = legilimensText = "can see in darkness";
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effect.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effect.java
@@ -85,11 +85,6 @@ public abstract class O2Effect {
     protected String affectedPlayerText;
 
     /**
-     * The output to be shown for prophecies that use this effect. This should be in future tense.
-     */
-    protected ArrayList<String> divinationText = new ArrayList<>();
-
-    /**
      * Common functions
      */
     Ollivanders2Common common;
@@ -187,22 +182,6 @@ public abstract class O2Effect {
      */
     public boolean isKilled() {
         return kill;
-    }
-
-    /**
-     * Get the text to be used for this effect in a prophecy
-     *
-     * @return a random divination text for this effect
-     */
-    @NotNull
-    public String getDivinationText() {
-        if (divinationText.isEmpty()) {
-            return "will be affected by an unseen affliction";
-        }
-        else {
-            int rand = (Math.abs(Ollivanders2Common.random.nextInt()) % divinationText.size());
-            return divinationText.get(rand);
-        }
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2EffectType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2EffectType.java
@@ -64,6 +64,10 @@ public enum O2EffectType {
      */
     FLAGRANTE_BURNING(FLAGRANTE_BURNING.class, MagicLevel.EXPERT),
     /**
+     * {@link FLYING}
+     */
+    FLYING(FLYING.class, MagicLevel.EXPERT),
+    /**
      * {@link FUMOS}
      */
     FUMOS(FUMOS.class, MagicLevel.BEGINNER),
@@ -71,10 +75,6 @@ public enum O2EffectType {
      * {@link FUMOS_DUO}
      */
     FUMOS_DUO(FUMOS.class, MagicLevel.OWL),
-    /**
-     * {@link FLYING}
-     */
-    FLYING(FLYING.class, MagicLevel.EXPERT),
     /**
      * {@link HARM}
      */
@@ -92,13 +92,13 @@ public enum O2EffectType {
      */
     HEALTH_BOOST(HEALTH_BOOST.class, MagicLevel.NEWT),
     /**
-     * {@link HUNGER}
-     */
-    HUNGER(HUNGER.class, MagicLevel.BEGINNER),
-    /**
      * {@link HIGHER_SKILL}
      */
     HIGHER_SKILL(HIGHER_SKILL.class, MagicLevel.NEWT),
+    /**
+     * {@link HUNGER}
+     */
+    HUNGER(HUNGER.class, MagicLevel.BEGINNER),
     /**
      * {@link IMMOBILIZE}
      */
@@ -164,6 +164,10 @@ public enum O2EffectType {
      */
     SLEEPING(SLEEPING.class, MagicLevel.BEGINNER),
     /**
+     * {@link SLOWNESS}
+     */
+    SLOWNESS(SLOWNESS.class, MagicLevel.BEGINNER),
+    /**
      * {@link SPEED}
      */
     SPEED(SPEED.class, MagicLevel.BEGINNER),
@@ -175,10 +179,6 @@ public enum O2EffectType {
      * {@link SPEED_SPEEDIEST}
      */
     SPEED_SPEEDIEST(SPEED_SPEEDIEST.class, MagicLevel.NEWT),
-    /**
-     * {@link SLOWNESS}
-     */
-    SLOWNESS(SLOWNESS.class, MagicLevel.BEGINNER),
     /**
      * {@link SUSPENSION}
      */

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/POISON.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/POISON.java
@@ -28,11 +28,6 @@ public class POISON extends PotionEffectSuper {
         effectType = O2EffectType.POISON;
         potionEffectType = PotionEffectType.POISON;
         informousText = legilimensText = "feels sick";
-
-        divinationText.add("will be struck by a terrible affliction");
-        divinationText.add("shall come to harm");
-        divinationText.add("will be cursed");
-        divinationText.add("will be possessed by a demon spirit");
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/SHRINKING.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/SHRINKING.java
@@ -26,11 +26,6 @@ public class SHRINKING extends PlayerChangeSizeSuper {
         scaleMultiplier = 0.5; // makes the player half size
 
         informousText = "is unnaturally small";
-        divinationText.add("will learn it is the little things that matter");
-        divinationText.add("shall find a dreadful deflation drawing near");
-        divinationText.add("shall be greatly reduced");
-        divinationText.add("will find their footsteps diminished");
-        divinationText.add("will become more grounded");
 
         startEffect();
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/SLEEPING.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/SLEEPING.java
@@ -32,11 +32,6 @@ public class SLEEPING extends O2Effect {
         effectType = O2EffectType.SLEEPING;
         informousText = legilimensText = "is affected by an unnatural sleep";
 
-        divinationText.add("will fall silent");
-        divinationText.add("shall fall in to a deep sleep");
-        divinationText.add("shall pass beyond this realm");
-        divinationText.add("will surrender to a sleeping death");
-
         permanent = false;
     }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/SLOWNESS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/SLOWNESS.java
@@ -29,11 +29,6 @@ public class SLOWNESS extends PotionEffectSuper {
         potionEffectType = PotionEffectType.SLOWNESS;
         informousText = legilimensText = "feels sluggish";
         affectedPlayerText = "You feel sluggish.";
-
-        divinationText.add("shall be cursed");
-        divinationText.add("will be afflicted in the mind");
-        divinationText.add("will be struck by a terrible affliction");
-        divinationText.add("will suffer a mental breakdown");
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/SPEED.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/SPEED.java
@@ -25,8 +25,6 @@ public class SPEED extends PotionEffectSuper {
         effectType = O2EffectType.SPEED;
         potionEffectType = PotionEffectType.SPEED;
         informousText = legilimensText = "is moving fast";
-
-        divinationText.add("will make haste");
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/SPEED_SPEEDIER.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/SPEED_SPEEDIER.java
@@ -27,9 +27,6 @@ public class SPEED_SPEEDIER extends PotionEffectSuper {
         effectType = O2EffectType.SPEED_SPEEDIER;
         potionEffectType = PotionEffectType.SPEED;
         informousText = legilimensText = "is moving very fast";
-
-        divinationText.add("will make haste");
-        divinationText.add("will wear the boots of Mercury");
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/SPEED_SPEEDIEST.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/SPEED_SPEEDIEST.java
@@ -27,9 +27,6 @@ public class SPEED_SPEEDIEST extends PotionEffectSuper {
         effectType = O2EffectType.SPEED_SPEEDIEST;
         potionEffectType = PotionEffectType.SPEED;
         informousText = legilimensText = "is moving extremely fast";
-
-        divinationText.add("will wear the boots of Mercury");
-        divinationText.add("will move with the power of the gods");
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/SWELLING.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/SWELLING.java
@@ -26,10 +26,6 @@ public class SWELLING extends PlayerChangeSizeSuper {
         scaleMultiplier = 2; // increase the player's by double
 
         informousText = "is unnaturally large";
-        divinationText.add("has a big future");
-        divinationText.add("shall find a dreadful inflation drawing near");
-        divinationText.add("will be full of themselves");
-        divinationText.add("has a bloated future");
 
         startEffect();
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/UNLUCK.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/UNLUCK.java
@@ -29,10 +29,6 @@ public class UNLUCK extends PotionEffectSuper {
         potionEffectType = PotionEffectType.UNLUCK;
         informousText = legilimensText = "feels unlucky";
         affectedPlayerText = "You feel unlucky.";
-
-        divinationText.add("will be cursed by misfortune");
-        divinationText.add("shall be cursed");
-        divinationText.add("will find nothing but misfortune");
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/WATER_BREATHING.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/WATER_BREATHING.java
@@ -28,10 +28,6 @@ public class WATER_BREATHING extends PotionEffectSuper {
         effectType = O2EffectType.WATER_BREATHING;
         potionEffectType = PotionEffectType.WATER_BREATHING;
         informousText = legilimensText = "can breath in water";
-
-        divinationText.add("will swim with the mermaids");
-        divinationText.add("will feel fishy");
-        divinationText.add("will no longer fear water");
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/WEAKNESS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/WEAKNESS.java
@@ -29,10 +29,6 @@ public class WEAKNESS extends PotionEffectSuper {
         potionEffectType = PotionEffectType.WEAKNESS;
         informousText = legilimensText = "feels weak";
         affectedPlayerText = "You feel weak.";
-
-        divinationText.add("shall be cursed");
-        divinationText.add("will be cursed by weakness");
-        divinationText.add("will be struck by a terrible affliction");
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/WEALTH.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/WEALTH.java
@@ -40,11 +40,6 @@ public class WEALTH extends O2Effect {
         informousText = legilimensText = "feels fortunate";
 
         target = p.getServer().getPlayer(targetID);
-
-        divinationText.add("will be blessed by fortune");
-        divinationText.add("will have unnatural luck");
-        divinationText.add("shall be granted a wish");
-        divinationText.add("will be gifted by a leprechaun");
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/listeners/OllivandersListener.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/listeners/OllivandersListener.java
@@ -526,7 +526,7 @@ public class OllivandersListener implements Listener {
         o2p.shiftMasterSpell(reverse);
         O2SpellType spell = o2p.getMasterSpell();
         if (spell != null) {
-            String spellName = Ollivanders2Common.firstLetterCapitalize(Ollivanders2Common.enumRecode(spell.toString()));
+            String spellName = spell.getSpellName();
             player.sendMessage(Ollivanders2.chatColor + "Wand master spell set to " + spellName);
         }
         else {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Player.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Player.java
@@ -680,7 +680,7 @@ public class O2Player {
             if (lineCount != 0)
                 content.append("\n");
 
-            String spell = Ollivanders2Common.firstLetterCapitalize(Ollivanders2Common.enumRecode(e.getKey().toString().toLowerCase()));
+            String spell = e.getKey().getSpellName();
             String count = e.getValue().toString();
             String line = spell + " " + count;
             content.append(spell).append(" ").append(count);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Players.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Players.java
@@ -780,7 +780,7 @@ public class O2Players {
 
                 O2SpellType masterSpell = o2p.getMasterSpell();
                 if (masterSpell != null)
-                    summary.append("\nMaster Spell: ").append(Ollivanders2Common.enumRecode(masterSpell.toString().toLowerCase()));
+                    summary.append("\nMaster Spell: ").append(masterSpell.getSpellName());
 
                 summary.append("\n");
             }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/IMPEDIMENTA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/IMPEDIMENTA.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Slows any living entity by an amount and time depending on the player's spell level.
  *
- * @autnor Azami7
+ * @author Azami7
  * @see <a href = "https://harrypotter.fandom.com/wiki/Impediment_Jinx">https://harrypotter.fandom.com/wiki/Impediment_Jinx</a>
  */
 public final class IMPEDIMENTA extends AddPotionEffect {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HORCRUX.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HORCRUX.java
@@ -75,9 +75,6 @@ public class HORCRUX extends O2StationarySpell {
      */
     private boolean itemLoaded = false;
 
-    //
-    // save data labels
-    //
     private final String materialLabel = "itemType";
     private final String worldLabel = "world";
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/LUMOS_FERVENS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/LUMOS_FERVENS.java
@@ -210,7 +210,9 @@ public class LUMOS_FERVENS extends O2StationarySpell {
         }
     }
 
-    // Label for serialization
+    /**
+     * Label for serialization
+     */
     private final String originalMaterialLabel = "original_material";
     
     /**


### PR DESCRIPTION
* updated javadoc in books, common, and divination packages
* added comments to unclear code
* removed @since tags, we are not consistently using them so they aren't useful

Refactors and bug fixes
* small refactor of getters in BookTexts.java
* abstracted page building code in O2Book.java
* added event cancelation check to onBookRead
* fixed bug in getBookTypeByTitle() where it was not stopping on first match
* Moved divination text from Effects classes to O2Divination's list of allowed effects (making it a map)
* Broke up monolithic O2Divination.divine() function
* reordered some O2EffectType enum values that were not in alphabetical order
* removed uses of enumRecode for spells and potions since those enums have a getName function
* rewrote deserializeProphecy() to use Java17-style switch statement
* simplified logic in Ollivanders2Common.getBlocksInRadius()
* simplified logic for enumRecode