### PR TITLE
Potions tests

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
@@ -1529,9 +1529,8 @@ public class Ollivanders2 extends JavaPlugin {
         if (!sender.hasPermission("Ollivanders2.admin"))
             return false;
 
-        O2PotionType potionType = null;
-
         // need to iterate rather than call potions.getPotionTypeByName so we can do startsWith
+        O2PotionType potionType = null;
         for (O2PotionType p : O2PotionType.values()) {
             if (p.getPotionName().toLowerCase().startsWith(potionName.toLowerCase())) {
                 potionType = p;
@@ -1541,19 +1540,13 @@ public class Ollivanders2 extends JavaPlugin {
 
         if (potionType == null) {
             sender.sendMessage(chatColor + "Unable to find potion " + potionName);
-
             return true;
         }
 
-        O2Potion potion = potions.getPotionFromType(potionType);
+        ItemStack brewedPotion = Ollivanders2API.getPotions().getPotionItemStackByType(potionType, 1);
 
-        if (potion == null)
-            return true;
-
-        ItemStack brewedPotion = potion.brew(sender, false);
         List<ItemStack> kit = new ArrayList<>();
         kit.add(brewedPotion);
-
         O2PlayerCommon.givePlayerKit(player, kit);
 
         return true;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/MAGICAL_DRAFTS_AND_POTIONS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/MAGICAL_DRAFTS_AND_POTIONS.java
@@ -1,6 +1,7 @@
 package net.pottercraft.ollivanders2.book;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.potion.FORGETFULNESS_POTION;
 import net.pottercraft.ollivanders2.potion.O2PotionType;
 import org.jetbrains.annotations.NotNull;
 
@@ -8,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
  * Magical Drafts and Potions - OWL potions book
  * <p>
  * {@link net.pottercraft.ollivanders2.potion.COMMON_ANTIDOTE_POTION}<br>
- * {@link net.pottercraft.ollivanders2.potion.FORGETFULLNESS_POTION}<br>
+ * {@link FORGETFULNESS_POTION}<br>
  * {@link net.pottercraft.ollivanders2.potion.HERBICIDE_POTION}<br>
  * {@link net.pottercraft.ollivanders2.potion.CURE_FOR_BOILS}<br>
  * {@link net.pottercraft.ollivanders2.potion.OCULUS_FELIS}<br>
@@ -38,7 +39,7 @@ public class MAGICAL_DRAFTS_AND_POTIONS extends O2Book {
 
         // 1st year
         potions.add(O2PotionType.COMMON_ANTIDOTE_POTION);
-        potions.add(O2PotionType.FORGETFULLNESS_POTION);
+        potions.add(O2PotionType.FORGETFULNESS_POTION);
         potions.add(O2PotionType.HERBICIDE_POTION);
         potions.add(O2PotionType.CURE_FOR_BOILS);
         potions.add(O2PotionType.OCULUS_FELIS);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/POTION_OPUSCULE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/POTION_OPUSCULE.java
@@ -1,6 +1,7 @@
 package net.pottercraft.ollivanders2.book;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.potion.FORGETFULNESS_POTION;
 import net.pottercraft.ollivanders2.potion.O2PotionType;
 import org.jetbrains.annotations.NotNull;
 
@@ -9,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
  * <p>
  * Contents:<br>
  * {@link net.pottercraft.ollivanders2.potion.BABBLING_BEVERAGE}<br>
- * {@link net.pottercraft.ollivanders2.potion.FORGETFULLNESS_POTION}
+ * {@link FORGETFULNESS_POTION}
  * </p>
  *
  * @author Azami7
@@ -27,7 +28,7 @@ public class POTION_OPUSCULE extends O2Book {
         bookType = O2BookType.POTION_OPUSCULE;
 
         potions.add(O2PotionType.BABBLING_BEVERAGE);
-        potions.add(O2PotionType.FORGETFULLNESS_POTION);
+        potions.add(O2PotionType.FORGETFULNESS_POTION);
         // todo hunger potion effect
         // todo mining fatigue potion effect - https://harrypotter.fandom.com/wiki/Fatiguing_Fusion
         // todo weaving potion effect

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/FIRE_RESISTANCE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/FIRE_RESISTANCE.java
@@ -1,0 +1,25 @@
+package net.pottercraft.ollivanders2.effect;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+public class FIRE_RESISTANCE extends PotionEffectSuper {
+    public FIRE_RESISTANCE(@NotNull Ollivanders2 plugin, int duration, boolean isPermanent, @NotNull UUID pid) {
+        super(plugin, duration, isPermanent, pid);
+
+        effectType = O2EffectType.FIRE_RESISTANCE;
+        checkDurationBounds();
+
+        potionEffectType = PotionEffectType.FIRE_RESISTANCE;
+        informousText = legilimensText = "does not fear fire";
+
+        strength = 1;
+    }
+
+    @Override
+    public void doRemove() {
+    }
+}

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2EffectType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2EffectType.java
@@ -78,6 +78,10 @@ public enum O2EffectType {
      */
     FAST_LEARNING(FAST_LEARNING.class, MagicLevel.NEWT, 30 * Ollivanders2Common.ticksPerSecond, Ollivanders2Common.ticksPerHour),
     /**
+     * {@link FIRE_RESISTANCE}
+     */
+    FIRE_RESISTANCE(FIRE_RESISTANCE.class, MagicLevel.OWL, 30 * Ollivanders2Common.ticksPerSecond, Ollivanders2Common.ticksPerHour),
+    /**
      * {@link FLAGRANTE_BURNING}
      */
     FLAGRANTE_BURNING(FLAGRANTE_BURNING.class, MagicLevel.EXPERT, 100, 100),
@@ -170,6 +174,14 @@ public enum O2EffectType {
      */
     PROTEGO(PROTEGO.class, MagicLevel.OWL, 30 * Ollivanders2Common.ticksPerSecond, 10 * Ollivanders2Common.ticksPerMinute),
     /**
+     * {@link REGENERATION}
+     */
+    REGENERATION(REGENERATION.class, MagicLevel.NEWT, 30 * Ollivanders2Common.ticksPerSecond, Ollivanders2Common.ticksPerHour),
+    /**
+     * {@link SATIATION}
+     */
+    SATIATION(SATIATION.class, MagicLevel.BEGINNER, 30 * Ollivanders2Common.ticksPerSecond, Ollivanders2Common.ticksPerHour),
+    /**
      * {@link SHRINKING}
      */
     SHRINKING(SHRINKING.class, MagicLevel.OWL, 30 * Ollivanders2Common.ticksPerSecond, Ollivanders2Common.ticksPerHour),
@@ -197,6 +209,10 @@ public enum O2EffectType {
      * {@link SPEED_SPEEDIEST}
      */
     SPEED_SPEEDIEST(SPEED_SPEEDIEST.class, MagicLevel.NEWT, 2 * Ollivanders2Common.ticksPerMinute, 5 * Ollivanders2Common.ticksPerMinute),
+    /**
+     * {@link STRENGTH}
+     */
+    STRENGTH(STRENGTH.class, MagicLevel.OWL, 30 * Ollivanders2Common.ticksPerSecond, Ollivanders2Common.ticksPerHour),
     /**
      * {@link SUSPENSION}
      */

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/REGENERATION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/REGENERATION.java
@@ -1,0 +1,55 @@
+package net.pottercraft.ollivanders2.effect;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+/**
+ * REGENERATION effect - restores a player's health over time.
+ *
+ * <p>When applied to a player, this effect continuously restores their health over the duration
+ * of the effect. It is a beneficial potion effect that provides passive healing. The effect uses
+ * the Minecraft REGENERATION potion effect with strength level 1.</p>
+ *
+ * <p>The effect displays "feels healthy" in informous and legilimency spell text, indicating
+ * the restorative nature of the effect.</p>
+ *
+ * @author Azami7
+ */
+public class REGENERATION extends PotionEffectSuper {
+    /**
+     * Constructor for REGENERATION effect.
+     *
+     * <p>Initializes the effect with the specified duration and permanent flag. Sets up the effect
+     * type as REGENERATION, applies strength level 1, and configures the informous and legilimency
+     * spell text to "feels healthy".</p>
+     *
+     * @param plugin the plugin instance
+     * @param duration the duration of the effect in server ticks
+     * @param isPermanent whether the effect should be permanent
+     * @param pid the UUID of the player affected by this effect
+     */
+    public REGENERATION(@NotNull Ollivanders2 plugin, int duration, boolean isPermanent, @NotNull UUID pid) {
+        super(plugin, duration, isPermanent, pid);
+
+        effectType = O2EffectType.REGENERATION;
+        checkDurationBounds();
+
+        potionEffectType = PotionEffectType.REGENERATION;
+        informousText = legilimensText = "feels healthy";
+
+        strength = 1;
+    }
+
+    /**
+     * Clean up the REGENERATION effect when removed.
+     *
+     * <p>Called when the effect is removed from a player. This effect has no special cleanup
+     * required beyond the standard effect removal handled by the parent class.</p>
+     */
+    @Override
+    public void doRemove() {
+    }
+}

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/SATIATION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/SATIATION.java
@@ -1,0 +1,55 @@
+package net.pottercraft.ollivanders2.effect;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+/**
+ * SATIATION effect - keeps a player's hunger bar full.
+ *
+ * <p>When applied to a player, this effect fills and maintains the player's hunger bar (food level),
+ * preventing starvation. It is a beneficial potion effect that provides continuous sustenance.
+ * The effect uses the Minecraft SATURATION potion effect with strength level 1.</p>
+ *
+ * <p>The effect displays "feels full" in informous and legilimency spell text, indicating the
+ * satiation provided by this effect.</p>
+ *
+ * @author Azami7
+ */
+public class SATIATION extends PotionEffectSuper {
+    /**
+     * Constructor for SATIATION effect.
+     *
+     * <p>Initializes the effect with the specified duration and permanent flag. Sets up the effect
+     * type as SATIATION, applies strength level 1, and configures the informous and legilimency
+     * spell text to "feels full".</p>
+     *
+     * @param plugin the plugin instance
+     * @param duration the duration of the effect in server ticks
+     * @param isPermanent whether the effect should be permanent
+     * @param pid the UUID of the player affected by this effect
+     */
+    public SATIATION(@NotNull Ollivanders2 plugin, int duration, boolean isPermanent, @NotNull UUID pid) {
+        super(plugin, duration, isPermanent, pid);
+
+        effectType = O2EffectType.SATIATION;
+        checkDurationBounds();
+
+        potionEffectType = PotionEffectType.SATURATION;
+        informousText = legilimensText = "feels full";
+
+        strength = 1;
+    }
+
+    /**
+     * Clean up the SATIATION effect when removed.
+     *
+     * <p>Called when the effect is removed from a player. This effect has no special cleanup
+     * required beyond the standard effect removal handled by the parent class.</p>
+     */
+    @Override
+    public void doRemove() {
+    }
+}

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/STRENGTH.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/STRENGTH.java
@@ -1,0 +1,56 @@
+package net.pottercraft.ollivanders2.effect;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+/**
+ * STRENGTH effect - increases a player's melee damage.
+ *
+ * <p>When applied to a player, this effect increases their melee damage output, making all
+ * physical attacks deal significantly more damage. It is a beneficial potion effect that provides
+ * a temporary combat boost. The effect uses the Minecraft STRENGTH potion effect with strength
+ * level 1.</p>
+ *
+ * <p>The effect displays "feels strong" in informous and legilimency spell text, indicating
+ * the increased strength provided by this effect.</p>
+ *
+ * @author Azami7
+ */
+public class STRENGTH extends PotionEffectSuper {
+    /**
+     * Constructor for STRENGTH effect.
+     *
+     * <p>Initializes the effect with the specified duration and permanent flag. Sets up the effect
+     * type as STRENGTH, applies strength level 1, and configures the informous and legilimency
+     * spell text to "feels strong".</p>
+     *
+     * @param plugin the plugin instance
+     * @param duration the duration of the effect in server ticks
+     * @param isPermanent whether the effect should be permanent
+     * @param pid the UUID of the player affected by this effect
+     */
+    public STRENGTH(@NotNull Ollivanders2 plugin, int duration, boolean isPermanent, @NotNull UUID pid) {
+        super(plugin, duration, isPermanent, pid);
+
+        effectType = O2EffectType.STRENGTH;
+        checkDurationBounds();
+
+        potionEffectType = PotionEffectType.STRENGTH;
+        informousText = legilimensText = "feels strong";
+
+        strength = 1;
+    }
+
+    /**
+     * Clean up the STRENGTH effect when removed.
+     *
+     * <p>Called when the effect is removed from a player. This effect has no special cleanup
+     * required beyond the standard effect removal handled by the parent class.</p>
+     */
+    @Override
+    public void doRemove() {
+    }
+}

--- a/Ollivanders/src/net/pottercraft/ollivanders2/item/O2ItemType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/item/O2ItemType.java
@@ -1,9 +1,9 @@
 package net.pottercraft.ollivanders2.item;
 
-import net.pottercraft.ollivanders2.common.O2Color;
 import net.pottercraft.ollivanders2.common.TimeCommon;
 import net.pottercraft.ollivanders2.Ollivanders2API;
 import net.pottercraft.ollivanders2.item.enchantment.ItemEnchantmentType;
+import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.entity.Item;
 import org.bukkit.inventory.ItemFlag;
@@ -24,367 +24,387 @@ public enum O2ItemType {
     /**
      * potion ingredient
      */
-    ACONITE(Material.ALLIUM, (short) 0, "Aconite", null, null),
+    ACONITE(Material.ALLIUM, null, "Aconite", null, null),
     /**
      * potion ingredient
      */
-    ARMADILLO_BILE(Material.POTION, (short) 9, "Armadillo Bile", null, null),
+    ARMADILLO_BILE(Material.POTION, Color.OLIVE, "Armadillo Bile", null, null),
     /**
      * potion ingredient
      */
-    ASPHODEL(Material.LILY_OF_THE_VALLEY, (short) 0, "Asphodel", null, null),
+    ASPHODEL(Material.LILY_OF_THE_VALLEY, null, "Asphodel", null, null),
     /**
      * unenchanted broomstick
      */
-    BASIC_BROOM(Material.STICK, (short) 0, "Broom", null, null),
+    BASIC_BROOM(Material.STICK, null, "Broom", null, null),
     /**
      * potion ingredient
      */
-    BAT_SPLEEN(Material.BEEF, (short) 0, "Bat Spleen", null, null),
+    BAT_SPLEEN(Material.BEEF, null, "Bat Spleen", null, null),
     /**
      * potion ingredient
      */
-    BEZOAR(Material.COAL, (short) 1, "Bezoar", null, null), // charcoal
+    BEZOAR(Material.COAL, null, "Bezoar", null, null), // charcoal
     /**
      * potion ingredient
      */
-    BILLYWIG_STING_SLIME(Material.SLIME_BALL, (short) 0, "Billywig Sting Slime", null, null),
+    BILLYWIG_STING_SLIME(Material.SLIME_BALL, null, "Billywig Sting Slime", null, null),
     /**
      * potion ingredient
      */
-    BLOOD(Material.POTION, (short) 7, "Blood", null, null),
+    BLOOD(Material.POTION, Color.fromRGB(120, 6, 6), "Blood", null, null),
     /**
      * potion ingredient
      */
-    BOOM_BERRY_JUICE(Material.POTION, (short) 11, "Boom Berry Juice", null, null),
+    BOOM_BERRY_JUICE(Material.POTION, Color.fromRGB(70, 65, 150), "Boom Berry Juice", null, null),
     /**
      * potion ingredient
      */
-    BOOMSLANG_SKIN(Material.ROTTEN_FLESH, (short) 0, "Boomslang Skin", null, null),
+    BOOMSLANG_SKIN(Material.ROTTEN_FLESH, null, "Boomslang Skin", null, null),
     /**
      * potion ingredient
      */
-    BONE(Material.BONE, (short) 0, "Bone", null, null),
+    BONE(Material.BONE, null, "Bone", null, null),
     /**
      * enchanted broomstick
      */
-    BROOMSTICK(Material.STICK, (short) 0, "Broomstick", null, ItemEnchantmentType.VOLATUS),
+    BROOMSTICK(Material.STICK, null, "Broomstick", null, ItemEnchantmentType.VOLATUS),
     /**
      * potion ingredient
      */
-    BURSTING_MUSHROOM(Material.CRIMSON_FUNGUS, (short) 0, "Bursting Mushroom", null, null),
+    BURSTING_MUSHROOM(Material.CRIMSON_FUNGUS, null, "Bursting Mushroom", null, null),
     /**
      * potion ingredient
      */
-    CHIZPURFLE_FANGS(Material.PUMPKIN_SEEDS, (short) 0, "Chizpurfle Fangs", null, null),
+    CHIZPURFLE_FANGS(Material.PUMPKIN_SEEDS, null, "Chizpurfle Fangs", null, null),
     /**
      * potion ingredient
      */
-    CHOPPED_MALLOW_LEAVES(Material.GREEN_DYE, (short) 0, "Chopped Mallow Leaves", null, null),
+    CHOPPED_MALLOW_LEAVES(Material.GREEN_DYE, null, "Chopped Mallow Leaves", null, null),
     /**
      * potion ingredient
      */
-    CRUSHED_CATS_EYE_OPAL(Material.ORANGE_DYE, (short) 0, "Crushed Cat's Eye Opal", null, null),
+    CRUSHED_CATS_EYE_OPAL(Material.ORANGE_DYE, null, "Crushed Cat's Eye Opal", null, null),
     /**
      * potion ingredient
      */
-    CRUSHED_FIRE_SEEDS(Material.REDSTONE, (short) 0, "Crushed Fire Seeds", null, null),
+    CRUSHED_FIRE_SEEDS(Material.REDSTONE, null, "Crushed Fire Seeds", null, null),
     /**
      * potion ingredient
      */
-    CRUSHED_GURDYROOT(Material.BROWN_DYE, (short) 0, "Crushed Gurdyroot", null, null),
+    CRUSHED_GURDYROOT(Material.BROWN_DYE, null, "Crushed Gurdyroot", null, null),
     /**
      * potion ingredient
      */
-    DEATHS_HEAD_MOTH_CHRYSALIS(Material.COAL, (short) 0, "Death's Head Moth Chrysalis", null, null),
+    DAISY_ROOTS(Material.SHORT_GRASS, null, "Daisy Roots", null, null),
     /**
      * potion ingredient
      */
-    DEW_DROP(Material.GHAST_TEAR, (short) 0, "Dew Drop", null, null),
+    DEATHS_HEAD_MOTH_CHRYSALIS(Material.COAL, null, "Death's Head Moth Chrysalis", null, null),
     /**
      * potion ingredient
      */
-    DITTANY(Material.BIRCH_SAPLING, (short) 0, "Dittany", null, null),
+    DEW_DROP(Material.GHAST_TEAR, null, "Dew Drop", null, null),
     /**
      * potion ingredient
      */
-    DOXY_VENOM(Material.POTION, (short) 11, "Doxy Venom", null, null),
+    DITTANY(Material.BIRCH_SAPLING, null, "Dittany", null, null),
     /**
      * potion ingredient
      */
-    DRAGON_BLOOD(Material.POTION, (short) 1, "Dragon Blood", null, null),
+    DOXY_VENOM(Material.POTION, Color.PURPLE, "Doxy Venom", null, null),
+    /**
+     * potion ingredient
+     */
+    DRAGON_BLOOD(Material.POTION, Color.BLACK, "Dragon Blood", null, null),
     /**
      * Wand core
      */
-    DRAGON_HEARTSTRING(Material.FERMENTED_SPIDER_EYE, (short) 0, "Dragon Heartstring", null, null),
+    DRAGON_HEARTSTRING(Material.FERMENTED_SPIDER_EYE, null, "Dragon Heartstring", null, null),
     /**
      * potion ingredient
      */
-    DRAGONFLY_THORAXES(Material.BEETROOT_SEEDS, (short) 0, "Dragonfly Thoraxes", null, null),
+    DRAGONFLY_THORAXES(Material.BEETROOT_SEEDS, null, "Dragonfly Thoraxes", null, null),
     /**
      * potion ingredient
      */
-    DRIED_NETTLES(Material.OAK_SAPLING, (short) 0, "Dried Nettles", null, null),
+    DRIED_NETTLES(Material.OAK_SAPLING, null, "Dried Nettles", null, null),
     /**
      * divination object
      */
-    EGG(Material.EGG, (short) 0, "Egg", null, null),
+    EGG(Material.EGG, null, "Egg", null, null),
     /**
      * the elder wand
      */
-    ELDER_WAND(Material.BLAZE_ROD, (short) 0, "Elder Wand", "Blaze and Ender Pearl", null),
+    ELDER_WAND(Material.BLAZE_ROD, null, "Elder Wand", "Blaze and Ender Pearl", null),
     /**
      * potion ingredient
      */
-    FAIRY_WING(Material.GOLD_NUGGET, (short) 0, "Fairy Wing", null, null),
+    FAIRY_WING(Material.GOLD_NUGGET, null, "Fairy Wing", null, null),
     /**
      * potion ingredient
      */
-    FLOBBERWORM_MUCUS(Material.SLIME_BALL, (short) 0, "Flobberworm Mucus", null, null),
+    FLOBBERWORM_MUCUS(Material.SLIME_BALL, null, "Flobberworm Mucus", null, null),
     /**
      * potion ingredient
      */
-    FLUXWEED(Material.VINE, (short) 0, "Fluxweed", null, null),
+    FLUXWEED(Material.VINE, null, "Fluxweed", null, null),
     /**
      * floo powder
      */
-    FLOO_POWDER(Material.REDSTONE, (short) 0, "Floo Powder", "Glittery, silver powder", null),
+    FLOO_POWDER(Material.REDSTONE, null, "Floo Powder", "Glittery, silver powder", null),
     /**
      * potion ingredient
      */
-    FULGURITE(Material.GLOWSTONE_DUST, (short) 0, "Fulgurite", null, null),
+    FULGURITE(Material.GLOWSTONE_DUST, null, "Fulgurite", null, null),
     /**
      * potion ingredient
      */
-    GALANTHUS_NIVALIS(Material.AZURE_BLUET, (short) 0, "Galanthus Nivalis", null, null),
+    GALANTHUS_NIVALIS(Material.AZURE_BLUET, null, "Galanthus Nivalis", null, null),
     /**
      * wizard money
      */
-    GALLEON(Material.GOLD_INGOT, (short) 0, "Galleon", "Galleon", null),
+    GALLEON(Material.GOLD_INGOT, null, "Galleon", "Galleon", null),
     /**
      * potion ingredient
      */
-    GINGER_ROOT(Material.BEETROOT, (short) 0, "Ginger Root", null, null),
+    GINGER_ROOT(Material.BEETROOT, null, "Ginger Root", null, null),
     /**
      * potion ingredient
      */
-    GROUND_DRAGON_HORN(Material.GLOWSTONE_DUST, (short) 0, "Ground Dragon Horn", null, null),
+    GROUND_DRAGON_HORN(Material.GLOWSTONE_DUST, null, "Ground Dragon Horn", null, null),
     /**
      * potion ingredient
      */
-    GROUND_PORCUPINE_QUILLS(Material.GRAY_DYE, (short) 0, "Ground Porcupine Quills", null, null),
+    GROUND_PORCUPINE_QUILLS(Material.GRAY_DYE, null, "Ground Porcupine Quills", null, null),
     /**
      * potion ingredient
      */
-    GROUND_SCARAB_BEETLE(Material.GUNPOWDER, (short) 0, "Ground Scarab Beetle", null, null),
+    GROUND_SCARAB_BEETLE(Material.GUNPOWDER, null, "Ground Scarab Beetle", null, null),
     /**
      * potion ingredient
      */
-    GROUND_SNAKE_FANGS(Material.LIGHT_GRAY_DYE, (short) 0, "Ground Snake Fangs", null, null),
+    GROUND_SNAKE_FANGS(Material.LIGHT_GRAY_DYE, null, "Ground Snake Fangs", null, null),
     /**
      * legacy wand core
      */
-    GUNPOWDER(Material.GUNPOWDER, (short) 0, "Gunpowder", null, null),
+    GUNPOWDER(Material.GUNPOWDER, null, "Gunpowder", null, null),
     /**
      * potion ingredient
      */
-    HONEYWATER(Material.POTION, (short) 0, "Honeywater", null, null),
+    HONEYWATER(Material.POTION, Color.fromRGB(247, 110, 2), "Honeywater", null, null),
     /**
      * potion ingredient
      */
-    HORKLUMP_JUICE(Material.DRAGON_BREATH, (short) 0, "Horklump Juice", null, null),
+    HORKLUMP_JUICE(Material.DRAGON_BREATH, null, "Horklump Juice", null, null),
     /**
      * potion ingredient
      */
-    HORNED_SLUG_MUCUS(Material.SLIME_BALL, (short) 0, "Horned Slug Mucus", null, null),
+    HORNED_SLUG_MUCUS(Material.SLIME_BALL, null, "Horned Slug Mucus", null, null),
     /**
      * potion ingredient
      */
-    HORN_OF_BICORN(Material.GOAT_HORN, (short) 0, "Horn of Bicorn", null, null),
+    HORN_OF_BICORN(Material.GOAT_HORN, null, "Horn of Bicorn", null, null),
     /**
      * potion ingredient
      */
-    INFUSION_OF_WORMWOOD(Material.POTION, (short) 5, "Infusion of Wormwood", null, null),
+    INFUSION_OF_COWBANE(Material.POTION, Color.fromRGB(255, 248, 220), "Infusion of Cowbane", null, null),
+    /**
+     * potion ingredient
+     */
+    INFUSION_OF_WORMWOOD(Material.POTION, Color.fromRGB(138, 154, 91), "Infusion of Wormwood", null, null),
     /**
      * an invisibility cloak
      */
-    INVISIBILITY_CLOAK(Material.CHAINMAIL_CHESTPLATE, (short) 0, "Cloak of Invisibility", "Silvery Transparent Cloak", null),
+    INVISIBILITY_CLOAK(Material.CHAINMAIL_CHESTPLATE, null, "Cloak of Invisibility", "Silvery Transparent Cloak", null),
     /**
      * potion ingredient
      */
-    JOBBERKNOLL_FEATHER(Material.FEATHER, (short) 0, "Jobberknoll Feather", null, null),
+    JOBBERKNOLL_FEATHER(Material.FEATHER, null, "Jobberknoll Feather", null, null),
     /**
      * wand core
      */
-    KELPIE_HAIR(Material.PALE_HANGING_MOSS, (short) 0, "Kelpie Hair", null, null),
+    KELPIE_HAIR(Material.PALE_HANGING_MOSS, null, "Kelpie Hair", null, null),
     /**
      * potion ingredient
      */
-    KNOTGRASS(Material.TALL_GRASS, (short) 0, "Knotgrass", null, null),
+    KNOTGRASS(Material.TALL_GRASS, null, "Knotgrass", null, null),
     /**
      * wizard money
      */
-    KNUT(Material.NETHERITE_INGOT, (short) 0, "Knut", "Knut", null),
+    KNUT(Material.NETHERITE_INGOT, null, "Knut", "Knut", null),
     /**
      * potion ingredient
      */
-    LACEWING_FLIES(Material.PUMPKIN_SEEDS, (short) 0, "Lacewing Flies", null, null),
+    LACEWING_FLIES(Material.PUMPKIN_SEEDS, null, "Lacewing Flies", null, null),
     /**
      * potion ingredient
      */
-    LAVENDER_SPRIG(Material.LILAC, (short) 0, "Lavender Sprig", null, null),
+    LAVENDER_SPRIG(Material.LILAC, null, "Lavender Sprig", null, null),
     /**
      * potion ingredient
      */
-    LEECH_JUICE(Material.POTION, (short) 7, "Leech Juice", null, null),
+    LEECH_JUICE(Material.POTION, Color.MAROON, "Leech Juice", null, null),
     /**
      * potion ingredient
      */
-    LEECHES(Material.INK_SAC, (short) 0, "Leeches", null, null),
+    LEECHES(Material.INK_SAC, null, "Leeches", null, null),
     /**
      * potion ingredient
      */
-    LETHE_RIVER_WATER(Material.POTION, (short) 0, "Lethe River Water", null, null), //bottle of water
+    LETHE_RIVER_WATER(Material.POTION, Color.AQUA, "Lethe River Water", null, null), //bottle of water
     /**
      * potion ingredient
      */
-    LIONFISH_SPINES(Material.PUMPKIN_SEEDS, (short) 0, "Lionfish Spines", null, null),
+    LIONFISH_SPINES(Material.PUMPKIN_SEEDS, null, "Lionfish Spines", null, null),
     /**
      * potion ingredient
      */
-    MANDRAKE_LEAF(Material.LILY_PAD, (short) 0, "Mandrake Leaf", null, null),
+    MANDRAKE_LEAF(Material.LILY_PAD, null, "Mandrake Leaf", null, null),
     /**
      * potion ingredient
      */
-    MERCURY(Material.POTION, (short) 13, "Mercury", null, null), // silver liquid
+    MERCURY(Material.POTION, Color.SILVER, "Mercury", null, null), // silver liquid
     /**
      * potion ingredient
      */
-    MINT_SPRIG(Material.KELP, (short) 0, "Mint Sprig", null, null),
+    MINT_SPRIG(Material.KELP, null, "Mint Sprig", null, null),
     /**
      * potion ingredient
      */
-    MISTLETOE_BERRIES(Material.NETHER_WART, (short) 0, "Mistletoe Berries", null, null),
+    MISTLETOE_BERRIES(Material.NETHER_WART, null, "Mistletoe Berries", null, null),
     /**
      * potion ingredient
      */
-    MOONCALF_MILK(Material.POTION, (short) -1, "Moonclaf Milk", null, null),
+    MOONCALF_MILK(Material.POTION, Color.WHITE, "Moonclaf Milk", null, null),
     /**
      * potion ingredient
      */
-    MOONDEW_DROP(Material.GHAST_TEAR, (short) 0, "Moondew Drop", null, null),
+    MOONDEW_DROP(Material.GHAST_TEAR, null, "Moondew Drop", null, null),
     /**
      * cauldron for making potions
      */
-    PEWTER_CAULDRON(Material.CAULDRON, (short) 0, "Pewter Cauldron", null, null),
+    PEWTER_CAULDRON(Material.CAULDRON, null, "Pewter Cauldron", null, null),
     /**
      * wand core
      */
-    PHOENIX_FEATHER(Material.FEATHER, (short) 0, "Phoenix Feather", null, null),
+    PHOENIX_FEATHER(Material.FEATHER, null, "Phoenix Feather", null, null),
     /**
      * divination object
      */
-    PLAYING_CARDS(Material.PAPER, (short) 0, "Playing Cards", null, null),
+    PLAYING_CARDS(Material.PAPER, null, "Playing Cards", null, null),
     /**
      * potion ingredient
      */
-    POISONOUS_POTATO(Material.POISONOUS_POTATO, (short) 0, "Poisonous Potato", null, null),
+    POISONOUS_POTATO(Material.POISONOUS_POTATO, null, "Poisonous Potato", null, null),
     /**
      * potion ingredient
      */
-    POWDERED_ASHPODEL_ROOT(Material.ORANGE_DYE, (short) 0, "Powdered Root of Asphodel", null, null),
+    POWDERED_ASHPODEL_ROOT(Material.ORANGE_DYE, null, "Powdered Root of Asphodel", null, null),
     /**
      * potion ingredient
      */
-    POWDERED_GRIFFIN_CLAW(Material.LIGHT_GRAY_DYE, (short) 0, "Powdered Griffin Claw", null, null),
+    POWDERED_GRIFFIN_CLAW(Material.LIGHT_GRAY_DYE, null, "Powdered Griffin Claw", null, null),
     /**
      * potion ingredient
      */
-    POWDERED_SAGE(Material.LIME_DYE, (short) 0, "Powdered Sage", null, null),
+    POWDERED_SAGE(Material.LIME_DYE, null, "Powdered Sage", null, null),
     /**
      * potion ingredient
      */
-    PUFFERFISH_EYE(Material.SPIDER_EYE, (short) 0, "Pufferfish Eye", null, null),
+    PUFFERFISH_EYE(Material.SPIDER_EYE, null, "Pufferfish Eye", null, null),
     /**
      * potion ingredient
      */
-    ROTTEN_FLESH(Material.ROTTEN_FLESH, (short) 0, "Rotten Flesh", null, null),
+    RAT_SPLEEN(Material.INK_SAC, null, "Rat Spleen", null, null),
     /**
      * potion ingredient
      */
-    RUNESPOOR_EGG(Material.EGG, (short) 0, "Runespoor Egg", null, null),
+    ROTTEN_FLESH(Material.ROTTEN_FLESH, null, "Rotten Flesh", null, null),
     /**
      * potion ingredient
      */
-    SALAMANDER_BLOOD(Material.POTION, (short) 7, "Salamander Blood", null, null),
+    RUNESPOOR_EGG(Material.EGG, null, "Runespoor Egg", null, null),
     /**
      * potion ingredient
      */
-    SALAMANDER_FIRE(Material.BLAZE_POWDER, (short) 0, "Salamander Fire", null, null),
+    SALAMANDER_BLOOD(Material.POTION, Color.fromRGB(136, 8, 8), "Salamander Blood", null, null),
+    /**
+     * potion ingredient
+     */
+    SALAMANDER_FIRE(Material.BLAZE_POWDER, null, "Salamander Fire", null, null),
+    /**
+     * potion ingredient
+     */
+    SHRIVELIG(Material.CHORUS_FRUIT, null, "Shrivelfig", null, null),
     /**
      * wizard money
      */
-    SICKLE(Material.IRON_INGOT, (short) 0, "Sickle", "Sickle", null),
+    SICKLE(Material.IRON_INGOT, null, "Sickle", "Sickle", null),
     /**
      * potion ingredient
      */
-    SLOTH_BRAIN(Material.FERMENTED_SPIDER_EYE, (short) 0, "Sloth Brain", null, null),
+    SLICED_CATERPILLARS(Material.WHEAT_SEEDS, null, "Sliced Caterpillar", null, null),
     /**
      * potion ingredient
      */
-    SLOTH_BRAIN_MUCUS(Material.POTION, (short) 4, "Sloth Brain Mucus", null, null),
+    SLOTH_BRAIN(Material.FERMENTED_SPIDER_EYE, null, "Sloth Brain", null, null),
     /**
      * potion ingredient
      */
-    SOPOPHORUS_BEAN_JUICE(Material.POTION, (short) 13, "Sopophorus Bean Juice", null, null),
+    SLOTH_BRAIN_MUCUS(Material.POTION, Color.GRAY, "Sloth Brain Mucus", null, null),
     /**
      * potion ingredient
      */
-    SPIDER_EYE(Material.SPIDER_EYE, (short) 0, "Spider Eye", null, null),
+    SOPOPHORUS_BEAN_JUICE(Material.POTION, Color.SILVER, "Sopophorus Bean Juice", null, null),
     /**
      * potion ingredient
      */
-    STANDARD_POTION_INGREDIENT(Material.SUGAR, (short) 0, "Standard Potion Ingredient", null, null),
+    SPIDER_EYE(Material.SPIDER_EYE, null, "Spider Eye", null, null),
+    /**
+     * potion ingredient
+     */
+    STANDARD_POTION_INGREDIENT(Material.SUGAR, null, "Standard Potion Ingredient", null, null),
     /**
      * divination object
      */
-    TAROT_CARDS(Material.PAPER, (short) 0, "Tarot Cards", null, null),
+    TAROT_CARDS(Material.PAPER, null, "Tarot Cards", null, null),
     /**
      * divination object
      */
-    TEA_LEAVES(Material.GREEN_DYE, (short) 0, "Tea Leaves", null, null),
+    TEA_LEAVES(Material.GREEN_DYE, null, "Tea Leaves", null, null),
     /**
      * potion ingredient, wand core
      */
-    UNICORN_HAIR(Material.STRING, (short) 0, "Unicorn Hair", null, null),
+    UNICORN_HAIR(Material.STRING, null, "Unicorn Hair", null, null),
     /**
      * potion ingredient
      */
-    UNICORN_HORN(Material.BREEZE_ROD, (short) 0, "Unicorn Horn", null, null),
+    UNICORN_HORN(Material.BREEZE_ROD, null, "Unicorn Horn", null, null),
     /**
      * potion ingredient
      */
-    VALERIAN_SPRIGS(Material.VINE, (short) 0, "Valerian Sprigs", null, null),
+    VALERIAN_SPRIGS(Material.VINE, null, "Valerian Sprigs", null, null),
     /**
      * potion ingredient
      */
-    VALERIAN_ROOT(Material.GOLDEN_CARROT, (short) 0, "Valerian Root", null, null),
+    VALERIAN_ROOT(Material.GOLDEN_CARROT, null, "Valerian Root", null, null),
     /**
      * wand core
      */
-    VEELA_HAIR(Material.STRING, (short) 0, "Veela Hair", null, null),
+    VEELA_HAIR(Material.STRING, null, "Veela Hair", null, null),
     /**
      * unenchanted wand
      */
-    WAND(Material.STICK, (short) 0, "Wand", null, null),
+    WAND(Material.STICK, null, "Wand", null, null),
     /**
      * potion ingredient
      */
-    WARTCAP_POWDER(Material.BROWN_DYE, (short) 0, "Wartcap Powder", null, null),
+    WARTCAP_POWDER(Material.BROWN_DYE, null, "Wartcap Powder", null, null),
     /**
      * potion ingredient
      */
-    WOLFSBANE(Material.ALLIUM, (short) 0, "Wolfsbane", null, null);
+    WOLFSBANE(Material.ALLIUM, null, "Wolfsbane", null, null);
 
     /**
      * Item material
@@ -404,7 +424,7 @@ public enum O2ItemType {
     /**
      * Item variant
      */
-    final private short variant;
+    final private Color color;
 
     /**
      * Item enchantment
@@ -415,15 +435,15 @@ public enum O2ItemType {
      * Constructor
      *
      * @param material    the material type
-     * @param variant     the variant information, this is 0 for most items but for things like potions it can control color
+     * @param color     the variant information, this is 0 for most items but for things like potions it can control color
      * @param name        the name of the item
      * @param lore        the lore for this item
      * @param enchantment the optional enchantment for this item
      */
-    O2ItemType(@NotNull Material material, short variant, @NotNull String name, @Nullable String lore, @Nullable ItemEnchantmentType enchantment) {
+    O2ItemType(@NotNull Material material, @Nullable Color color, @NotNull String name, @Nullable String lore, @Nullable ItemEnchantmentType enchantment) {
         this.material = material;
         this.name = name;
-        this.variant = variant;
+        this.color = color;
         this.lore = lore;
         this.itemEnchantment = enchantment;
     }
@@ -565,7 +585,10 @@ public enum O2ItemType {
         // if potion, set potion meta
         if (material == Material.POTION) {
             meta.addItemFlags(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
-            ((PotionMeta) meta).setColor(O2Color.getBukkitColorByNumber(variant).getBukkitColor());
+            if (color != null)
+                ((PotionMeta) meta).setColor(color);
+            else
+                ((PotionMeta) meta).setColor(Color.WHITE);
         }
 
         // add custom NBT tag

--- a/Ollivanders/src/net/pottercraft/ollivanders2/listeners/OllivandersListener.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/listeners/OllivandersListener.java
@@ -679,6 +679,7 @@ public class OllivandersListener implements Listener {
      */
     @EventHandler(priority = EventPriority.NORMAL)
     public void onPlayerDrink(@NotNull PlayerItemConsumeEvent event) {
+        //todo move this to O2Potions
         ItemStack item = event.getItem();
         if (item.getType() == Material.POTION) {
             Player player = event.getPlayer();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Players.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/player/O2Players.java
@@ -522,7 +522,7 @@ public class O2Players {
      * @param value the serialized count of potion experience
      */
     private void deserializePotion(@NotNull O2Player o2p, @NotNull String label, @NotNull String value) {
-        O2PotionType potionType = O2PotionType.potionTypeFromString(label);
+        O2PotionType potionType = O2PotionType.getPotionTypeFromString(label);
         if (potionType == null)
             return;
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/ANIMAGUS_POTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/ANIMAGUS_POTION.java
@@ -11,11 +11,28 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Consumed after successfully casting the Animagus incantation, this will turn a player in to an Animagus.
+ * Animagus Potion - transforms a player into their animal form.
+ *
+ * <p>This potion is consumed after successfully casting the Animagus incantation spell.
+ * When consumed, it transforms the player into their animal form and grants them the
+ * ANIMAGUS_EFFECT for permanent transformation ability without needing the potion.</p>
+ *
+ * <p>Requirements for successful transformation:</p>
+ * <ul>
+ * <li>LibsDisguises plugin must be enabled</li>
+ * <li>Player must have recently cast the Animagus incantation (ANIMAGUS_INCANTATION effect)</li>
+ * <li>If useStrictAnimagusConditions is enabled, the transformation only works during thunderstorms</li>
+ * </ul>
+ *
+ * <p>If the player is already an Animagus, drinking the potion has no effect but provides
+ * feedback that the potion tastes familiar.</p>
  *
  * @author Azami7
  */
 public final class ANIMAGUS_POTION extends O2Potion {
+    String potionFailureMessage = "Nothing seems to happen.";
+    String alreadyAnimagusMessage = "You taste something vaguely familiar.";
+
     /**
      * Constructor
      *
@@ -31,17 +48,28 @@ public final class ANIMAGUS_POTION extends O2Potion {
         ingredients.put(O2ItemType.DEATHS_HEAD_MOTH_CHRYSALIS, 1);
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 3);
 
+        potionColor = Color.fromRGB(102, 0, 0);
+        potionSuccessMessage = "You feel transformed.";
+
         text = "An Animagus is a wizard who elects to turn into an animal. This potion, if brewed and consumed correctly, " +
-                "will disguisePlayer the drinker in to their animal form. Thereafter, the Animagus can disguisePlayer without the " +
+                "will transform the drinker into their animal form. Thereafter, the Animagus can transform without the " +
                 "potion, however it will take considerable practice to change forms consistently at will.";
         flavorText.add("\"You know that I can disguise myself most effectively.\" -Peter Pettigrew");
         flavorText.add("\"Normally, I have a very sweet disposition as a dog; in fact, more than once, James suggested I make the change permanent. The tail I could live with...but the fleas, they're murder.\" -Sirius Black");
-
-        potionColor = Color.fromRGB(102, 0, 0);
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Animagus Potion and apply transformation effects.
+     *
+     * <p>The behavior depends on several conditions:</p>
+     * <ul>
+     * <li>If LibsDisguises is disabled, the potion has no effect</li>
+     * <li>If the player is already an Animagus, the potion has no transformation effect</li>
+     * <li>If useStrictAnimagusConditions is enabled and it's not thundering, the potion has no effect</li>
+     * <li>If the player has the ANIMAGUS_INCANTATION effect, they are transformed into their animal form
+     *     and granted the permanent ANIMAGUS_EFFECT</li>
+     * <li>If none of the above conditions are met, nothing happens</li>
+     * </ul>
      *
      * @param player the player who drank the potion
      */
@@ -50,7 +78,7 @@ public final class ANIMAGUS_POTION extends O2Potion {
         O2Player o2p = p.getO2Player(player);
 
         if (o2p == null || !Ollivanders2.libsDisguisesEnabled) {
-            player.sendMessage(Ollivanders2.chatColor + "Nothing seems to happen.");
+            player.sendMessage(Ollivanders2.chatColor + potionFailureMessage);
             return;
         }
 
@@ -58,13 +86,13 @@ public final class ANIMAGUS_POTION extends O2Potion {
             if (Ollivanders2API.getPlayers().playerEffects.hasEffect(o2p.getID(), O2EffectType.ANIMAGUS_INCANTATION))
                 Ollivanders2API.getPlayers().playerEffects.removeEffect(o2p.getID(), O2EffectType.ANIMAGUS_INCANTATION);
 
-            player.sendMessage(Ollivanders2.chatColor + "You taste something vaguely familiar.");
+            player.sendMessage(Ollivanders2.chatColor + alreadyAnimagusMessage);
             return;
         }
 
         if (!player.getWorld().isThundering() && Ollivanders2.useStrictAnimagusConditions) {
             // potion only works in a thunderstorm
-            player.sendMessage(Ollivanders2.chatColor + "Nothing seems to happen.");
+            player.sendMessage(Ollivanders2.chatColor + potionFailureMessage);
             return;
         }
 
@@ -75,7 +103,19 @@ public final class ANIMAGUS_POTION extends O2Potion {
             ANIMAGUS_EFFECT animagusEffect = new ANIMAGUS_EFFECT(p, 5, true, player.getUniqueId());
             Ollivanders2API.getPlayers().playerEffects.addEffect(animagusEffect);
 
-            player.sendMessage(Ollivanders2.chatColor + "You feel transformed.");
+            player.sendMessage(Ollivanders2.chatColor + potionSuccessMessage);
         }
+        else {
+            // Player hasn't cast the Animagus incantation yet
+            player.sendMessage(Ollivanders2.chatColor + potionFailureMessage);
+        }
+    }
+
+    public String getPotionFailureMessage() {
+        return potionFailureMessage;
+    }
+
+    public String getAlreadyAnimagusMessage() {
+        return alreadyAnimagusMessage;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/BABBLING_BEVERAGE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/BABBLING_BEVERAGE.java
@@ -9,16 +9,23 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Babbling Beverage is a potion that caused the drinker to babble nonsense.
+ * Babbling Beverage - a potion that causes the drinker to babble nonsense.
+ *
+ * <p>When consumed, this potion applies the BABBLING effect to the player, forcing them
+ * to speak randomly selected nonsense phrases for the duration of the effect. This is
+ * primarily a cosmetic/humorous effect with no mechanical disadvantage.</p>
  *
  * @author Azami7
  * @since 2.2.7
  */
 public class BABBLING_BEVERAGE extends O2Potion {
     /**
-     * Constructor
+     * Constructor for Babbling Beverage potion.
      *
-     * @param plugin a callback to the plugin
+     * <p>Initializes the potion with its ingredients, description text, flavor text, and
+     * potion color. Sets up the recipe and all effects that will be applied when consumed.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
     public BABBLING_BEVERAGE(@NotNull Ollivanders2 plugin) {
         super(plugin);
@@ -31,13 +38,18 @@ public class BABBLING_BEVERAGE extends O2Potion {
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 2);
 
         potionColor = Color.FUCHSIA;
+        potionSuccessMessage = "Your tongue feels fuzzy.";
 
         text = "Babbling Beverage is a potion that causes the drinker to babble nonsense.";
         flavorText.add("\"Potter, when I want nonsense shouted at me I shall give you a Babbling Beverage.\" -Severus Snape");
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Babbling Beverage and apply the babbling effect.
+     *
+     * <p>Applies the BABBLING effect to the player for the duration defined by the potion's
+     * duration field. The effect causes the player to speak random nonsense phrases at regular
+     * intervals while the effect is active.</p>
      *
      * @param player the player who drank the potion
      */
@@ -46,6 +58,6 @@ public class BABBLING_BEVERAGE extends O2Potion {
         BABBLING effect = new BABBLING(p, duration, false, player.getUniqueId());
         Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
 
-        player.sendMessage(Ollivanders2.chatColor + "You tongue feels fuzzy.");
+        player.sendMessage(Ollivanders2.chatColor + potionSuccessMessage);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/BARUFFIOS_BRAIN_ELIXIR.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/BARUFFIOS_BRAIN_ELIXIR.java
@@ -9,16 +9,25 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * All spells cast are twice as powerful.
+ * Baruffio's Brain Elixir - a potion that doubles the power of all spells cast.
+ *
+ * <p>When consumed, this potion applies the HIGHER_SKILL effect to the player, which
+ * doubles the modifier used when calculating spell power and success rates. This makes
+ * all spells cast during the effect duration significantly more effective and more likely
+ * to succeed.</p>
  *
  * @author Azami7
  * @author cakenggt
  */
 public final class BARUFFIOS_BRAIN_ELIXIR extends O2Potion {
     /**
-     * Constructor
+     * Constructor for Baruffio's Brain Elixir potion.
      *
-     * @param plugin a callback to the plugin
+     * <p>Initializes the potion with its ingredients (Runespoor Egg, Ginger Root, and Standard
+     * Potion Ingredients), description text, flavor text, and potion color. Sets up the recipe
+     * and the HIGHER_SKILL effect that will be applied when the potion is consumed.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
     public BARUFFIOS_BRAIN_ELIXIR(@NotNull Ollivanders2 plugin) {
         super(plugin);
@@ -29,14 +38,19 @@ public final class BARUFFIOS_BRAIN_ELIXIR extends O2Potion {
         ingredients.put(O2ItemType.GINGER_ROOT, 2);
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 2);
 
-        text = "Baruffio's Brain Elixir is a potion that increases the taker's brain power. All spells cast are twice as powerful.";
-
-        flavorText.add("\"I've performed tests on the potion sample you collected. My best guess is that it was supposed to be Baruffio's Brain Elixir. Now, that's a potion which doesn't work at the best of times, but whoever brewed this was seriously incompetent! Forget boosting one's brain; this concoction would most likely melt it!\" —Gethsemane Prickle");
         potionColor = Color.fromRGB(255, 251, 222);
+        potionSuccessMessage = "You feel clarity of thought.";
+
+        text = "Baruffio's Brain Elixir is a potion that increases the taker's brain power. All spells cast are twice as powerful.";
+        flavorText.add("\"I've performed tests on the potion sample you collected. My best guess is that it was supposed to be Baruffio's Brain Elixir. Now, that's a potion which doesn't work at the best of times, but whoever brewed this was seriously incompetent! Forget boosting one's brain; this concoction would most likely melt it!\" —Gethsemane Prickle");
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink Baruffio's Brain Elixir and gain temporary spell power enhancement.
+     *
+     * <p>Applies the HIGHER_SKILL effect to the player for the duration defined by the potion's
+     * duration field. The HIGHER_SKILL effect doubles the player's skill modifier, which increases
+     * the power of all spells cast and doubles their success rate during the effect's duration.</p>
      *
      * @param player the player who drank the potion
      */
@@ -45,6 +59,6 @@ public final class BARUFFIOS_BRAIN_ELIXIR extends O2Potion {
         HIGHER_SKILL effect = new HIGHER_SKILL(p, duration, false, player.getUniqueId());
         Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
 
-        player.sendMessage(Ollivanders2.chatColor + "You feel clarity of thought.");
+        player.sendMessage(Ollivanders2.chatColor + potionSuccessMessage);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/COMMON_ANTIDOTE_POTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/COMMON_ANTIDOTE_POTION.java
@@ -1,7 +1,6 @@
 package net.pottercraft.ollivanders2.potion;
 
 import net.pottercraft.ollivanders2.item.O2ItemType;
-import net.pottercraft.ollivanders2.player.O2Player;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import org.bukkit.Color;
 import org.bukkit.entity.Player;
@@ -9,9 +8,14 @@ import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * The Antidote for Common Poisons is a potion which counteracts ordinary poisons, such as creature bites and stings.
+ * Common Antidote Potion - counteracts ordinary poisons and toxins.
  *
- * <p>Reference: http://harrypotter.wikia.com/wiki/Antidote_to_Common_Poisons</p>
+ * <p>This potion removes the poison effect from a player when consumed. It is effective
+ * against ordinary poisons such as creature bites and stings (Minecraft POISON effects).
+ * If no poison is currently affecting the player, the potion has no mechanical effect
+ * but provides flavor text feedback.</p>
+ *
+ * @see <a href="http://harrypotter.wikia.com/wiki/Antidote_to_Common_Poisons">Harry Potter Wiki - Antidote to Common Poisons</a>
  *
  * @author Azami7
  * @since 2.2.7
@@ -20,9 +24,20 @@ public final class COMMON_ANTIDOTE_POTION extends O2Potion {
     // todo lower strength so that we can also have the stronger antidote to uncommon poisons for longer duration poison
 
     /**
-     * Constructor
+     * Message sent to player when potion has no effect.
      *
-     * @param plugin a callback to the plugin
+     * <p>This message is displayed when the player drinks the potion but is not currently poisoned.
+     * It provides flavor text feedback while having no mechanical effect.</p>
+     */
+    String potionDoNothingMessage = "You smell a faint odor that reminds you of winter, then it is gone.";
+    /**
+     * Constructor for Common Antidote Potion.
+     *
+     * <p>Initializes the potion with its ingredients (Mistletoe Berries, Bezoar, Unicorn Hair,
+     * and Standard Potion Ingredients), description text, and potion color. Sets up the recipe
+     * for brewing this antidote potion.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
     public COMMON_ANTIDOTE_POTION(@NotNull Ollivanders2 plugin) {
         super(plugin);
@@ -34,13 +49,18 @@ public final class COMMON_ANTIDOTE_POTION extends O2Potion {
         ingredients.put(O2ItemType.UNICORN_HAIR, 1);
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 2);
 
-        text = "Counteracts ordinary poisons, such as creature bites and stings.";
-
         potionColor = Color.TEAL;
+        potionSuccessMessage = "A cool feeling flows through your body as the poison is removed.";
+
+        text = "Counteracts ordinary poisons, such as creature bites and stings.";
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Common Antidote Potion and remove poison effects.
+     *
+     * <p>If the player is currently poisoned (has the POISON effect), it is immediately removed
+     * and the player receives confirmation feedback. If the player is not poisoned, the potion
+     * still consumes but provides only flavor text feedback with no mechanical effect.</p>
      *
      * @param player the player who drank the potion
      */
@@ -49,10 +69,22 @@ public final class COMMON_ANTIDOTE_POTION extends O2Potion {
         if (player.hasPotionEffect(PotionEffectType.POISON)) {
             player.removePotionEffect(PotionEffectType.POISON);
 
-            player.sendMessage(Ollivanders2.chatColor + "A cool feeling flows through your body as the poison is removed.");
+            player.sendMessage(Ollivanders2.chatColor + potionSuccessMessage);
         }
         else {
-            player.sendMessage(Ollivanders2.chatColor + "You smell a faint odor that reminds you of winter, then it is gone.");
+            player.sendMessage(Ollivanders2.chatColor + potionDoNothingMessage);
         }
+    }
+
+    /**
+     * Get the message displayed when the potion has no effect.
+     *
+     * <p>Returns the flavor text message shown to the player when they drink this potion
+     * while not currently poisoned.</p>
+     *
+     * @return the no-effect message string
+     */
+    public String getPotionDoNothingMessage() {
+        return potionDoNothingMessage;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/CURE_FOR_BOILS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/CURE_FOR_BOILS.java
@@ -1,24 +1,36 @@
 package net.pottercraft.ollivanders2.potion;
 
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.effect.HEAL;
 import net.pottercraft.ollivanders2.item.O2ItemType;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import org.bukkit.Color;
 import org.bukkit.entity.Player;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * The Cure for Boils (also known as simply Boil Cure) is a potion which cures boils, even those produced by the Pimple Jinx.
+ * Cure for Boils - a potion that provides instant healing to cure boils and other conditions.
+ *
+ * <p>This potion cures boils and similar skin conditions, even those produced by the Pimple Jinx curse.
+ * When consumed, it applies an Instant Health I effect (restores health) and is marked with a blue color
+ * to indicate its healing properties. Despite being called a "cure" for boils, it functions as a general
+ * healing potion.</p>
+ *
+ * <p>Reference: Harry Potter Potions, used to cure boils caused by spells and other sources.</p>
  *
  * @author Azami7
  * @since 2.2.8
  */
 public class CURE_FOR_BOILS extends O2Potion {
     /**
-     * Constructor.
+     * Constructor for Cure for Boils potion.
      *
-     * @param plugin the callback to the MC plugin
+     * <p>Initializes the potion with its ingredients (Ground Snake Fangs, Dried Nettles, Ground
+     * Porcupine Quills, Horned Slug Mucus, and Standard Potion Ingredients), description text,
+     * flavor text, and the Instant Health I potion effect. Sets up the recipe and the healing
+     * effect that will be applied when the potion is consumed.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
     public CURE_FOR_BOILS(@NotNull Ollivanders2 plugin) {
         super(plugin);
@@ -31,21 +43,28 @@ public class CURE_FOR_BOILS extends O2Potion {
         ingredients.put(O2ItemType.HORNED_SLUG_MUCUS, 4);
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 4);
 
+        potionColor = Color.fromRGB(65, 105, 225); // blue
+        potionSuccessMessage = "You feel healthier.";
+
         text = "The Cure for Boils (also known as simply Boil Cure) is a potion which cures boils, even those produced by the Pimple Jinx.";
         flavorText.add("\"Being an effective remedie against pustules, hives, boils and many other scrofulous conditions. This is a robust potion of powerful character. Care should be taken when brewing. Prepared incorrectly this potion has been known to cause boils, rather than cure them...\" -Zygmunt Budge");
-
-        // Healing I
-        minecraftPotionEffect = new PotionEffect(PotionEffectType.INSTANT_HEALTH, duration, 0);
-        potionColor = Color.fromRGB(65, 105, 225); // blue
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Cure for Boils potion and receive healing.
+     *
+     * <p>Applies the HEAL effect to the player for the default potion duration. This effect restores
+     * the player's health, curing boils and other skin conditions. The healing is instant and allows
+     * the player to recover from damage or ailments caused by curses like the Pimple Jinx. The potion
+     * displays a success message to confirm the healing has taken effect.</p>
      *
      * @param player the player who drank the potion
      */
     @Override
     public void drink(@NotNull Player player) {
-        player.sendMessage(Ollivanders2.chatColor + "You feel healthier.");
+        HEAL effect = new HEAL(p, duration, false, player.getUniqueId());
+        Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
+
+        player.sendMessage(Ollivanders2.chatColor + potionSuccessMessage);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/DRAUGHT_OF_LIVING_DEATH.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/DRAUGHT_OF_LIVING_DEATH.java
@@ -10,16 +10,31 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * The Draught of Living Death is an extremely powerful sleeping draught, sending the drinker into a deathlike slumber.
+ * Draught of Living Death - an extremely powerful sleeping potion that induces permanent magical sleep.
+ *
+ * <p>This is one of the most dangerous potions in existence. When consumed, it puts the drinker
+ * into a permanent magical sleep (SLEEPING effect). The sleep can only be broken by a player
+ * who has the AWAKE effect active, which will render the potion's effects harmless.</p>
+ *
+ * <p>This potion requires a complex recipe with rare ingredients including Powdered Asphodel Root
+ * and Infusion of Wormwood, making it a high-level potion to brew. It should be handled with
+ * extreme caution.</p>
  *
  * @author Azami7
  * @since 2.2.8
  */
 public class DRAUGHT_OF_LIVING_DEATH extends O2Potion {
+    String awakeEffectMessage = "You yawn, close your eyes for a moment, then feel fine.";
+
     /**
-     * Constructor
+     * Constructor for Draught of Living Death potion.
      *
-     * @param plugin a callback to the plugin
+     * <p>Initializes the potion with its complex recipe of rare ingredients (Powdered Asphodel Root,
+     * Infusion of Wormwood, Valerian Root, Sopophorus Bean Juice, Sloth Brain, and Standard Potion
+     * Ingredients), description text, flavor text, and potion color. Sets up the permanent SLEEPING
+     * effect that will be applied when the potion is consumed.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
     public DRAUGHT_OF_LIVING_DEATH(@NotNull Ollivanders2 plugin) {
         super(plugin);
@@ -33,30 +48,53 @@ public class DRAUGHT_OF_LIVING_DEATH extends O2Potion {
         ingredients.put(O2ItemType.SLOTH_BRAIN, 1);
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 2);
 
+        potionColor = Color.fromRGB(200, 162, 200);
+        potionSuccessMessage = "You fall into a powerful magic sleep.";
+
         text = "Puts the drinker in a permanent magical sleep.";
         flavorText.add("The Draught of Living Death brings upon its drinker a very powerful sleep that can last indefinitely. This is an extremely dangerous potion. Execute with maximum caution.");
         flavorText.add("By mixing an infusion of wormwood with powdered root of asphodel you can make a sleeping potion so powerful it is known as the Draught of Living Death.");
         flavorText.add("\"Mr. Potter. Our new celebrity. Tell me, what would I get if I added powdered root of asphodel to an infusion of wormwood?\" -Severus Snape");
-
-        potionColor = Color.fromRGB(200, 162, 200);
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Draught of Living Death and enter permanent magical sleep.
+     *
+     * <p>The effect of this potion depends on whether the player has the AWAKE effect active:</p>
+     * <ul>
+     * <li>If the player has the AWAKE effect, the potion is harmless and the player returns to
+     *     normal consciousness with a brief yawn</li>
+     * <li>If the player does not have the AWAKE effect, they are put into permanent magical sleep
+     *     (SLEEPING effect). The only way to break this sleep is for another player with the AWAKE
+     *     effect to use a counter-potion or spell</li>
+     * </ul>
      *
      * @param player the player who drank the potion
      */
     @Override
     public void drink(@NotNull Player player) {
         if (Ollivanders2API.getPlayers().playerEffects.hasEffect(player.getUniqueId(), O2EffectType.AWAKE)) {
-            player.sendMessage(Ollivanders2.chatColor + "You yawn, close your eyes for a moment, then feel fine.");
+            player.sendMessage(Ollivanders2.chatColor + awakeEffectMessage);
         }
         else {
             SLEEPING effect = new SLEEPING(p, 5, true, player.getUniqueId());
             effect.setPermanent(true);
             Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
 
-            player.sendMessage(Ollivanders2.chatColor + "You fall in to a powerful magic sleep.");
+            player.sendMessage(Ollivanders2.chatColor + "You fall into a powerful magic sleep.");
         }
+    }
+
+    /**
+     * Get the message shown to players with the AWAKE effect when drinking this potion.
+     *
+     * <p>Returns the special message that is displayed to players who have the AWAKE effect active
+     * when they drink the Draught of Living Death. This message indicates that the potion's sleep
+     * effect is harmless to them due to their immunity to sleep.</p>
+     *
+     * @return the message displayed to awakened players ("You yawn, close your eyes for a moment, then feel fine.")
+     */
+    public String getAwakeEffectMessage() {
+        return awakeEffectMessage;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/FORGETFULNESS_POTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/FORGETFULNESS_POTION.java
@@ -14,23 +14,35 @@ import java.util.Set;
 import java.util.ArrayList;
 
 /**
- * The Forgetfulness Potion is a potion which causes a degree of memory loss in the drinker.
+ * Forgetfulness Potion - causes memory loss affecting spell or potion skills.
  *
- * <p>Reference: http://harrypotter.wikia.com/wiki/Forgetfulness_Potion</p>
+ * <p>This potion causes the drinker to lose experience with either a randomly selected spell
+ * or a randomly selected potion. The amount of skill lost is random (1-20 levels), and there
+ * is a 50% chance it will affect spell skills vs. potion skills. The skill loss can significantly
+ * impact the player's ability to cast spells or brew potions effectively.</p>
+ *
+ * <p>If the player has no known spells and the spell skill loss is selected (or vice versa
+ * for potions), no effect is applied.</p>
+ *
+ * @see <a href="http://harrypotter.wikia.com/wiki/Forgetfulness_Potion">Harry Potter Wiki - Forgetfulness Potion</a>
  *
  * @author Azami7
  * @since 2.2.7
  */
-public final class FORGETFULLNESS_POTION extends O2Potion {
+public final class FORGETFULNESS_POTION extends O2Potion {
     /**
-     * Constructor
+     * Constructor for Forgetfulness Potion.
      *
-     * @param plugin a callback to the plugin
+     * <p>Initializes the potion with its ingredients (Mistletoe Berries, Valerian Sprigs, Lethe
+     * River Water, and Standard Potion Ingredients), description text, flavor text, and potion
+     * color. Sets up the recipe for brewing this potion that causes skill loss in the drinker.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
-    public FORGETFULLNESS_POTION(@NotNull Ollivanders2 plugin) {
+    public FORGETFULNESS_POTION(@NotNull Ollivanders2 plugin) {
         super(plugin);
 
-        potionType = O2PotionType.FORGETFULLNESS_POTION;
+        potionType = O2PotionType.FORGETFULNESS_POTION;
 
         ingredients.put(O2ItemType.MISTLETOE_BERRIES, 4);
         ingredients.put(O2ItemType.VALERIAN_SPRIGS, 2);
@@ -44,7 +56,17 @@ public final class FORGETFULLNESS_POTION extends O2Potion {
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Forgetfulness Potion and suffer skill loss.
+     *
+     * <p>Causes the player to lose experience with a randomly selected skill:</p>
+     * <ul>
+     * <li>50% chance: A random known spell's skill count is reduced by 1-20 levels</li>
+     * <li>50% chance: A random known potion's skill count is reduced by 1-20 levels</li>
+     * </ul>
+     *
+     * <p>The amount of skill lost is determined randomly (1-20 levels). If the selected skill
+     * type (spell or potion) has no known skills, no effect is applied. The skill loss can
+     * significantly impact the player's ability to successfully cast spells or brew potions.</p>
      *
      * @param player the player who drank the potion
      */
@@ -60,11 +82,11 @@ public final class FORGETFULLNESS_POTION extends O2Potion {
 
         int memLoss = Math.abs(Ollivanders2Common.random.nextInt() % 20) + 1;
 
-        String lostSpell = "";
+        String lostSkill = "";
 
         if (coinToss > 0) {
             Map<O2SpellType, Integer> knownSpells = o2p.getKnownSpells();
-            if (knownSpells.size() > 0) {
+            if (!knownSpells.isEmpty()) {
                 Set<O2SpellType> keySet = knownSpells.keySet();
                 ArrayList<O2SpellType> listOfSpells = new ArrayList<>(keySet);
                 int index = Math.abs(Ollivanders2Common.random.nextInt() % listOfSpells.size());
@@ -75,12 +97,12 @@ public final class FORGETFULLNESS_POTION extends O2Potion {
                 // decrease their skill level
                 int curLevel = o2p.getSpellCount(spell);
                 o2p.setSpellCount(spell, curLevel - memLoss);
-                lostSpell = listOfSpells.get(index).toString();
+                lostSkill = spell.toString();
             }
         }
         else {
             Map<O2PotionType, Integer> knownPotions = o2p.getKnownPotions();
-            if (knownPotions.size() > 0) {
+            if (!knownPotions.isEmpty()) {
                 Set<O2PotionType> keySet = knownPotions.keySet();
                 ArrayList<O2PotionType> listOfPotions = new ArrayList<>(keySet);
                 int index = Math.abs(Ollivanders2Common.random.nextInt() % listOfPotions.size());
@@ -91,11 +113,11 @@ public final class FORGETFULLNESS_POTION extends O2Potion {
                 // decrease their skill level
                 int curLevel = o2p.getPotionCount(potion);
                 o2p.setPotionCount(potion, curLevel - memLoss);
-                lostSpell = listOfPotions.get(index).toString();
+                lostSkill = potion.toString();
             }
         }
 
-        common.printDebugMessage("Forgetfullness Potion: " + player.getDisplayName() + " lost " + memLoss + " experience  with " + lostSpell, null, null, false);
+        common.printDebugMessage("Forgetfulness Potion: " + player.getName() + " lost " + memLoss + " experience with " + lostSkill, null, null, false);
 
         player.sendMessage(Ollivanders2.chatColor + "It feels like you've forgotten something.");
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/HERBICIDE_POTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/HERBICIDE_POTION.java
@@ -17,24 +17,45 @@ import org.bukkit.entity.LivingEntity;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Herbicide Potion (or simply Herbicide) is a potion that kills or damages creepers and kills all plants in the splash
- * area of the potion. It will also harm other entities, including players, though not as much as Creepers.
+ * Herbicide Potion - a splash potion that damages plant-based entities and kills plants.
+ *
+ * <p>This is a splash potion designed to be thrown rather than consumed directly. When thrown,
+ * it deals full damage to plant-based entities (Creepers and Creakings) and creates a plant-killing
+ * effect in a 4-block radius splash area. The potion will also harm other living creatures
+ * (including players), but at reduced intensity (10% of normal damage).</p>
+ *
+ * <p>Effects when splashed:</p>
+ * <ul>
+ * <li>Full Instant Damage II effect for Creepers and Creakings</li>
+ * <li>Reduced intensity (10%) for all other entities including players</li>
+ * <li>HERBICIDE stationary spell effect that kills plants in the 4-block radius</li>
+ * </ul>
  *
  * @author Azami7
  * @see <a href = "https://harrypotter.fandom.com/wiki/Herbicide_Potion">https://harrypotter.fandom.com/wiki/Herbicide_Potion</a>
  * @since 2.2.7
  */
 public final class HERBICIDE_POTION extends O2SplashPotion {
-    // the minimum intensity for this effect when thrown on non-plant entities
+    /**
+     * The minimum damage intensity for non-plant entities.
+     * Reduces damage to 10% for players and non-plant mobs when splashed.
+     */
     private final double minimumEffect = 0.1;
 
-    // the radius of a splash potion's effect in minecraft
+    /**
+     * The radius of the splash potion's effect in blocks.
+     * The HERBICIDE stationary spell affects all plant blocks within this radius.
+     */
     private final int radius = 4;
 
     /**
-     * Constructor
+     * Constructor for Herbicide Potion.
      *
-     * @param plugin a callback to the plugin
+     * <p>Initializes the splash potion with its ingredients (Lionfish Spines, Flobberworm Mucus,
+     * Horklump Juice, and Standard Potion Ingredients), description text, potion color, and the
+     * Instant Damage effect. Sets up the 30-second duration for the plant-killing effect.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
     public HERBICIDE_POTION(@NotNull Ollivanders2 plugin) {
         super(plugin);
@@ -46,7 +67,7 @@ public final class HERBICIDE_POTION extends O2SplashPotion {
         ingredients.put(O2ItemType.HORKLUMP_JUICE, 2);
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 2);
 
-        text = "The Herbicide Potion is damages plant-based entities and kills plants in a radius. It is minorly harmful to other living creatures.";
+        text = "The Herbicide Potion damages plant-based entities and kills plants in a radius. It is minorly harmful to other living creatures.";
 
         // potion color
         potionColor = Color.fromRGB(51, 102, 0);
@@ -58,18 +79,31 @@ public final class HERBICIDE_POTION extends O2SplashPotion {
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Herbicide Potion - no effect when consumed directly.
+     *
+     * <p>This is a splash potion intended to be thrown, not consumed. Drinking it has no special
+     * effect. The potion's primary functionality is triggered through the splash event when thrown,
+     * which damages plant-based entities and kills plants in the affected area.</p>
      *
      * @param player the player who drank the potion
      */
     @Override
     public void drink(@NotNull Player player) {
+        // No effect when drunk - this is a splash potion
     }
 
     /**
-     * Reduce intensity of this potion if the affected entity is not a Creeper.
+     * Handle the splash potion event and apply herbicide effects.
      *
-     * @param event the splash potion thrown event
+     * <p>When the potion splashes:</p>
+     * <ul>
+     * <li>Creepers and Creakings receive full damage intensity from the potion effect</li>
+     * <li>All other entities (players, mobs, etc.) receive reduced damage (10% intensity)</li>
+     * <li>A HERBICIDE stationary spell is created at the splash location to kill plant blocks
+     *     in the affected radius (4 blocks) for the duration of the potion effect (30 seconds)</li>
+     * </ul>
+     *
+     * @param event the splash potion thrown event containing affected entities and location
      */
     @Override
     public void doOnPotionSplashEvent(@NotNull PotionSplashEvent event) {
@@ -78,13 +112,13 @@ public final class HERBICIDE_POTION extends O2SplashPotion {
 
         // minimize the effect on non-creeper or creaking
         for (LivingEntity e : event.getAffectedEntities()) {
-            if (e.getType() != EntityType.CREEPER || e.getType() != EntityType.CREAKING) {
+            if (e.getType() != EntityType.CREEPER && e.getType() != EntityType.CREAKING) {
                 event.setIntensity(e, minimumEffect);
             }
         }
 
         // affect all the plant blocks in the radius of the potion effect
-        HERBICIDE herbicide = new net.pottercraft.ollivanders2.stationaryspell.HERBICIDE(p, thrower.getUniqueId(), eventLocation, radius, duration);
+        HERBICIDE herbicide = new HERBICIDE(p, thrower.getUniqueId(), eventLocation, radius, duration);
         Ollivanders2API.getStationarySpells().addStationarySpell(herbicide);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/HUNGER_POTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/HUNGER_POTION.java
@@ -1,28 +1,43 @@
 package net.pottercraft.ollivanders2.potion;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
 import net.pottercraft.ollivanders2.common.Ollivanders2Common;
+import net.pottercraft.ollivanders2.effect.HUNGER;
 import net.pottercraft.ollivanders2.item.O2ItemType;
 import org.bukkit.Color;
 import org.bukkit.entity.Player;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Hunger potion adds the Hunger potion effect.
+ * Hunger Potion - causes severe hunger and exhaustion in the drinker.
+ *
+ * <p>When consumed, this potion applies the HUNGER effect (Hunger I) to the player for 3 minutes.
+ * The Hunger effect causes rapid food depletion, forcing the player to consume food frequently
+ * to avoid starvation. This is primarily a negative/debilitating potion effect useful for
+ * challenging gameplay scenarios.</p>
+ *
+ * <p>The hunger effect reduces the player's food saturation and can lead to damage if not
+ * counteracted with food consumption during the effect duration.</p>
  *
  * @author Azami7
  * @since 2.21
  */
 public class HUNGER_POTION extends O2Potion {
+    /**
+     * Constructor for Hunger Potion.
+     *
+     * <p>Initializes the potion with its ingredients (Rotten Flesh, Ground Scarab Beetle, Crushed
+     * Fire Seeds, Crushed Gurdyroot, Infusion of Wormwood, and Standard Potion Ingredients),
+     * description text, potion color, and the Hunger I potion effect. Sets up the 3-minute
+     * duration for the hunger effect.</p>
+     *
+     * @param plugin a callback to the plugin instance
+     */
     public HUNGER_POTION(@NotNull Ollivanders2 plugin) {
         super(plugin);
 
-        // potion config
         potionType = O2PotionType.HUNGER_POTION;
-        potionColor = Color.fromRGB(88, 118, 83); // dark green
-        duration = Ollivanders2Common.ticksPerMinute * 3;
 
         // ingredients
         ingredients.put(O2ItemType.ROTTEN_FLESH, 2);
@@ -32,20 +47,28 @@ public class HUNGER_POTION extends O2Potion {
         ingredients.put(O2ItemType.INFUSION_OF_WORMWOOD, 1);
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 3);
 
+        potionColor = Color.fromRGB(88, 118, 83); // dark green
+        duration = Ollivanders2Common.ticksPerMinute * 3;
+        potionSuccessMessage = "You feel ravenously hungry.";
+
         // spellbook text
         text = "The hunger potion will cause the drinker to feel ravenous.";
-
-        // Hunger I
-        minecraftPotionEffect = new PotionEffect(PotionEffectType.HUNGER, duration, 0);
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Hunger Potion and suffer from the hunger effect.
+     *
+     * <p>Applies the HUNGER effect (Hunger I) to the player for 3 minutes. This effect causes
+     * rapid food depletion and food bar exhaustion. The player will need to consume food
+     * frequently to avoid taking damage from starvation.</p>
      *
      * @param player the player who drank the potion
      */
     @Override
     public void drink(@NotNull Player player) {
-        player.sendMessage(Ollivanders2.chatColor + "You feel ravenously hungry.");
+        HUNGER effect = new HUNGER(p, duration, false, player.getUniqueId());
+        Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
+
+        player.sendMessage(Ollivanders2.chatColor + potionSuccessMessage);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/ICE_POTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/ICE_POTION.java
@@ -1,26 +1,39 @@
 package net.pottercraft.ollivanders2.potion;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
 import net.pottercraft.ollivanders2.common.Ollivanders2Common;
+import net.pottercraft.ollivanders2.effect.FIRE_RESISTANCE;
 import net.pottercraft.ollivanders2.item.O2ItemType;
 import org.bukkit.Color;
 import org.bukkit.entity.Player;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * The Fire-Protection Potion - aka the Ice Potion - is used to move through flames unscathed.
+ * Ice Potion (Fire-Protection Potion) - grants immunity to fire damage.
+ *
+ * <p>When consumed, this potion applies the FIRE_RESISTANCE II effect to the player for 5 minutes,
+ * allowing them to move through flames and lava unscathed without taking any fire damage. This is
+ * particularly useful for navigating dangerous fire-filled environments or combat scenarios where
+ * fire damage is a threat.</p>
+ *
+ * <p>The 5-minute duration is longer than the standard Minecraft Fire Resistance II potion,
+ * providing extended protection for the drinker.</p>
  *
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/Fire_Protection_Potion">https://harrypotter.fandom.com/wiki/Fire_Protection_Potion</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Fire_Protection_Potion">Fire Protection Potion</a>
  * @since 2.21
  */
 public class ICE_POTION extends O2Potion {
     /**
-     * Constructor.
+     * Constructor for Ice Potion (Fire-Protection Potion).
      *
-     * @param plugin the callback to the MC plugin
+     * <p>Initializes the potion with its ingredients (Salamander Blood, Wartcap Powder, Bursting
+     * Mushroom, and Standard Potion Ingredients), description text, flavor text, and potion color.
+     * Sets up the Fire Resistance II potion effect with a 5-minute duration for protection against
+     * fire and lava damage.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
     public ICE_POTION(@NotNull Ollivanders2 plugin) {
         super(plugin);
@@ -32,26 +45,31 @@ public class ICE_POTION extends O2Potion {
         ingredients.put(O2ItemType.BURSTING_MUSHROOM, 4);
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 1);
 
+        // potion color
+        potionColor = Color.fromRGB(176, 224, 230); // powder blue
+        // last 5 minutes, which is longer than fire resistance II lasts
+        duration = Ollivanders2Common.ticksPerMinute * 5;
+        potionSuccessMessage = "You feel as though ice flows through your body.";
+
         text = "The Fire-Protection, or Ice Potion, allows the drinker to move through flames unscathed.";
         flavorText.add("\"Danger lies before you, while safety lies behind, Two of us will help you, whichever you would find, One among us seven will let you move ahead, Another will transport the drinker back instead.\"");
         flavorText.add("\"It was indeed as though ice was flooding his body.\"");
-
-        // potion color
-        potionColor = Color.fromRGB(176, 224, 230); // powder blue
-
-        // last 5 minutes, which is longer than fire resistance II lasts
-        duration = Ollivanders2Common.ticksPerMinute * 5;
-
-        minecraftPotionEffect = new PotionEffect(PotionEffectType.FIRE_RESISTANCE, duration, 1);
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Ice Potion and gain fire immunity.
+     *
+     * <p>Applies the FIRE_RESISTANCE II effect to the player for 5 minutes. This effect grants
+     * complete immunity to fire damage, allowing the player to walk through lava and fire blocks
+     * without taking damage. The effect also prevents damage from being in the burning status.</p>
      *
      * @param player the player who drank the potion
      */
     @Override
     public void drink(@NotNull Player player) {
-        player.sendMessage(Ollivanders2.chatColor + "You feel as though ice flows through your body.");
+        FIRE_RESISTANCE effect = new FIRE_RESISTANCE(p, duration, false, player.getUniqueId());
+        Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
+
+        player.sendMessage(Ollivanders2.chatColor + potionSuccessMessage);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/MEMORY_POTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/MEMORY_POTION.java
@@ -9,16 +9,29 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Doubles spell experience gained when casting spells.
+ * Memory Potion - enhances spell learning and experience gain.
+ *
+ * <p>When consumed, this potion applies the FAST_LEARNING effect to the player, which doubles
+ * the experience gained from casting spells. This allows players to quickly improve their spell
+ * skills and expertise. The effect lasts for the default potion duration, providing a significant
+ * temporary boost to magical learning and development.</p>
+ *
+ * <p>This potion is particularly useful for players looking to advance their spell casting
+ * abilities quickly and efficiently.</p>
  *
  * @author Azami7
  * @author cakenggt
  */
 public final class MEMORY_POTION extends O2Potion {
     /**
-     * Constructor
+     * Constructor for Memory Potion.
      *
-     * @param plugin a callback to the plugin
+     * <p>Initializes the potion with its ingredients (Mandrake Leaf, Jobberknoll Feather,
+     * Galanthus Nivalis, Powdered Sage, and Standard Potion Ingredients), description text,
+     * and potion color. Sets up the FAST_LEARNING effect that will be applied when the potion
+     * is consumed to double spell experience gain.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
     public MEMORY_POTION(@NotNull Ollivanders2 plugin) {
         super(plugin);
@@ -31,12 +44,19 @@ public final class MEMORY_POTION extends O2Potion {
         ingredients.put(O2ItemType.POWDERED_SAGE, 1);
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 2);
 
-        text = "This potion improves the drinker's memory. All spell experience is doubled.";
         potionColor = Color.fromRGB(255, 128, 0);
+        potionSuccessMessage = "You feel more alert.";
+
+        text = "This potion improves the drinker's memory. All spell experience is doubled.";
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Memory Potion and gain temporary spell learning enhancement.
+     *
+     * <p>Applies the FAST_LEARNING effect to the player. While this effect is active, all spell
+     * experience gained from casting spells is doubled, allowing for accelerated skill development
+     * and expertise growth. The effect remains active for the default potion duration, providing a
+     * temporary boost to magical learning.</p>
      *
      * @param player the player who drank the potion
      */
@@ -44,6 +64,6 @@ public final class MEMORY_POTION extends O2Potion {
         FAST_LEARNING effect = new FAST_LEARNING(p, duration, false, player.getUniqueId());
         Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
 
-        player.sendMessage(Ollivanders2.chatColor + "You feel more alert.");
+        player.sendMessage(Ollivanders2.chatColor + potionSuccessMessage);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2Potion.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2Potion.java
@@ -35,10 +35,9 @@ import org.jetbrains.annotations.Nullable;
  * Ollivanders Effect - effects related to the mechanics of the Ollivanders plugin. These are applied on the potion
  * drink action in OllivandersListener in the onPlayerDrink().</p>
  *
- * <p>Reference: https://harrypotter.fandom.com/wiki/Potion</p>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Potion">Harry Potter Wiki - Potion</a>
  */
-public abstract class O2Potion
-{
+public abstract class O2Potion {
     /**
      * Reference to the plugin
      */
@@ -60,12 +59,12 @@ public abstract class O2Potion
     protected Map<O2ItemType, Integer> ingredients = new HashMap<>();
 
     /**
-     * The description text for this spell in spell books.  Required or spell cannot be written in a book.
+     * The description text for this potion in books.  Required or potion cannot be written in a book.
      */
     protected String text = "";
 
     /**
-     * Flavor text for this spell in spellbooks, etc.  Optional.
+     * Flavor text for this potion in books, etc.  Optional.
      */
     protected ArrayList<String> flavorText = new ArrayList<>();
 
@@ -95,12 +94,16 @@ public abstract class O2Potion
     public double usesModifier = 1;
 
     /**
+     *
+     */
+    protected String potionSuccessMessage = "";
+
+    /**
      * Constructor
      *
      * @param plugin a callback to the plugin
      */
-    public O2Potion(@NotNull Ollivanders2 plugin)
-    {
+    public O2Potion(@NotNull Ollivanders2 plugin) {
         p = plugin;
         potionType = O2PotionType.BABBLING_BEVERAGE;
         common = new Ollivanders2Common(p);
@@ -112,13 +115,11 @@ public abstract class O2Potion
      * @return the recipe text for this ingredient
      */
     @NotNull
-    protected String getIngredientsText()
-    {
+    protected String getIngredientsText() {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("\n\nIngredients:");
 
-        for (Entry<O2ItemType, Integer> e : ingredients.entrySet())
-        {
+        for (Entry<O2ItemType, Integer> e : ingredients.entrySet()) {
             O2ItemType ingredientType = e.getKey();
             String name = Ollivanders2API.getItems().getItemNameByType(ingredientType);
 
@@ -134,8 +135,7 @@ public abstract class O2Potion
      * @return the type of potion
      */
     @NotNull
-    public O2PotionType getPotionType()
-    {
+    public O2PotionType getPotionType() {
         return potionType;
     }
 
@@ -145,8 +145,7 @@ public abstract class O2Potion
      * @return the name of the potion
      */
     @NotNull
-    public String getName()
-    {
+    public String getName() {
         return potionType.getPotionName();
     }
 
@@ -156,9 +155,11 @@ public abstract class O2Potion
      * @return a Map of the ingredients for this potion
      */
     @NotNull
-    Map<O2ItemType, Integer> getIngredients()
-    {
-        return ingredients;
+    public Map<O2ItemType, Integer> getIngredients() {
+        HashMap<O2ItemType, Integer> ingredientsCopy = new HashMap<>();
+        ingredientsCopy.putAll(ingredients);
+
+        return ingredientsCopy;
     }
 
     /**
@@ -168,8 +169,7 @@ public abstract class O2Potion
      * @return the description text for this potion
      */
     @NotNull
-    public String getText()
-    {
+    public String getText() {
         return text + getIngredientsText();
     }
 
@@ -180,12 +180,10 @@ public abstract class O2Potion
      * @return the flavor text for this potion.
      */
     @Nullable
-    public String getFlavorText()
-    {
+    public String getFlavorText() {
         if (flavorText.isEmpty())
             return null;
-        else
-        {
+        else {
             int index = Math.abs(Ollivanders2Common.random.nextInt() % flavorText.size());
             return flavorText.get(index);
         }
@@ -197,8 +195,7 @@ public abstract class O2Potion
      * @return the branch of magic for this potion
      */
     @NotNull
-    public O2MagicBranch getMagicBranch()
-    {
+    public O2MagicBranch getMagicBranch() {
         return O2MagicBranch.POTIONS;
     }
 
@@ -208,9 +205,18 @@ public abstract class O2Potion
      * @return the level of magic for this potion
      */
     @NotNull
-    public MagicLevel getLevel()
-    {
+    public MagicLevel getLevel() {
         return potionType.getLevel();
+    }
+
+    /**
+     * Get the potion success message used in drink()
+     *
+     * @return the potion success message
+     */
+    @NotNull
+    public String getPotionSuccessMessage() {
+        return potionSuccessMessage;
     }
 
     /**
@@ -219,32 +225,27 @@ public abstract class O2Potion
      * @param cauldronIngredients the ingredients found in the cauldron
      * @return true if the ingredient list matches this potion recipe exactly, false otherwise
      */
-    public boolean checkRecipe(@NotNull Map<O2ItemType, Integer> cauldronIngredients)
-    {
+    public boolean checkRecipe(@NotNull Map<O2ItemType, Integer> cauldronIngredients) {
         common.printDebugMessage("Checking " + potionType.getPotionName() + " recipe", null, null, false);
 
         // are there the right number of ingredients?
-        if (ingredients.size() != cauldronIngredients.size())
-        {
+        if (ingredients.size() != cauldronIngredients.size()) {
             common.printDebugMessage("   expected " + ingredients.size() + " ingredients, got " + cauldronIngredients.size(), null, null, false);
             return false;
         }
 
-        for (Map.Entry<O2ItemType, Integer> e : ingredients.entrySet())
-        {
+        for (Map.Entry<O2ItemType, Integer> e : ingredients.entrySet()) {
             O2ItemType ingredientType = e.getKey();
             Integer count = e.getValue();
 
             // is this ingredient in the recipe?
-            if (!cauldronIngredients.containsKey(ingredientType))
-            {
+            if (!cauldronIngredients.containsKey(ingredientType)) {
                 common.printDebugMessage("   cauldron does not contain " + ingredientType.getName(), null, null, false);
                 return false;
             }
 
             // is the amount of the ingredient correct?
-            if (cauldronIngredients.get(ingredientType).intValue() != count.intValue())
-            {
+            if (cauldronIngredients.get(ingredientType).intValue() != count.intValue()) {
                 common.printDebugMessage("   recipe needs " + count + " " + ingredientType.getName() + ", got " + cauldronIngredients.get(ingredientType), null, null, false);
                 return false;
             }
@@ -262,41 +263,52 @@ public abstract class O2Potion
      * @return an ItemStack with a single bottle of this potion
      */
     @NotNull
-    public ItemStack brew(@NotNull Player brewer, boolean checkCanBrew)
-    {
+    public ItemStack brew(@NotNull Player brewer, boolean checkCanBrew) {
         ItemStack potion;
 
-        if (checkCanBrew && !canBrew(brewer))
-        {
+        if (checkCanBrew && !canBrew(brewer)) {
             brewer.sendMessage(Ollivanders2.chatColor + "You feel uncertain about how to make this potion.");
             potion = brewBadPotion();
         }
         else
-        {
-            potion = new ItemStack(potionMaterialType);
-            PotionMeta meta = (PotionMeta) potion.getItemMeta();
-
-            if (meta == null)
-            {
-                common.printDebugMessage("O2Potion.brew: item meta is null", null, null, true);
-                potion = brewBadPotion();
-            }
-            else
-            {
-                meta.setDisplayName(potionType.getPotionName());
-                PersistentDataContainer container = meta.getPersistentDataContainer();
-                container.set(O2Potions.potionTypeKey, PersistentDataType.STRING, potionType.toString());
-
-                meta.setColor(potionColor);
-                if (minecraftPotionEffect != null)
-                    meta.addCustomEffect(minecraftPotionEffect, true);
-
-                meta.addItemFlags(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
-                potion.setItemMeta(meta);
-            }
-        }
+            potion = createPotionItemStack(1);
 
         p.getO2Player(brewer).incrementPotionCount(potionType);
+
+        return potion;
+    }
+
+    /**
+     * Create an ItemStack for this potion with the specified amount.
+     * <p>
+     * Sets up the potion metadata including display name, color, custom effects,
+     * and NBT tags for potion type identification.
+     * </p>
+     *
+     * @param amount the number of potions in the ItemStack
+     * @return an ItemStack containing the potion, or a bad potion if metadata creation fails
+     */
+    public ItemStack createPotionItemStack(int amount) {
+        ItemStack potion = new ItemStack(potionMaterialType);
+        potion.setAmount(amount);
+        PotionMeta meta = (PotionMeta) potion.getItemMeta();
+
+        if (meta == null) {
+            common.printDebugMessage("O2Potion.brew: item meta is null", null, null, true);
+            potion = brewBadPotion();
+        }
+        else {
+            meta.setDisplayName(potionType.getPotionName());
+            PersistentDataContainer container = meta.getPersistentDataContainer();
+            container.set(O2Potions.potionTypeKey, PersistentDataType.STRING, potionType.getPotionName());
+
+            meta.setColor(potionColor);
+            if (minecraftPotionEffect != null)
+                meta.addCustomEffect(minecraftPotionEffect, true);
+
+            meta.addItemFlags(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
+            potion.setItemMeta(meta);
+        }
 
         return potion;
     }
@@ -310,8 +322,7 @@ public abstract class O2Potion
      * @param brewer the player brewing the potion
      * @return true if the player will be successful, false otherwise.
      */
-    private boolean canBrew(@NotNull Player brewer)
-    {
+    private boolean canBrew(@NotNull Player brewer) {
         if (p.getConfig().isSet("overrideBrewSuccessCheck") && p.getConfig().getBoolean("overrideBrewSuccessCheck"))
             return true;
 
@@ -322,16 +333,17 @@ public abstract class O2Potion
         boolean canBrew;
 
         O2Player o2p = Ollivanders2API.getPlayers().getPlayer(brewer.getUniqueId());
-        if (o2p == null)
+        if (o2p == null) {
+            common.printDebugMessage("O2Potion.canBrew: failed to find O2Player", null, null, true);
             return false;
+        }
 
         int potionCount = o2p.getPotionCount(potionType);
 
         // do not allow them to brew if book learning is turned on and the brewer does not know this potion
         if (Ollivanders2.bookLearning && (potionCount < 1))
             canBrew = false;
-        else
-        {
+        else {
             setUsesModifier(o2p);
 
             int rand = (Math.abs(Ollivanders2Common.random.nextInt()) % 100) + 1;
@@ -347,8 +359,7 @@ public abstract class O2Potion
      * @return a random bad potion
      */
     @NotNull
-    public static ItemStack brewBadPotion()
-    {
+    public static ItemStack brewBadPotion() {
         ItemStack potion = new ItemStack(Material.POTION);
         PotionMeta meta = (PotionMeta) potion.getItemMeta();
 
@@ -359,35 +370,29 @@ public abstract class O2Potion
         String name = "Watery Potion";
         Color color = Color.BLUE;
 
-        if (rand == 9)
-        {
+        if (rand == 9) {
             name = "Slimy Potion";
             color = Color.GREEN;
         }
-        else if (rand == 8)
-        {
+        else if (rand == 8) {
             name = "Lumpy Potion";
             color = Color.GRAY;
         }
-        else if (rand == 7)
-        {
+        else if (rand == 7) {
             name = "Cloudy Potion";
             color = Color.WHITE;
         }
-        else if (rand == 6)
-        {
+        else if (rand == 6) {
             name = "Smelly Potion";
             color = Color.ORANGE;
         }
-        else if (rand == 5)
-        {
+        else if (rand == 5) {
             name = "Sticky Potion";
             color = Color.OLIVE;
         }
         // else rand < 5, use "Watery Potion" and Color.BLUE
 
         meta.setDisplayName(name);
-        //meta.setLore(Arrays.asList(name));
         meta.setColor(color);
 
         rand = Math.abs(Ollivanders2Common.random.nextInt() % 10);
@@ -395,8 +400,7 @@ public abstract class O2Potion
         int duration = 1200;
         int amplifier = 1;
 
-        if (rand >= 5)
-        {
+        if (rand >= 5) {
             PotionEffect e;
 
             if (rand == 9)
@@ -431,14 +435,12 @@ public abstract class O2Potion
      *
      * @param o2p the player who is brewing the potion
      */
-    protected void setUsesModifier(@NotNull O2Player o2p)
-    {
+    protected void setUsesModifier(@NotNull O2Player o2p) {
         // if max skill is set, set usesModifier to max level
         if (Ollivanders2.maxSpellLevel)
             usesModifier = 200;
             // uses modifier is the number of times the spell has been cast
-        else
-        {
+        else {
             usesModifier = o2p.getPotionCount(potionType);
 
             // if the caster is affected by HIGHER_SKILL, double their usesModifier
@@ -446,9 +448,8 @@ public abstract class O2Potion
                 usesModifier *= 2;
         }
 
-        // if years is enabled, spell usage is affected by caster's level
-        if (Ollivanders2.useYears)
-        {
+        // if years is enabled, potion brewing is affected by brewer's level
+        if (Ollivanders2.useYears) {
             MagicLevel maxLevelForPlayer = o2p.getYear().getHighestLevelForYear();
 
             if (maxLevelForPlayer.ordinal() > (potionType.getLevel().ordinal() + 1))
@@ -458,7 +459,7 @@ public abstract class O2Potion
                 // 50% skill increase when 1 level above
                 usesModifier *= 1.5;
                 /*
-                    maxLevelForPlayer.ordinal() == spellType.getLevel().ordinal())
+                    maxLevelForPlayer.ordinal() == potionType.getLevel().ordinal())
                     no change to usesModifier
                  */
             else if ((maxLevelForPlayer.ordinal() + 1) < potionType.getLevel().ordinal())

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2PotionType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2PotionType.java
@@ -1,134 +1,153 @@
 package net.pottercraft.ollivanders2.potion;
 
 import net.pottercraft.ollivanders2.common.MagicLevel;
-import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * All potions types
+ * Enumeration of all potion types available in Ollivanders2.
+ * <p>
+ * Each potion type defines a distinct magical brew with its display name, implementation class,
+ * and magic difficulty level. Potions are brewed by players using cauldrons and specific ingredients,
+ * then consumed for various magical effects.
+ * </p>
+ * <p>
+ * Magic levels range from BEGINNER (simple potions like Cure for Boils) to NEWT (advanced potions
+ * like Draught of Living Death).
+ * </p>
  *
  * @author Azami7
+ * @see O2Potion the abstract base class for all potion implementations
  */
 public enum O2PotionType {
     /**
      * {@link ANIMAGUS_POTION}
      */
-    ANIMAGUS_POTION(ANIMAGUS_POTION.class, MagicLevel.NEWT),
+    ANIMAGUS_POTION(ANIMAGUS_POTION.class, "Animagus Potion", MagicLevel.NEWT),
     /**
      * {@link BABBLING_BEVERAGE}
      */
-    BABBLING_BEVERAGE(BABBLING_BEVERAGE.class, MagicLevel.OWL),
+    BABBLING_BEVERAGE(BABBLING_BEVERAGE.class, "Babbling Beverage", MagicLevel.OWL),
     /**
      * {@link BARUFFIOS_BRAIN_ELIXIR}
      */
-    BARUFFIOS_BRAIN_ELIXIR(BARUFFIOS_BRAIN_ELIXIR.class, MagicLevel.EXPERT),
+    BARUFFIOS_BRAIN_ELIXIR(BARUFFIOS_BRAIN_ELIXIR.class, "Baruffio's Brain Elixir", MagicLevel.EXPERT),
     /**
      * {@link COMMON_ANTIDOTE_POTION}
      */
-    COMMON_ANTIDOTE_POTION(COMMON_ANTIDOTE_POTION.class, MagicLevel.BEGINNER),
+    COMMON_ANTIDOTE_POTION(COMMON_ANTIDOTE_POTION.class, "Antidote to Common Poisons", MagicLevel.BEGINNER),
     /**
      * {@link CURE_FOR_BOILS}
      */
-    CURE_FOR_BOILS(CURE_FOR_BOILS.class, MagicLevel.BEGINNER),
+    CURE_FOR_BOILS(CURE_FOR_BOILS.class, "Cure for Boils", MagicLevel.BEGINNER),
     /**
      * {@link DRAUGHT_OF_LIVING_DEATH}
      */
-    DRAUGHT_OF_LIVING_DEATH(DRAUGHT_OF_LIVING_DEATH.class, MagicLevel.NEWT),
+    DRAUGHT_OF_LIVING_DEATH(DRAUGHT_OF_LIVING_DEATH.class, "Draught of Living Death", MagicLevel.NEWT),
     /**
-     * {@link FORGETFULLNESS_POTION}
+     * {@link FORGETFULNESS_POTION}
      */
-    FORGETFULLNESS_POTION(FORGETFULLNESS_POTION.class, MagicLevel.OWL),
+    FORGETFULNESS_POTION(FORGETFULNESS_POTION.class, "Forgetfulness Potion", MagicLevel.OWL),
     /**
      * {@link HERBICIDE_POTION}
      */
-    HERBICIDE_POTION(HERBICIDE_POTION.class, MagicLevel.BEGINNER),
+    HERBICIDE_POTION(HERBICIDE_POTION.class, "Herbicide Potion", MagicLevel.BEGINNER),
     /**
      * {@link HUNGER_POTION}
      */
-    HUNGER_POTION(HUNGER_POTION.class, MagicLevel.BEGINNER),
+    HUNGER_POTION(HUNGER_POTION.class, "Hunger Potion", MagicLevel.BEGINNER),
     /**
      * {@link ICE_POTION}
      */
-    ICE_POTION(ICE_POTION.class, MagicLevel.OWL),
+    ICE_POTION(ICE_POTION.class, "Ice Potion", MagicLevel.OWL),
     /**
      * {@link MEMORY_POTION}
      */
-    MEMORY_POTION(MEMORY_POTION.class, MagicLevel.NEWT),
+    MEMORY_POTION(MEMORY_POTION.class, "Memory Potion", MagicLevel.NEWT),
     /**
      * {@link OCULUS_FELIS}
      */
-    OCULUS_FELIS(OCULUS_FELIS.class, MagicLevel.BEGINNER),
+    OCULUS_FELIS(OCULUS_FELIS.class, "Oculus Felis", MagicLevel.BEGINNER),
     /**
      * {@link REGENERATION_POTION}
      */
-    REGENERATION_POTION(REGENERATION_POTION.class, MagicLevel.NEWT),
+    REGENERATION_POTION(REGENERATION_POTION.class, "Regeneration Potion", MagicLevel.NEWT),
     /**
      * {@link SATIATION_POTION}
      */
-    SATIATION_POTION(SATIATION_POTION.class, MagicLevel.BEGINNER),
+    SATIATION_POTION(SATIATION_POTION.class, "Satiation Potion", MagicLevel.BEGINNER),
     /**
      * {@link SHRINKING_SOLUTION}
      */
-    SHRINKING_SOLUTION(SHRINKING_SOLUTION.class, MagicLevel.OWL),
+    SHRINKING_SOLUTION(SHRINKING_SOLUTION.class, "Shrinking Solution", MagicLevel.OWL),
     /**
      * {@link SLEEPING_DRAUGHT}
      */
-    SLEEPING_DRAUGHT(SLEEPING_DRAUGHT.class, MagicLevel.BEGINNER),
+    SLEEPING_DRAUGHT(SLEEPING_DRAUGHT.class, "Sleeping Draught", MagicLevel.BEGINNER),
     /**
      * {@link STRENGTHENING_SOLUTION}
      */
-    STRENGTHENING_SOLUTION(STRENGTHENING_SOLUTION.class, MagicLevel.OWL),
+    STRENGTHENING_SOLUTION(STRENGTHENING_SOLUTION.class, "Strengthening Solution", MagicLevel.OWL),
     /**
      * {@link SWELLING_SOLUTION}
      */
-    SWELLING_SOLUTION(SWELLING_SOLUTION.class, MagicLevel.OWL),
+    SWELLING_SOLUTION(SWELLING_SOLUTION.class, "Swelling Solution", MagicLevel.OWL),
     /**
      * {@link WEAKNESS_POTION}
      */
-    WEAKNESS_POTION(WEAKNESS_POTION.class, MagicLevel.BEGINNER),
+    WEAKNESS_POTION(WEAKNESS_POTION.class, "Weakness Potion", MagicLevel.BEGINNER),
     /**
      * {@link WIDEYE_POTION}
      */
-    WIDEYE_POTION(WIDEYE_POTION.class, MagicLevel.BEGINNER),
+    WIDEYE_POTION(WIDEYE_POTION.class, "Wideye Potion", MagicLevel.BEGINNER),
     /**
      * {@link WIGGENWELD_POTION}
      */
-    WIGGENWELD_POTION(WIGGENWELD_POTION.class, MagicLevel.OWL),
+    WIGGENWELD_POTION(WIGGENWELD_POTION.class, "Wiggenweld Potion", MagicLevel.OWL),
     /**
      * {@link WIT_SHARPENING_POTION}
      */
-    WIT_SHARPENING_POTION(WIT_SHARPENING_POTION.class, MagicLevel.OWL),
+    WIT_SHARPENING_POTION(WIT_SHARPENING_POTION.class, "Wit-Sharpening Potion", MagicLevel.OWL),
     /**
      * {@link WOLFSBANE_POTION}
      */
-    WOLFSBANE_POTION(WOLFSBANE_POTION.class, MagicLevel.EXPERT);
+    WOLFSBANE_POTION(WOLFSBANE_POTION.class, "Wolfsbane Potion", MagicLevel.EXPERT);
 
     /**
-     * The class of the potion this type creates
+     * The implementation class for this potion type.
+     * <p>
+     * Used with reflection to instantiate potion objects. Must extend O2Potion.
+     * </p>
      */
     private final Class<?> className;
 
     /**
-     * The level of this potion
+     * The magic difficulty level required to brew this potion.
      */
     private final MagicLevel level;
 
     /**
-     * Constructor.
-     *
-     * @param className the class for this potion type
-     * @param level     the level of this potion
+     * The human-readable display name of this potion (e.g., "Baruffio's Brain Elixir").
      */
-    O2PotionType(@NotNull Class<?> className, MagicLevel level) {
+    private final String name;
+
+    /**
+     * Constructor for creating a potion type enum constant.
+     *
+     * @param className the implementation class for this potion type (must extend O2Potion)
+     * @param name      the display name of the potion (e.g., "Baruffio's Brain Elixir")
+     * @param level     the magic difficulty level required to brew this potion
+     */
+    O2PotionType(@NotNull Class<?> className, @NotNull String name, @NotNull MagicLevel level) {
         this.className = className;
+        this.name = name;
         this.level = level;
     }
 
     /**
-     * Get the class for this potion type
+     * Get the implementation class for this potion type.
      *
-     * @return the class name for this type of potion.
+     * @return the Class object for this potion's implementation (extends O2Potion)
      */
     @NotNull
     public Class<?> getClassName() {
@@ -146,25 +165,28 @@ public enum O2PotionType {
     }
 
     /**
-     * Get the name for this potion type.
+     * Get the display name for this potion type.
      *
-     * @return the spell name for this potion type.
+     * @return the human-readable potion name (e.g., "Baruffio's Brain Elixir")
      */
     @NotNull
     public String getPotionName() {
-        String potionTypeString = this.toString().toLowerCase();
-
-        return Ollivanders2Common.firstLetterCapitalize(potionTypeString.replace("_", " "));
+        return name;
     }
 
     /**
-     * Get a O2PotionType enum from a string. This should be used as the opposite of toString() on the enum.
+     * Get an O2PotionType enum from its enum name string.
+     * <p>
+     * This should be used as the opposite of toString() on the enum. This is distinctly different from
+     * {@link #getPotionTypeByName(String)} which gets the potion type by the display name, which may
+     * not match enum.toString() (e.g., "Baruffio's Brain Elixir" vs "BARUFFIOS_BRAIN_ELIXIR").
+     * </p>
      *
-     * @param potionString the name of the potion type, ex. "AQUA_ERUCTO"
-     * @return the potion type
+     * @param potionString the enum name of the potion type (e.g., "SLEEPING_DRAUGHT", "WIGGENWELD_POTION")
+     * @return the potion type if found, null if the string doesn't match any potion type
      */
     @Nullable
-    public static O2PotionType potionTypeFromString(@NotNull String potionString) {
+    public static O2PotionType getPotionTypeFromString(@NotNull String potionString) {
         O2PotionType potionType = null;
 
         try {
@@ -175,5 +197,29 @@ public enum O2PotionType {
         }
 
         return potionType;
+    }
+
+    /**
+     * Get a potion type by its display name.
+     * <p>
+     * This is distinctly different from {@link #getPotionTypeFromString(String)} which gets the potion
+     * based on the enum.toString() value. Display names may include punctuation and spaces that aren't
+     * valid in enum names (e.g., "Baruffio's Brain Elixir", "Wit-Sharpening Potion").
+     * </p>
+     * <p>
+     * The comparison is case-insensitive.
+     * </p>
+     *
+     * @param name the display name of the potion to find (e.g., "Sleeping Draught")
+     * @return the potion type if found, null if no potion matches the given name
+     */
+    @Nullable
+    public static O2PotionType getPotionTypeByName(@NotNull String name) {
+        for (O2PotionType potionType : O2PotionType.values()) {
+            if (potionType.getPotionName().equalsIgnoreCase(name))
+                return potionType;
+        }
+
+        return null;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2SplashPotion.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/O2SplashPotion.java
@@ -6,16 +6,32 @@ import org.bukkit.event.entity.PotionSplashEvent;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Adds functionality to O2Potions when they are splash potions.
+ * Abstract base class for splash potion implementations.
+ *
+ * <p>O2SplashPotion extends O2Potion to provide functionality specific to splash potions that are
+ * thrown rather than consumed directly. Splash potions affect a radius of entities when they impact
+ * and break, unlike normal potions which are consumed by a player drinking them.</p>
+ *
+ * <p>Subclasses must implement {@link #doOnPotionSplashEvent(PotionSplashEvent)} to define the
+ * custom effects that occur when the splash potion explodes. The potion material type is
+ * automatically set to {@link Material#SPLASH_POTION}.</p>
+ *
+ * <p>Examples of splash potions include HERBICIDE_POTION which kills plants in a radius and
+ * damages plant-based entities when thrown.</p>
  *
  * @author Azami7
  * @since 2.2.7
  */
 public abstract class O2SplashPotion extends O2Potion {
     /**
-     * Constructor
+     * Constructor for O2SplashPotion.
      *
-     * @param plugin a callback to the plugin
+     * <p>Initializes the splash potion by calling the parent O2Potion constructor and setting
+     * the potion material type to {@link Material#SPLASH_POTION}. Subclasses should call this
+     * constructor via {@code super(plugin)} and then set up their specific recipe, ingredients,
+     * effects, and other potion properties.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
     public O2SplashPotion(@NotNull Ollivanders2 plugin) {
         super(plugin);
@@ -24,9 +40,20 @@ public abstract class O2SplashPotion extends O2Potion {
     }
 
     /**
-     * Do the effect this potion has when thrown.
+     * Handle the effects that occur when this splash potion is thrown and impacts.
      *
-     * @param event the splash potion thrown event
+     * <p>This abstract method is called when the splash potion breaks and its effects are applied.
+     * Subclasses must implement this method to define their custom splash effects, such as:</p>
+     * <ul>
+     * <li>Modifying the intensity of the potion effect for different entity types</li>
+     * <li>Creating stationary spells or effects at the splash location</li>
+     * <li>Applying custom transformations or interactions to affected entities</li>
+     * </ul>
+     *
+     * <p>The PotionSplashEvent contains information about the potion, thrower, splash location,
+     * affected entities, and the original potion effect intensity that can be modified.</p>
+     *
+     * @param event the splash potion event containing splash location, affected entities, and effect intensity
      */
     public abstract void doOnPotionSplashEvent(@NotNull PotionSplashEvent event);
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/OCULUS_FELIS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/OCULUS_FELIS.java
@@ -1,25 +1,38 @@
 package net.pottercraft.ollivanders2.potion;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
 import net.pottercraft.ollivanders2.common.Ollivanders2Common;
+import net.pottercraft.ollivanders2.effect.NIGHT_VISION;
 import net.pottercraft.ollivanders2.item.O2ItemType;
 import org.bukkit.Color;
 import org.bukkit.entity.Player;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Oculus Felis gives the drinker night vision.
+ * Oculus Felis - grants feline night vision for seeing in darkness.
+ *
+ * <p>When consumed, this potion applies the NIGHT_VISION II effect to the player for 5 minutes,
+ * granting them the ability to see clearly in near-total darkness. This potion mimics a cat's
+ * superior night vision, allowing the player to navigate dark areas as if they were brightly lit.</p>
+ *
+ * <p>The 5-minute duration is longer than the standard Minecraft Night Vision II potion, providing
+ * extended visibility for the drinker. This is particularly useful for exploring dark caves,
+ * navigating at night, or other low-light scenarios.</p>
  *
  * @author Azami7
  * @since 2.21
  */
 public class OCULUS_FELIS extends O2Potion {
     /**
-     * Constructor.
+     * Constructor for Oculus Felis potion.
      *
-     * @param plugin the callback to the MC plugin
+     * <p>Initializes the potion with its ingredients (Crushed Cat's Eye Opal, Mooncalf Milk,
+     * Jobberknoll Feather, Asphodel, and Standard Potion Ingredients), description text, potion
+     * color, and the Night Vision II potion effect. Sets up the 5-minute duration for the night
+     * vision effect.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
     public OCULUS_FELIS(@NotNull Ollivanders2 plugin) {
         super(plugin);
@@ -32,24 +45,29 @@ public class OCULUS_FELIS extends O2Potion {
         ingredients.put(O2ItemType.ASPHODEL, 1);
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 2);
 
-        text = "Oculus Felis is a potion which gives the drinker a cat’s ability to see in near-total darkness.";
-
         // potion color
         potionColor = Color.fromRGB(255, 191, 0); // amber
         // potion duration - last 5 minutes, which is longer than night vision II lasts
         duration = Ollivanders2Common.ticksPerMinute * 5;
+        potionSuccessMessage = "The world looks brighter.";
 
-        // Night Vision II
-        minecraftPotionEffect = new PotionEffect(PotionEffectType.NIGHT_VISION, duration, 1);
+        text = "Oculus Felis is a potion which gives the drinker a cat’s ability to see in near-total darkness.";
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink Oculus Felis and gain night vision.
+     *
+     * <p>Applies the NIGHT_VISION II effect to the player for 5 minutes. This effect allows the
+     * player to see clearly in darkness and low-light conditions, as if the world were lit by
+     * daylight. The enhanced vision mimics a feline's ability to see in near-total darkness.</p>
      *
      * @param player the player who drank the potion
      */
     @Override
     public void drink(@NotNull Player player) {
-        player.sendMessage(Ollivanders2.chatColor + "The world looks brighter.");
+        NIGHT_VISION effect = new NIGHT_VISION(p, duration, false, player.getUniqueId());
+        Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
+
+        player.sendMessage(Ollivanders2.chatColor + potionSuccessMessage);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/REGENERATION_POTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/REGENERATION_POTION.java
@@ -1,23 +1,36 @@
 package net.pottercraft.ollivanders2.potion;
 
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.effect.REGENERATION;
 import net.pottercraft.ollivanders2.item.O2ItemType;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import org.bukkit.Color;
 import org.bukkit.entity.Player;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * The regeneration potion restores a player's experience after death if deathExpLoss is enabled.
+ * Regeneration Potion - heals the drinker over time through magical regeneration.
+ *
+ * <p>When consumed, this potion applies the REGENERATION II effect to the player for the default
+ * potion duration. The Regeneration effect causes the player to slowly heal over time, restoring
+ * lost health points. This is a restorative potion useful for recovering from injuries sustained
+ * during combat or other dangerous activities.</p>
+ *
+ * <p>The potion is crafted with components associated with life and resurrection, including bone,
+ * blood, rotten flesh, and salamander fire, reflecting its purpose of restoring life and vitality.</p>
  *
  * @author Azami7
  */
 public final class REGENERATION_POTION extends O2Potion {
     /**
-     * Constructor
+     * Constructor for Regeneration Potion.
      *
-     * @param plugin a callback to the plugin
+     * <p>Initializes the potion with its ingredients (Bone, Blood, Rotten Flesh, Salamander Fire,
+     * and Standard Potion Ingredients), description text, flavor text, potion color, and the
+     * Regeneration effect. Sets up the healing effect that will be applied when the
+     * potion is consumed.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
     public REGENERATION_POTION(@NotNull Ollivanders2 plugin) {
         super(plugin);
@@ -30,19 +43,27 @@ public final class REGENERATION_POTION extends O2Potion {
         ingredients.put(O2ItemType.SALAMANDER_FIRE, 1);
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 4);
 
+        potionColor = Color.WHITE;
+        potionSuccessMessage = "You feel recovered.";
+
         text = "This potion will heal a player.";
         flavorText.add("\"Bone of the father, unknowingly given, you will renew your son! Flesh of the servant, willingly sacrificed, you will revive your master. Blood of the enemy, forcibly taken, you will resurrect your foe.\" -Peter Pettigrew");
-
-        minecraftPotionEffect = new PotionEffect(PotionEffectType.REGENERATION, duration, 1);
-        potionColor = Color.WHITE;
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Regeneration Potion and gain health regeneration.
+     *
+     * <p>Applies the REGENERATION effect to the player for the default potion duration.
+     * This effect causes the player's health to gradually restore over time. The regeneration
+     * effect is particularly useful for recovering health after combat, falls, or other
+     * damage-dealing events.</p>
      *
      * @param player the player who drank the potion
      */
     public void drink(@NotNull Player player) {
-        player.sendMessage(Ollivanders2.chatColor + "You feel recovered.");
+        REGENERATION effect = new REGENERATION(p, duration, false, player.getUniqueId());
+        Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
+
+        player.sendMessage(Ollivanders2.chatColor + potionSuccessMessage);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/SATIATION_POTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/SATIATION_POTION.java
@@ -1,28 +1,44 @@
 package net.pottercraft.ollivanders2.potion;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
 import net.pottercraft.ollivanders2.common.Ollivanders2Common;
+import net.pottercraft.ollivanders2.effect.SATIATION;
 import net.pottercraft.ollivanders2.item.O2ItemType;
 import org.bukkit.Color;
 import org.bukkit.entity.Player;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Satiation potion adds the Saturation potion effect.
+ * Satiation Potion - restores food saturation and satisfies hunger.
+ *
+ * <p>When consumed, this potion applies the SATIATION effect to the player for
+ * 5 minutes. The Satiation effect restores the player's food saturation level without consuming
+ * actual food, allowing them to go longer between meals. This is particularly useful for survival
+ * scenarios or extended activities where food is limited.</p>
+ *
+ * <p>Unlike eating food, saturation effects prevent hunger decay and provide nourishment without
+ * requiring food items. The saturation from this potion works in tandem with the food bar to
+ * prevent health loss from starvation.</p>
  *
  * @author Azami7
  * @since 2.21
  */
 public class SATIATION_POTION extends O2Potion {
+    /**
+     * Constructor for Satiation Potion.
+     *
+     * <p>Initializes the potion with its ingredients (Chopped Mallow Leaves, Knotgrass, Honeywater,
+     * and Standard Potion Ingredients), description text, potion color, and the Saturation I potion
+     * effect. Sets up the 5-minute duration for the saturation effect.</p>
+     *
+     * @param plugin a callback to the plugin instance
+     */
     public SATIATION_POTION(@NotNull Ollivanders2 plugin) {
         super(plugin);
 
         // potion config
         potionType = O2PotionType.SATIATION_POTION;
-        potionColor = Color.fromRGB(248, 125, 35); // warm orange
-        duration = Ollivanders2Common.ticksPerMinute * 5;
 
         // ingredients
         ingredients.put(O2ItemType.CHOPPED_MALLOW_LEAVES, 2);
@@ -30,20 +46,29 @@ public class SATIATION_POTION extends O2Potion {
         ingredients.put(O2ItemType.HONEYWATER, 2);
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 3);
 
+        potionColor = Color.fromRGB(248, 125, 35); // warm orange
+        duration = Ollivanders2Common.ticksPerMinute * 5;
+        potionSuccessMessage = "You feel completely satisfied and nourished.";
+
         // spellbook text
         text = "The satiation potion will satisfy the drinker's hunger and restore their energy.";
-
-        // Saturation I
-        minecraftPotionEffect = new PotionEffect(PotionEffectType.SATURATION, duration, 0);
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Satiation Potion and restore food saturation.
+     *
+     * <p>Applies the Satiation effect to the player for 5 minutes. This effect
+     * restores and maintains the player's food saturation level, preventing hunger decay and
+     * starvation damage. The player will feel completely satisfied and nourished while the
+     * effect is active, allowing them to focus on other tasks without worrying about hunger.</p>
      *
      * @param player the player who drank the potion
      */
     @Override
     public void drink(@NotNull Player player) {
-        player.sendMessage(Ollivanders2.chatColor + "You feel completely satisfied and nourished.");
+        SATIATION effect = new SATIATION(p, duration, false, player.getUniqueId());
+        Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
+
+        player.sendMessage(Ollivanders2.chatColor + potionSuccessMessage);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/SHRINKING_SOLUTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/SHRINKING_SOLUTION.java
@@ -9,22 +9,48 @@ import org.bukkit.Color;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Shrinking Solution - causes the drinker to shrink in size.
+ *
+ * <p>When consumed, this potion applies the SHRINKING effect to the player for 5 minutes,
+ * causing them to become smaller in physical size. The shrinking effect can impact movement,
+ * interaction with the world, and visibility. This potion is primarily a transformative effect
+ * useful for puzzle-solving, exploration, or roleplay scenarios.</p>
+ *
+ * <p>The shrinking effect is temporary and will wear off after the duration expires, returning
+ * the player to their normal size.</p>
+ *
+ * @author Azami7
+ */
 public class SHRINKING_SOLUTION extends O2Potion {
     /**
-     * Constructor
+     * Constructor for Shrinking Solution potion.
      *
-     * @param plugin a callback to the plugin
+     * <p>Initializes the potion with its ingredients (Standard Potion Ingredients), potion color,
+     * and the SHRINKING effect. Sets up the 5-minute duration for the shrinking effect that will
+     * be applied when the potion is consumed.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
     public SHRINKING_SOLUTION(@NotNull Ollivanders2 plugin) {
         super(plugin);
 
+        // ingredients
+        ingredients.put(O2ItemType.RAT_SPLEEN, 1);
+        ingredients.put(O2ItemType.SLICED_CATERPILLARS, 2);
+        ingredients.put(O2ItemType.SHRIVELIG, 2);
+        ingredients.put(O2ItemType.LEECH_JUICE, 1);
+        ingredients.put(O2ItemType.DAISY_ROOTS, 2);
+        ingredients.put(O2ItemType.INFUSION_OF_COWBANE, 1);
+        ingredients.put(O2ItemType.INFUSION_OF_WORMWOOD, 2);
+        ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 3);
+
         // potion config
         potionType = O2PotionType.SHRINKING_SOLUTION;
+
         potionColor = Color.fromRGB(218, 165, 32); // goldenrod
         duration = Ollivanders2Common.ticksPerMinute * 5;
-
-        // ingredients
-        ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 3);
+        potionSuccessMessage = "You feel yourself compressing.";
 
         // spellbook text
         text = "";
@@ -32,16 +58,20 @@ public class SHRINKING_SOLUTION extends O2Potion {
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Shrinking Solution and become smaller in size.
+     *
+     * <p>Applies the SHRINKING effect to the player for 5 minutes. This effect causes the player
+     * to physically shrink in size, which can affect their movement, interactions with the world,
+     * and visibility. The shrinking effect is temporary and will wear off after the duration expires.</p>
      *
      * @param player the player who drank the potion
      */
     @Override
     public void drink(@NotNull Player player) {
-        // add the swelling effect
+        // add the shrinking effect
         SHRINKING effect = new SHRINKING(p, duration, false, player.getUniqueId());
         Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
 
-        player.sendMessage(Ollivanders2.chatColor + "You feel yourself compressing.");
+        player.sendMessage(Ollivanders2.chatColor + potionSuccessMessage);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/SLEEPING_DRAUGHT.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/SLEEPING_DRAUGHT.java
@@ -10,39 +10,65 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Puts the drinker in to a deep but temporary sleep.
+ * Sleeping Draught - causes the drinker to fall into a deep, dreamless sleep.
+ *
+ * <p>When consumed, this potion applies the SLEEPING effect to the player for approximately
+ * 2 minutes, causing them to fall into a deep, enchanted sleep. While asleep, the player cannot
+ * perform most actions and is essentially incapacitated for the duration of the effect.</p>
+ *
+ * <p>The sleep can be immediately countered if the player has the AWAKE effect active, which
+ * will prevent the sleeping effect from taking hold. This is the primary counter to the
+ * Draught of Living Death, which puts players into permanent sleep.</p>
+ *
+ * <p>This potion is useful for incapacitating threats temporarily or for puzzle scenarios where
+ * sleep is required.</p>
  *
  * @author Azami7
  * @since 2.2.8
  */
 public class SLEEPING_DRAUGHT extends O2Potion {
+    String awakeEffectMessage = "You yawn, otherwise nothing happens.";
+
     /**
-     * Constructor
+     * Constructor for Sleeping Draught potion.
      *
-     * @param plugin a callback to the MC plugin
+     * <p>Initializes the potion with its ingredients (Lavender Sprig, Flobberworm Mucus, Valerian
+     * Sprigs, and Standard Potion Ingredients), description text, flavor text, and potion color.
+     * Sets up the SLEEPING effect that will be applied when the potion is consumed for
+     * approximately 2 minutes of deep sleep.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
     public SLEEPING_DRAUGHT(@NotNull Ollivanders2 plugin) {
         super(plugin);
 
         potionType = O2PotionType.SLEEPING_DRAUGHT;
 
-        text = "A Sleeping Draught causes the drinker to fall almost instantly into a deep, dreamless sleep.";
-
         ingredients.put(O2ItemType.LAVENDER_SPRIG, 4);
         ingredients.put(O2ItemType.FLOBBERWORM_MUCUS, 2);
         ingredients.put(O2ItemType.VALERIAN_SPRIGS, 4);
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 6);
 
+        potionColor = Color.fromRGB(75, 0, 130);
+        potionSuccessMessage = "You fall into a deep, dreamless, enchanted sleep.";
+
+        text = "A Sleeping Draught causes the drinker to fall almost instantly into a deep, dreamless sleep.";
         flavorText.add("\"I've got it all worked out. I've filled these with a simple Sleeping Draught.\" -Hermione Granger");
         flavorText.add("\"You'll need to drink all of this, Harry. It's a potion for dreamless sleep.\" -Madam Pomfrey");
         flavorText.add("\"Then, without the smallest change of expression, they both keeled over backwards on to the floor.\"");
         flavorText.add("\"If I thought I could help you by putting you into an enchanted sleep and allowing you to postpone the moment when you would have to think about what has happened tonight, I would do it. But I know better.\" -Albus Dumbledore");
-
-        potionColor = Color.fromRGB(75, 0, 130);
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Sleeping Draught and fall into an enchanted sleep.
+     *
+     * <p>The effect of this potion depends on whether the player has the AWAKE effect:</p>
+     * <ul>
+     * <li>If the player has the AWAKE effect, the potion is harmless and they return to normal consciousness</li>
+     * <li>If the player does not have the AWAKE effect, they are put into a deep, dreamless sleep
+     *     (SLEEPING effect) for approximately 2 minutes. While asleep, they cannot perform most actions
+     *     and are essentially incapacitated until the effect wears off</li>
+     * </ul>
      *
      * @param player the player who drank the potion
      */
@@ -56,7 +82,20 @@ public class SLEEPING_DRAUGHT extends O2Potion {
             SLEEPING effect = new SLEEPING(p, 2400, false, player.getUniqueId());
             Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
 
-            player.sendMessage(Ollivanders2.chatColor + "You fall in to a deep, dreamless, enchanted sleep.");
+            player.sendMessage(Ollivanders2.chatColor + "You fall into a deep, dreamless, enchanted sleep.");
         }
+    }
+
+    /**
+     * Get the message shown to players with the AWAKE effect when drinking this potion.
+     *
+     * <p>Returns the special message that is displayed to players who have the AWAKE effect active
+     * when they drink the Sleeping Draught. This message indicates that the potion's sleep effect
+     * is harmless to them due to their immunity to sleep.</p>
+     *
+     * @return the message displayed to awakened players ("You yawn, otherwise nothing happens.")
+     */
+    public String getAwakeEffectMessage() {
+        return awakeEffectMessage;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/STRENGTHENING_SOLUTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/STRENGTHENING_SOLUTION.java
@@ -1,26 +1,40 @@
 package net.pottercraft.ollivanders2.potion;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
 import net.pottercraft.ollivanders2.common.Ollivanders2Common;
+import net.pottercraft.ollivanders2.effect.STRENGTH;
 import net.pottercraft.ollivanders2.item.O2ItemType;
 import org.bukkit.Color;
 import org.bukkit.entity.Player;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Strengthening Solution is a potion that grants the drinker immense strength.
+ * Strengthening Solution - enhances the drinker's physical strength significantly.
  *
- * @since 2.21
+ * <p>When consumed, this potion applies the STRENGTH effect to the player for 5 minutes,
+ * greatly increasing their physical strength and power. The player will deal significantly more
+ * damage with melee attacks and be able to perform stronger physical actions during the effect
+ * duration.</p>
+ *
+ * <p>The 5-minute duration is longer than the standard Minecraft Strength II potion, providing
+ * extended combat advantage. This potion is useful for offensive gameplay, combat scenarios, and
+ * situations requiring physical power.</p>
+ *
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/Strengthening_Solution">https://harrypotter.fandom.com/wiki/Strengthening_Solution</a>
+ * @since 2.21
+ * @see <a href="https://harrypotter.fandom.com/wiki/Strengthening_Solution">Strengthening Solution</a>
  */
 public class STRENGTHENING_SOLUTION extends O2Potion {
     /**
-     * Constructor.
+     * Constructor for Strengthening Solution potion.
      *
-     * @param plugin the callback to the MC plugin
+     * <p>Initializes the potion with its ingredients (Salamander Blood, Powdered Griffin Claw,
+     * Ground Snake Fangs, and Standard Potion Ingredients), description text, flavor text, potion
+     * color, and the Strength effect. Sets up the 5-minute duration for the strength
+     * enhancement effect.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
     public STRENGTHENING_SOLUTION(@NotNull Ollivanders2 plugin) {
         super(plugin);
@@ -32,27 +46,32 @@ public class STRENGTHENING_SOLUTION extends O2Potion {
         ingredients.put(O2ItemType.GROUND_SNAKE_FANGS, 1);
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 2);
 
-        text = "A Strengthening Solution gives the drinking immense strength.";
-        flavorText.add("\"Well, the class seems fairly advanced for their level. Though I would question whether it is advisable to teach them a potion like the Strengthening Solution. I think the Ministry would prefer it if that was removed from the syllabus.\" -Dolores Umbridge");
-        flavorText.add("\"We are continuing with our Strengthening Solutions today, you will find your mixtures as you left them last lesson, if correctly made they should have matured well over the weekend — instructions — on the board. Carry on.\" -Severus Snape");
-
         // potion color
         potionColor = Color.fromRGB(54, 224, 208); // turquoise
-
         // last 5 minutes, which is longer than strength II lasts
         duration = Ollivanders2Common.ticksPerMinute * 5;
+        potionSuccessMessage = "You feel incredibly strong.";
 
-        // Strength II
-        minecraftPotionEffect = new PotionEffect(PotionEffectType.STRENGTH, duration, 1);
+        text = "A Strengthening Solution gives the drinker immense strength.";
+        flavorText.add("\"Well, the class seems fairly advanced for their level. Though I would question whether it is advisable to teach them a potion like the Strengthening Solution. I think the Ministry would prefer it if that was removed from the syllabus.\" -Dolores Umbridge");
+        flavorText.add("\"We are continuing with our Strengthening Solutions today, you will find your mixtures as you left them last lesson, if correctly made they should have matured well over the weekend — instructions — on the board. Carry on.\" -Severus Snape");
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Strengthening Solution and gain immense physical strength.
+     *
+     * <p>Applies the STRENGTH effect to the player for 5 minutes. This effect significantly
+     * increases the player's melee damage output and physical power, allowing them to deal much
+     * more damage with attacks. The strength bonus is particularly useful for combat scenarios and
+     * defeating enemies.</p>
      *
      * @param player the player who drank the potion
      */
     @Override
     public void drink(@NotNull Player player) {
-        player.sendMessage(Ollivanders2.chatColor + "You feel as though ice flows through your body.");
+        STRENGTH effect = new STRENGTH(p, duration, false, player.getUniqueId());
+        Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
+
+        player.sendMessage(Ollivanders2.chatColor + potionSuccessMessage);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/SWELLING_SOLUTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/SWELLING_SOLUTION.java
@@ -10,30 +10,45 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * The Swelling Solution is a potion which causes whatever it touched to swell in size.
+ * Swelling Solution - causes the drinker to grow in size.
+ *
+ * <p>When consumed, this potion applies the SWELLING effect to the player for 5 minutes,
+ * causing them to become larger in physical size. The swelling effect can impact movement,
+ * interactions with the world, and overall gameplay mechanics. Players affected by this potion
+ * will experience difficulty navigating tight spaces and may have altered physics.</p>
+ *
+ * <p>The swelling effect is temporary and will wear off after the duration expires, returning
+ * the player to their normal size. This potion is primarily a transformative or debilitating
+ * effect useful for puzzle-solving, exploration challenges, or roleplay scenarios.</p>
  *
  * @author Azami7
- * @see <a href="https://harrypotter.fandom.com/wiki/Swelling_Solution">https://harrypotter.fandom.com/wiki/Swelling_Solution</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Swelling_Solution">Swelling Solution</a>
  */
 public class SWELLING_SOLUTION extends O2Potion {
     /**
-     * Constructor
+     * Constructor for Swelling Solution potion.
      *
-     * @param plugin a callback to the plugin
+     * <p>Initializes the potion with its ingredients (Dried Nettles, Pufferfish Eye, Bat Spleen,
+     * and Standard Potion Ingredients), description text, flavor text, and potion color. Sets up
+     * the SWELLING effect that will be applied when the potion is consumed for 5 minutes.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
     public SWELLING_SOLUTION(@NotNull Ollivanders2 plugin) {
         super(plugin);
 
-        // potion config
         potionType = O2PotionType.SWELLING_SOLUTION;
-        potionColor = Color.fromRGB(218, 165, 32); // goldenrod
-        duration = Ollivanders2Common.ticksPerMinute * 5;
 
         // ingredients
         ingredients.put(O2ItemType.DRIED_NETTLES, 3);
         ingredients.put(O2ItemType.PUFFERFISH_EYE, 3);
         ingredients.put(O2ItemType.BAT_SPLEEN, 1);
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 3);
+
+        // potion config
+        potionColor = Color.fromRGB(218, 165, 32); // goldenrod
+        duration = Ollivanders2Common.ticksPerMinute * 5;
+        potionSuccessMessage = "You feel yourself expanding.";
 
         // spellbook text
         text = "The Swelling Solution will cause the drinker to grow in size.";
@@ -43,7 +58,13 @@ public class SWELLING_SOLUTION extends O2Potion {
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Swelling Solution and grow in size.
+     *
+     * <p>Applies the SWELLING effect to the player for 5 minutes. This effect causes the player
+     * to physically grow in size, which can affect their movement, interactions with the world,
+     * and overall gameplay mechanics. The player will experience difficulty navigating tight spaces
+     * and may encounter altered physics while swollen. The swelling effect is temporary and will
+     * wear off after the duration expires.</p>
      *
      * @param player the player who drank the potion
      */
@@ -53,6 +74,6 @@ public class SWELLING_SOLUTION extends O2Potion {
         SWELLING effect = new SWELLING(p, duration, false, player.getUniqueId());
         Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
 
-        player.sendMessage(Ollivanders2.chatColor + "You feel yourself expanding.");
+        player.sendMessage(Ollivanders2.chatColor + potionSuccessMessage);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/WEAKNESS_POTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/WEAKNESS_POTION.java
@@ -1,28 +1,48 @@
 package net.pottercraft.ollivanders2.potion;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
 import net.pottercraft.ollivanders2.common.Ollivanders2Common;
+import net.pottercraft.ollivanders2.effect.WEAKNESS;
 import net.pottercraft.ollivanders2.item.O2ItemType;
 import org.bukkit.Color;
 import org.bukkit.entity.Player;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Weakness potion add the Weakness potion effect.
+ * Weakness Potion - significantly reduces the drinker's physical strength.
+ *
+ * <p>When consumed, this potion applies the WEAKNESS II effect to the player for 5 minutes,
+ * drastically reducing their melee damage output and overall physical strength. This is a
+ * debilitating potion that makes combat much more difficult and is useful for handicapping
+ * opponents or creating challenging gameplay scenarios.</p>
+ *
+ * <p>While weakened, players deal significantly less damage with all melee attacks and may
+ * struggle with physically demanding tasks. The weakness effect can be strategically used in
+ * PvP situations or as an obstacle in puzzles and challenges.</p>
  *
  * @author Azami7
  * @since 2.21
  */
 public class WEAKNESS_POTION extends O2Potion {
+    /**
+     * Constructor for Weakness Potion.
+     *
+     * <p>Initializes the potion with its ingredients (Flobberworm Mucus, Valerian Root, Leech
+     * Juice, Doxy Venom, and Standard Potion Ingredients), description text, potion color, and
+     * the Weakness II potion effect. Sets up the 5-minute duration for the weakness effect.</p>
+     *
+     * @param plugin a callback to the plugin instance
+     */
     public WEAKNESS_POTION(@NotNull Ollivanders2 plugin) {
         super(plugin);
 
         // potion config
         potionType = O2PotionType.WEAKNESS_POTION;
+
         potionColor = Color.fromRGB(244, 164, 96); // light brown
         duration = Ollivanders2Common.ticksPerMinute * 5;
+        potionSuccessMessage = "You feel drained of strength.";
 
         // ingredients
         ingredients.put(O2ItemType.FLOBBERWORM_MUCUS, 1);
@@ -33,18 +53,24 @@ public class WEAKNESS_POTION extends O2Potion {
 
         // spellbook text
         text = "The weakness potion will drain the drinker of strength.";
-
-        // Weakness II
-        minecraftPotionEffect = new PotionEffect(PotionEffectType.WEAKNESS, duration, 1);
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Weakness Potion and suffer reduced strength.
+     *
+     * <p>Applies the WEAKNESS II effect to the player for 5 minutes. This effect significantly
+     * reduces the player's melee damage output, making all attacks deal much less damage. While
+     * weakened, players will struggle in combat situations and may have difficulty with
+     * physically demanding tasks. The weakness effect is temporary and will wear off after
+     * the duration expires.</p>
      *
      * @param player the player who drank the potion
      */
     @Override
     public void drink(@NotNull Player player) {
-        player.sendMessage(Ollivanders2.chatColor + "You feel drained of strength.");
+        WEAKNESS effect = new WEAKNESS(p, duration, false, player.getUniqueId());
+        Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
+
+        player.sendMessage(Ollivanders2.chatColor + potionSuccessMessage);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/WIDEYE_POTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/WIDEYE_POTION.java
@@ -9,16 +9,29 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Wideye potion prevents the drinker from falling asleep.
+ * Wideye Potion (Awakening Potion) - grants immunity to sleep effects.
+ *
+ * <p>When consumed, this potion applies the AWAKE effect to the player, preventing them from
+ * being put to sleep by sleep-inducing potions such as the Sleeping Draught or Draught of Living
+ * Death. While the AWAKE effect is active, the player is immune to all sleep-related magical
+ * effects and cannot be forced into sleep.</p>
+ *
+ * <p>This potion serves as a critical counter to sleeping potions and is essential for survival
+ * in situations where sleep effects might be used as an attack or punishment. Players with the
+ * AWAKE effect remain fully conscious and able to act.</p>
  *
  * @author Azami7
  * @since 2.2.8
  */
 public class WIDEYE_POTION extends O2Potion {
     /**
-     * Constructor
+     * Constructor for Wideye Potion (Awakening Potion).
      *
-     * @param plugin a callback to the plugin
+     * <p>Initializes the potion with its ingredients (Ground Snake Fangs, Billywig Sting Slime,
+     * Wolfsbane, and Standard Potion Ingredients), description text, and potion color. Sets up
+     * the AWAKE effect that will be applied when the potion is consumed to grant sleep immunity.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
     public WIDEYE_POTION(@NotNull Ollivanders2 plugin) {
         super(plugin);
@@ -30,13 +43,19 @@ public class WIDEYE_POTION extends O2Potion {
         ingredients.put(O2ItemType.WOLFSBANE, 2);
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 4);
 
-        text = "The Wideye Potion, also known as the Awakening Potion, is used to prevent the drinker from falling asleep.";
-
         potionColor = Color.fromRGB(13, 55, 13);
+        potionSuccessMessage = "You feel alert.";
+
+        text = "The Wideye Potion, also known as the Awakening Potion, is used to prevent the drinker from falling asleep.";
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Wideye Potion and become immune to sleep effects.
+     *
+     * <p>Applies the AWAKE effect to the player for the default potion duration. While this effect
+     * is active, the player is completely immune to all sleep-inducing potions and effects,
+     * including the Sleeping Draught and Draught of Living Death. The AWAKE effect is a critical
+     * defensive tool for countering sleep-based attacks and protecting against magical incapacitation.</p>
      *
      * @param player the player who drank the potion
      */
@@ -45,6 +64,6 @@ public class WIDEYE_POTION extends O2Potion {
         AWAKE effect = new AWAKE(p, duration, false, player.getUniqueId());
         Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
 
-        player.sendMessage(Ollivanders2.chatColor + "You feel alert.");
+        player.sendMessage(Ollivanders2.chatColor + potionSuccessMessage);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/WIGGENWELD_POTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/WIGGENWELD_POTION.java
@@ -13,17 +13,36 @@ import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * The Wiggenweld Potion is a healing potion with the power to awaken a person from a magically-induced sleep, which
- * gives it the ability to reverse the effects of potions like the Sleeping Draught and the Draught of Living Death.
+ * Wiggenweld Potion - a powerful healing potion that awakens sleeping players.
+ *
+ * <p>This splash potion is a critical tool for reversing sleep effects. When thrown, it removes
+ * the SLEEPING effect from all affected players, instantly awakening them from magically-induced
+ * sleep such as that caused by the Sleeping Draught or Draught of Living Death. The potion
+ * provides both healing through an Instant Health effect and awakening functionality.</p>
+ *
+ * <p>As a splash potion, the Wiggenweld Potion is thrown rather than consumed directly. The healing
+ * effect affects all entities in the splash radius, while the awakening effect specifically targets
+ * and wakes sleeping players. This makes it an essential potion for countering sleep-based attacks
+ * and rescuing incapacitated allies.</p>
+ *
+ * <p>The complex recipe with many rare ingredients reflects the potion's powerful dual-purpose
+ * effects.</p>
  *
  * @author Azami7
  * @since 2.2.8
  */
 public class WIGGENWELD_POTION extends O2SplashPotion {
     /**
-     * Constructor
+     * Constructor for Wiggenweld Potion.
      *
-     * @param plugin a callback to the plugin
+     * <p>Initializes the splash potion with its complex recipe of many rare ingredients (Horklump
+     * Juice, Flobberworm Mucus, Chizpurfle Fangs, Billywig Sting Slime, Mint Sprig, Boom Berry
+     * Juice, Mandrake Leaf, Honeywater, Sloth Brain Mucus, Moondew Drop, Salamander Blood,
+     * Lionfish Spines, Unicorn Horn, Wolfsbane, and Standard Potion Ingredients), description text,
+     * flavor text, potion color, and the Instant Health effect. Sets up the dual awakening and
+     * healing functionality of this powerful potion.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
     public WIGGENWELD_POTION(@NotNull Ollivanders2 plugin) {
         super(plugin);
@@ -54,18 +73,29 @@ public class WIGGENWELD_POTION extends O2SplashPotion {
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Wiggenweld Potion - no effect when consumed directly.
+     *
+     * <p>This is a splash potion intended to be thrown, not consumed. Drinking it has no special
+     * effect. The potion's primary functionality is triggered through the splash event when thrown,
+     * which removes the SLEEPING effect from affected players and applies the healing effect.</p>
      *
      * @param player the player who drank the potion
      */
     @Override
     public void drink(@NotNull Player player) {
+        // No effect when drunk - this is a splash potion
     }
 
     /**
-     * Do the effect this potion has when thrown.
+     * Handle the splash potion event and awaken sleeping players.
      *
-     * @param event the splash potion thrown event
+     * <p>When the Wiggenweld Potion splashes, it removes the SLEEPING effect from all affected
+     * players in the splash radius. This instantly wakes any players who are magically asleep due
+     * to the Sleeping Draught, Draught of Living Death, or other sleep-inducing effects. The
+     * potion's healing effect (Instant Health II) is automatically applied through the standard
+     * Minecraft potion system.</p>
+     *
+     * @param event the splash potion event containing affected entities and splash location
      */
     @Override
     public void doOnPotionSplashEvent(@NotNull PotionSplashEvent event) {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/WIT_SHARPENING_POTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/WIT_SHARPENING_POTION.java
@@ -9,16 +9,29 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * The Wit-Sharpening Potion is a potion which allows the drinker to think more clearly. Due to this, it acts a
- * counteragent to the Confundus Charm.
+ * Wit-Sharpening Potion - enhances mental clarity and learning ability.
+ *
+ * <p>When consumed, this potion applies the IMPROVED_BOOK_LEARNING effect to the player,
+ * significantly enhancing their ability to learn from books and magical instruction. The potion
+ * allows the drinker to think more clearly and comprehend complex information more easily. This
+ * makes it useful for studying spells, potions, and other magical knowledge from books.</p>
+ *
+ * <p>The enhanced clarity and learning ability serve as a counteragent to confusion effects, helping
+ * players overcome mental fog and disorientation. This potion is particularly valuable for
+ * accelerating learning and improving study effectiveness.</p>
  *
  * @author Azami7
  */
 public final class WIT_SHARPENING_POTION extends O2Potion {
     /**
-     * Constructor
+     * Constructor for Wit-Sharpening Potion.
      *
-     * @param plugin a callback to the plugin
+     * <p>Initializes the potion with its ingredients (Ginger Root, Ground Scarab Beetle, Armadillo
+     * Bile, and Standard Potion Ingredients), description text, flavor text, and potion color.
+     * Sets up the IMPROVED_BOOK_LEARNING effect that will be applied when the potion is consumed
+     * to enhance mental clarity and learning ability.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
     public WIT_SHARPENING_POTION(@NotNull Ollivanders2 plugin) {
         super(plugin);
@@ -30,15 +43,21 @@ public final class WIT_SHARPENING_POTION extends O2Potion {
         ingredients.put(O2ItemType.ARMADILLO_BILE, 2);
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 2);
 
-        text = "The Wit-Sharpening Potion is a potion which allows the drinker to think more clearly. Due to this, it acts"
+        potionColor = Color.fromRGB(204, 102, 0);
+        potionSuccessMessage = "You feel ready to learn.";
+
+        text = "The Wit-Sharpening Potion is a potion which allows the drinker to think more clearly. Due to this, it acts "
                 + "as a counteragent to the Confundus Charm.";
         flavorText.add("\"Some of you will benefit from today's assignment: Wit-Sharpening Potion. Perhaps you should begin immediately.\" -Severus Snape");
-
-        potionColor = Color.fromRGB(204, 102, 0);
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Wit-Sharpening Potion and enhance mental clarity.
+     *
+     * <p>Applies the IMPROVED_BOOK_LEARNING effect to the player for the default potion duration.
+     * This effect enhances the player's ability to learn from books and magical instruction,
+     * allowing them to understand complex concepts more easily and gain knowledge more quickly.
+     * The improved mental clarity helps overcome confusion and improves cognitive function.</p>
      *
      * @param player the player who drank the potion
      */
@@ -47,6 +66,6 @@ public final class WIT_SHARPENING_POTION extends O2Potion {
         IMPROVED_BOOK_LEARNING effect = new IMPROVED_BOOK_LEARNING(p, duration, false, player.getUniqueId());
         Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
 
-        player.sendMessage(Ollivanders2.chatColor + "You feel ready to learn.");
+        player.sendMessage(Ollivanders2.chatColor + potionSuccessMessage);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/potion/WOLFSBANE_POTION.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/potion/WOLFSBANE_POTION.java
@@ -9,16 +9,31 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Relieve the symptoms of Lycanthropy
+ * Wolfsbane Potion - relieves the symptoms of Lycanthropy.
+ *
+ * <p>When consumed, this potion applies the LYCANTHROPY_RELIEF effect to the player, alleviating
+ * the severe symptoms of Lycanthropy (werewolf curse). While this potion does not cure the condition
+ * entirely, it greatly reduces the symptoms' severity, allowing affected players to function more
+ * normally during their afflicted state. This potion is essential for managing the debilitating
+ * effects of Lycanthropy and represents the most advanced potion-making techniques available.</p>
+ *
+ * <p>The LYCANTHROPY_RELIEF effect provides temporary respite from the worst aspects of the curse,
+ * making this a critical potion for those affected by Lycanthropy. As an advanced potion with a
+ * complex recipe, it requires significant potion-making skill to brew successfully.</p>
  *
  * @author Azami7
  * @author cakenggt
  */
 public final class WOLFSBANE_POTION extends O2Potion {
     /**
-     * Constructor
+     * Constructor for Wolfsbane Potion.
      *
-     * @param plugin a callback to the plugin
+     * <p>Initializes the potion with its complex recipe of rare ingredients (Wolfsbane, Mandrake
+     * Leaf, Poisonous Potato, Dittany, and Standard Potion Ingredients), description text, flavor
+     * text, potion color, and the LYCANTHROPY_RELIEF effect. Sets up the potion as an advanced
+     * brewing recipe reflecting the complexity of managing Lycanthropy symptoms.</p>
+     *
+     * @param plugin a callback to the plugin instance
      */
     public WOLFSBANE_POTION(@NotNull Ollivanders2 plugin) {
         super(plugin);
@@ -31,15 +46,24 @@ public final class WOLFSBANE_POTION extends O2Potion {
         ingredients.put(O2ItemType.DITTANY, 2);
         ingredients.put(O2ItemType.STANDARD_POTION_INGREDIENT, 3);
 
-        text = "This potion will relieve, though not cure, the symptoms of Lycanthropy. It is a complex potion and requires"
+        potionColor = Color.fromRGB(51, 0, 102);
+        potionSuccessMessage = "You feel a sense of relief.";
+
+        text = "This potion will relieve, though not cure, the symptoms of Lycanthropy. It is a complex potion and requires "
                 + "the most advanced potion-making skills.";
 
         flavorText.add("\"There is no known cure, although recent developments in potion-making have to a great extent alleviated the worst symptoms.\" —Newton Scamander");
-        potionColor = Color.fromRGB(51, 0, 102);
     }
 
     /**
-     * Drink this potion and do effects
+     * Drink the Wolfsbane Potion and relieve Lycanthropy symptoms.
+     *
+     * <p>Applies the LYCANTHROPY_RELIEF effect to the player for the default potion duration.
+     * This effect alleviates the severe symptoms of Lycanthropy, providing temporary relief from
+     * the curse's worst manifestations. While the potion does not cure Lycanthropy entirely, it
+     * greatly reduces the debilitating symptoms and allows the affected player to function more
+     * normally during the effect duration. The relief is temporary and will wear off after the
+     * effect expires.</p>
      *
      * @param player the player who drank the potion
      */
@@ -48,6 +72,6 @@ public final class WOLFSBANE_POTION extends O2Potion {
         LYCANTHROPY_RELIEF effect = new LYCANTHROPY_RELIEF(p, duration, false, player.getUniqueId());
         Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
 
-        player.sendMessage(Ollivanders2.chatColor + "You feel a sense of relief.");
+        player.sendMessage(Ollivanders2.chatColor + potionSuccessMessage);
     }
 }

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/common/Ollivanders2CommonTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/common/Ollivanders2CommonTest.java
@@ -405,11 +405,11 @@ public class Ollivanders2CommonTest {
 
         String received = player1.nextMessage();
         assertNotNull(received, "player1.nextMessage() was null");
-        assertTrue(TestCommon.messageEquals(testMessage, received), "Player1 did not receive correct message, expected: " + testMessage + ", actual: " + received);
+        assertEquals(testMessage, TestCommon.cleanChatMessage(received), "Player1 did not receive correct message");
 
         received = player2.nextMessage();
         assertNotNull(received, "player2.nextMessage() was null");
-        assertTrue(TestCommon.messageEquals(testMessage, received), "Player2 did not receive correct message, expected: " + testMessage + ", actual: " + received);
+        assertEquals(testMessage, TestCommon.cleanChatMessage(received), "Player2 did not receive correct message");
 
         received = player3.nextMessage();
         assertNull(received, "player3.nextMessage() was not null");

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/effect/FireResistanceTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/effect/FireResistanceTest.java
@@ -1,0 +1,32 @@
+package net.pottercraft.ollivanders2.test.effect;
+
+import net.pottercraft.ollivanders2.effect.FIRE_RESISTANCE;
+import org.bukkit.entity.Player;
+
+/**
+ * Test suite for the FIRE_RESISTANCE effect.
+ *
+ * <p>Verifies that the FIRE_RESISTANCE effect functions correctly when applied to players.
+ * Tests the effect's properties, duration handling, and permanent effect support using the
+ * base test infrastructure.</p>
+ *
+ * @see PotionEffectSuperTest for the base test infrastructure
+ */
+public class FireResistanceTest extends PotionEffectSuperTest {
+    /**
+     * Create a FIRE_RESISTANCE effect instance for testing.
+     *
+     * <p>Instantiates a new FIRE_RESISTANCE effect with the specified duration and permanent flag.
+     * This method is called by the inherited test framework to create effect instances for
+     * testing various duration scenarios and permanent effect handling.</p>
+     *
+     * @param target the player who will be affected by the effect
+     * @param durationInTicks the duration of the effect in server ticks
+     * @param isPermanent whether the effect should be permanent
+     * @return a new FIRE_RESISTANCE effect instance
+     */
+    @Override
+    FIRE_RESISTANCE createEffect(Player target, int durationInTicks, boolean isPermanent) {
+        return new FIRE_RESISTANCE(testPlugin, durationInTicks, isPermanent, target.getUniqueId());
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/effect/RegenerationTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/effect/RegenerationTest.java
@@ -1,0 +1,32 @@
+package net.pottercraft.ollivanders2.test.effect;
+
+import net.pottercraft.ollivanders2.effect.REGENERATION;
+import org.bukkit.entity.Player;
+
+/**
+ * Test suite for the REGENERATION effect.
+ *
+ * <p>Verifies that the REGENERATION effect functions correctly when applied to players.
+ * Tests the effect's properties, duration handling, and permanent effect support using the
+ * base test infrastructure.</p>
+ *
+ * @see PotionEffectSuperTest for the base test infrastructure
+ */
+public class RegenerationTest extends PotionEffectSuperTest {
+    /**
+     * Create a REGENERATION effect instance for testing.
+     *
+     * <p>Instantiates a new REGENERATION effect with the specified duration and permanent flag.
+     * This method is called by the inherited test framework to create effect instances for
+     * testing various duration scenarios and permanent effect handling.</p>
+     *
+     * @param target the player who will be affected by the effect
+     * @param durationInTicks the duration of the effect in server ticks
+     * @param isPermanent whether the effect should be permanent
+     * @return a new REGENERATION effect instance
+     */
+    @Override
+    REGENERATION createEffect(Player target, int durationInTicks, boolean isPermanent) {
+        return new REGENERATION(testPlugin, durationInTicks, isPermanent, target.getUniqueId());
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/effect/SatiationTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/effect/SatiationTest.java
@@ -1,0 +1,32 @@
+package net.pottercraft.ollivanders2.test.effect;
+
+import net.pottercraft.ollivanders2.effect.SATIATION;
+import org.bukkit.entity.Player;
+
+/**
+ * Test suite for the SATIATION effect.
+ *
+ * <p>Verifies that the SATIATION effect functions correctly when applied to players.
+ * Tests the effect's properties, duration handling, and permanent effect support using the
+ * base test infrastructure.</p>
+ *
+ * @see PotionEffectSuperTest for the base test infrastructure
+ */
+public class SatiationTest extends PotionEffectSuperTest {
+    /**
+     * Create a SATIATION effect instance for testing.
+     *
+     * <p>Instantiates a new SATIATION effect with the specified duration and permanent flag.
+     * This method is called by the inherited test framework to create effect instances for
+     * testing various duration scenarios and permanent effect handling.</p>
+     *
+     * @param target the player who will be affected by the effect
+     * @param durationInTicks the duration of the effect in server ticks
+     * @param isPermanent whether the effect should be permanent
+     * @return a new SATIATION effect instance
+     */
+    @Override
+    SATIATION createEffect(Player target, int durationInTicks, boolean isPermanent) {
+        return new SATIATION(testPlugin, durationInTicks, isPermanent, target.getUniqueId());
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/effect/StrengthTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/effect/StrengthTest.java
@@ -1,0 +1,32 @@
+package net.pottercraft.ollivanders2.test.effect;
+
+import net.pottercraft.ollivanders2.effect.STRENGTH;
+import org.bukkit.entity.Player;
+
+/**
+ * Test suite for the STRENGTH effect.
+ *
+ * <p>Verifies that the STRENGTH effect functions correctly when applied to players.
+ * Tests the effect's properties, duration handling, and permanent effect support using the
+ * base test infrastructure.</p>
+ *
+ * @see PotionEffectSuperTest for the base test infrastructure
+ */
+public class StrengthTest extends PotionEffectSuperTest {
+    /**
+     * Create a STRENGTH effect instance for testing.
+     *
+     * <p>Instantiates a new STRENGTH effect with the specified duration and permanent flag.
+     * This method is called by the inherited test framework to create effect instances for
+     * testing various duration scenarios and permanent effect handling.</p>
+     *
+     * @param target the player who will be affected by the effect
+     * @param durationInTicks the duration of the effect in server ticks
+     * @param isPermanent whether the effect should be permanent
+     * @return a new STRENGTH effect instance
+     */
+    @Override
+    STRENGTH createEffect(Player target, int durationInTicks, boolean isPermanent) {
+        return new STRENGTH(testPlugin, durationInTicks, isPermanent, target.getUniqueId());
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/AnimagusPotionTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/AnimagusPotionTest.java
@@ -1,0 +1,138 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.effect.ANIMAGUS_INCANTATION;
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.player.O2Player;
+import net.pottercraft.ollivanders2.potion.ANIMAGUS_POTION;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test suite for the Animagus Potion effect.
+ *
+ * <p>Verifies that the Animagus Potion correctly grants the ANIMAGUS_EFFECT to players who meet
+ * specific conditions: they must have the ANIMAGUS_INCANTATION effect and the weather must be
+ * thundering. Tests multiple scenarios including failure cases (missing incantation or wrong weather)
+ * and success cases (all conditions met). Also tests behavior when a player is already an animagus.</p>
+ */
+public class AnimagusPotionTest {
+    /**
+     * Shared mock Bukkit server instance for all tests.
+     *
+     * <p>Static field initialized once before all tests in this class. Reused across test instances
+     * to avoid expensive server setup/teardown for each test method.</p>
+     */
+    static ServerMock mockServer;
+
+    /**
+     * The plugin instance being tested.
+     *
+     * <p>Loaded once before all tests with the default configuration. Provides access to
+     * logger, scheduler, and other plugin API methods during tests.</p>
+     */
+    static Ollivanders2 testPlugin;
+
+    /**
+     * Initialize the mock Bukkit server before all tests.
+     *
+     * <p>Static setup method called once before all tests in this class. Creates the shared
+     * MockBukkit server instance that is reused across all test methods to avoid expensive
+     * server creation/destruction overhead.</p>
+     */
+    @BeforeAll
+    static void globalSetUp() {
+        Ollivanders2.testMode = true;
+
+        mockServer = MockBukkit.mock();
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+
+        // advance the server by 20 ticks to let the scheduler start (it has an initial delay of 20 ticks)
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
+    }
+
+    /**
+     * Test the Animagus Potion's effect under various conditions.
+     *
+     * <p>This comprehensive test verifies four distinct scenarios:</p>
+     * <ol>
+     *   <li><b>No incantation:</b> Player without ANIMAGUS_INCANTATION receives failure message and no effect</li>
+     *   <li><b>Wrong weather:</b> Player with ANIMAGUS_INCANTATION but no thunder receives failure message and no effect</li>
+     *   <li><b>Success:</b> Player with ANIMAGUS_INCANTATION during thundering weather receives success message,
+     *       gains ANIMAGUS_EFFECT, and loses ANIMAGUS_INCANTATION</li>
+     *   <li><b>Already animagus:</b> Player who is already an animagus receives the already-animagus message</li>
+     * </ol>
+     */
+    @Test
+    void drinkTest() {
+        PlayerMock player = mockServer.addPlayer();
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 4, 100);
+        ANIMAGUS_POTION potion = new ANIMAGUS_POTION(testPlugin);
+
+        player.setLocation(location);
+
+        // player does not have animagus incantation effect and wrong weather, nothing happens
+        potion.drink(player);
+        String potionMessage = player.nextMessage();
+        assertNotNull(potionMessage);
+        assertEquals(potion.getPotionFailureMessage(), TestCommon.cleanChatMessage(potionMessage), "Player did not get expected potion failure message");
+        assertFalse(Ollivanders2API.getPlayers().playerEffects.hasEffect(player.getUniqueId(), O2EffectType.ANIMAGUS_EFFECT), "Animagus effect set on player when they did not have animagus incantation");
+
+        // player has animagus incantation but it is not thundering
+        ANIMAGUS_INCANTATION animagusIncantation = new ANIMAGUS_INCANTATION(testPlugin, 1000, false, player.getUniqueId());
+        Ollivanders2API.getPlayers().playerEffects.addEffect(animagusIncantation);
+        mockServer.getScheduler().performTicks(20);
+        potion.drink(player);
+        potionMessage = player.nextMessage();
+        assertNotNull(potionMessage);
+        assertEquals(potion.getPotionFailureMessage(), TestCommon.cleanChatMessage(potionMessage), "Player did not get expected potion failure message");
+        assertFalse(Ollivanders2API.getPlayers().playerEffects.hasEffect(player.getUniqueId(), O2EffectType.ANIMAGUS_EFFECT), "Animagus effect set when it was not thundering");
+
+        // player had animagus incantation and it is thundering
+        testWorld.setThundering(true);
+        potion.drink(player);
+        mockServer.getScheduler().performTicks(20);
+        potionMessage = player.nextMessage();
+        assertNotNull(potionMessage);
+        assertEquals(potion.getPotionSuccessMessage(), TestCommon.cleanChatMessage(potionMessage), "Player did not get potion success message");
+        assertTrue(Ollivanders2API.getPlayers().playerEffects.hasEffect(player.getUniqueId(), O2EffectType.ANIMAGUS_EFFECT), "Animagus effect not set");
+        assertFalse(Ollivanders2API.getPlayers().playerEffects.hasEffect(player.getUniqueId(), O2EffectType.ANIMAGUS_INCANTATION), "Animagus incantation effect not removed");
+
+        PlayerMock player2 = mockServer.addPlayer();
+        O2Player o2player2 = Ollivanders2API.getPlayers().getPlayer(player2.getUniqueId());
+        assertNotNull(o2player2);
+        o2player2.setIsAnimagus();
+        potion.drink(player2);
+        potionMessage = player2.nextMessage();
+        assertNotNull(potionMessage);
+        assertEquals(potion.getAlreadyAnimagusMessage(), TestCommon.cleanChatMessage(potionMessage), "Player2 did not get already animagus message");
+    }
+
+    /**
+     * Tear down the mock Bukkit server after all tests complete.
+     *
+     * <p>Static teardown method called once after all tests in this class have finished.
+     * Releases the MockBukkit server resources to prevent memory leaks and allow clean
+     * test execution in subsequent test classes.</p>
+     */
+    @AfterAll
+    static void globalTearDown() {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/BabblingBeverageTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/BabblingBeverageTest.java
@@ -1,0 +1,29 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Test suite for the Babbling Beverage potion effect.
+ *
+ * <p>Verifies that the Babbling Beverage potion correctly applies the BABBLING effect to players
+ * when consumed. Tests both the player feedback message and the effect application to ensure
+ * the potion functions as intended.</p>
+ *
+ * @see PotionTestSuper for the base test infrastructure
+ */
+public class BabblingBeverageTest extends PotionTestSuper {
+    /**
+     * Set up the test by specifying the potion type to test.
+     *
+     * <p>Initializes the test to use the BABBLING_BEVERAGE potion type and the BABBLING effect.
+     * This method is called before each test to ensure the correct potion is being tested by the
+     * inherited drinkTest() method.</p>
+     */
+    @Override @BeforeEach
+    void setUp() {
+        potionType = O2PotionType.BABBLING_BEVERAGE;
+        effectType = O2EffectType.BABBLING;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/BaruffiosBrainElixirTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/BaruffiosBrainElixirTest.java
@@ -1,0 +1,29 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Test suite for the Baruffios Brain Elixir potion effect.
+ *
+ * <p>Verifies that the Baruffios Brain Elixir potion correctly applies the HIGHER_SKILL effect to players
+ * when consumed. Tests both the player feedback message and the effect application to ensure
+ * the potion functions as intended.</p>
+ *
+ * @see PotionTestSuper for the base test infrastructure
+ */
+public class BaruffiosBrainElixirTest extends PotionTestSuper {
+    /**
+     * Set up the test by specifying the potion type to test.
+     *
+     * <p>Initializes the test to use the BARUFFIOS_BRAIN_ELIXIR potion type and the HIGHER_SKILL effect.
+     * This method is called before each test to ensure the correct potion is being tested by the
+     * inherited drinkTest() method.</p>
+     */
+    @Override @BeforeEach
+    void setUp() {
+        potionType = O2PotionType.BARUFFIOS_BRAIN_ELIXIR;
+        effectType = O2EffectType.HIGHER_SKILL;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/CommonAntidotePotionTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/CommonAntidotePotionTest.java
@@ -1,0 +1,119 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.potion.COMMON_ANTIDOTE_POTION;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Test suite for the Common Antidote Potion effect.
+ *
+ * <p>Verifies that the Common Antidote Potion correctly removes poison effects from players
+ * when consumed. Tests both the no-effect scenario (when player has no poison) and the
+ * success scenario (when player has an active poison effect). This potion is designed to
+ * cure poison effects that affect players.</p>
+ */
+public class CommonAntidotePotionTest  {
+    /**
+     * Shared mock Bukkit server instance for all tests.
+     *
+     * <p>Static field initialized once before all tests in this class. Reused across test instances
+     * to avoid expensive server setup/teardown for each test method.</p>
+     */
+    static ServerMock mockServer;
+
+    /**
+     * The plugin instance being tested.
+     *
+     * <p>Loaded once before all tests with the default configuration. Provides access to
+     * logger, scheduler, and other plugin API methods during tests.</p>
+     */
+    static Ollivanders2 testPlugin;
+
+    /**
+     * Initialize the mock Bukkit server before all tests.
+     *
+     * <p>Static setup method called once before all tests in this class. Creates the shared
+     * MockBukkit server instance that is reused across all test methods to avoid expensive
+     * server creation/destruction overhead.</p>
+     */
+    @BeforeAll
+    static void globalSetUp() {
+        Ollivanders2.testMode = true;
+
+        mockServer = MockBukkit.mock();
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+
+        // advance the server by 20 ticks to let the scheduler start (it has an initial delay of 20 ticks)
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
+    }
+
+    /**
+     * Test the Common Antidote Potion's effect on poison and no-effect scenarios.
+     *
+     * <p>This test verifies two scenarios:</p>
+     * <ol>
+     *   <li><b>No-effect scenario:</b> When a player without any poison effect drinks the potion,
+     *       they should receive a "potion has no effect" message</li>
+     *   <li><b>Success scenario:</b> When a player with an active POISON effect drinks the potion,
+     *       the poison effect should be removed and they should receive a success message</li>
+     * </ol>
+     *
+     * <p>The test procedure:</p>
+     * <ol>
+     *   <li>Create a Common Antidote Potion instance</li>
+     *   <li>Create a mock player and have them drink the potion (no poison)</li>
+     *   <li>Verify the player receives the no-effect message</li>
+     *   <li>Apply a POISON effect to the player</li>
+     *   <li>Have the player drink the potion again</li>
+     *   <li>Verify the player receives the success message</li>
+     *   <li>Verify the POISON effect has been removed</li>
+     * </ol>
+     */
+    @Test
+    void drinkTest() {
+        COMMON_ANTIDOTE_POTION potion = new COMMON_ANTIDOTE_POTION(testPlugin);
+        PlayerMock player = mockServer.addPlayer();
+
+        // player does not have poison
+        potion.drink(player);
+
+        String potionMessage = player.nextMessage();
+        assertNotNull(potionMessage);
+        assertEquals(potion.getPotionDoNothingMessage(), TestCommon.cleanChatMessage(potionMessage), "Player did not get expected message when potion has no effect");
+
+        // player has poison
+        player.addPotionEffect(new PotionEffect(PotionEffectType.POISON, 1000, 1));
+        potion.drink(player);
+
+        potionMessage = player.nextMessage();
+        assertNotNull(potionMessage);
+        assertEquals(potion.getPotionSuccessMessage(), TestCommon.cleanChatMessage(potionMessage), "Player did not get expected message when potion succeeded");
+        assertFalse(player.hasPotionEffect(PotionEffectType.POISON), "Player still has POISON effect");
+    }
+
+    /**
+     * Tear down the mock Bukkit server after all tests complete.
+     *
+     * <p>Static teardown method called once after all tests in this class have finished.
+     * Releases the MockBukkit server resources to prevent memory leaks and allow clean
+     * test execution in subsequent test classes.</p>
+     */
+    @AfterAll
+    static void globalTearDown() {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/CureForBoilsTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/CureForBoilsTest.java
@@ -1,0 +1,29 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Test suite for the Cure for Boils potion effect.
+ *
+ * <p>Verifies that the Cure for Boils potion correctly applies the HEAL effect to players
+ * when consumed. Tests both the player feedback message and the effect application to ensure
+ * the potion functions as intended.</p>
+ *
+ * @see PotionTestSuper for the base test infrastructure
+ */
+public class CureForBoilsTest extends PotionTestSuper {
+    /**
+     * Set up the test by specifying the potion type to test.
+     *
+     * <p>Initializes the test to use the CURE_FOR_BOILS potion type and the HEAL effect.
+     * This method is called before each test to ensure the correct potion is being tested by the
+     * inherited drinkTest() method.</p>
+     */
+    @Override @BeforeEach
+    void setUp() {
+        potionType = O2PotionType.CURE_FOR_BOILS;
+        effectType = O2EffectType.HEAL;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/DraughtOfLivingDeathTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/DraughtOfLivingDeathTest.java
@@ -1,0 +1,77 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.effect.AWAKE;
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.potion.DRAUGHT_OF_LIVING_DEATH;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test suite for the Draught of Living Death potion effect.
+ *
+ * <p>Verifies that the Draught of Living Death potion correctly applies the SLEEPING effect to players
+ * when consumed. Tests both the player feedback message and the effect application. Additionally,
+ * tests the special behavior where players with the AWAKE effect are protected from the sleep effect.</p>
+ *
+ * @see PotionTestSuper for the base test infrastructure
+ */
+public class DraughtOfLivingDeathTest extends PotionTestSuper {
+    /**
+     * Set up the test by specifying the potion type to test.
+     *
+     * <p>Initializes the test to use the DRAUGHT_OF_LIVING_DEATH potion type and the SLEEPING effect.
+     * This method is called before each test to ensure the correct potion is being tested by the
+     * inherited drinkTest() method.</p>
+     */
+    @Override @BeforeEach
+    void setUp() {
+        potionType = O2PotionType.DRAUGHT_OF_LIVING_DEATH;
+        effectType = O2EffectType.SLEEPING;
+    }
+
+    /**
+     * Test that the AWAKE effect prevents the Draught of Living Death from inducing sleep.
+     *
+     * <p>Verifies the special interaction between the Draught of Living Death and the AWAKE effect.
+     * When a player with the AWAKE effect (immunity to sleep) drinks the Draught, the potion should
+     * not apply the SLEEPING effect. Instead, the player should receive a special message indicating
+     * they are protected from the sleep effect due to their awake state.</p>
+     *
+     * <p>Test procedure:</p>
+     * <ol>
+     *   <li>Create a mock player and add the AWAKE effect to them</li>
+     *   <li>Have the player drink the Draught of Living Death</li>
+     *   <li>Verify the player receives the special AWAKE effect message</li>
+     *   <li>Verify that the SLEEPING effect was NOT applied to the player</li>
+     * </ol>
+     */
+    @Test
+    void awakeEffectTest() {
+        assertNotNull(potionType, "potionType not set");
+        DRAUGHT_OF_LIVING_DEATH potion = new DRAUGHT_OF_LIVING_DEATH(testPlugin);
+        assertNotNull(potion, "Failed to get O2Potion");
+
+        // add awake effect to player
+        PlayerMock player = mockServer.addPlayer();
+        AWAKE awake = new AWAKE(testPlugin, 1000, false, player.getUniqueId());
+        Ollivanders2API.getPlayers().playerEffects.addEffect(awake);
+        assertTrue(Ollivanders2API.getPlayers().playerEffects.hasEffect(player.getUniqueId(), awake.effectType));
+
+        potion.drink(player);
+
+        String potionMessage = player.nextMessage();
+        assertNotNull(potionMessage);
+        assertEquals(potion.getAwakeEffectMessage(), TestCommon.cleanChatMessage(potionMessage), "Player did not receive expected message after drinking potion");
+
+        assertFalse(Ollivanders2API.getPlayers().playerEffects.hasEffect(player.getUniqueId(), effectType), "SLEEPING effect added when player has AWAKE effect.");
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/ForgetfulnessPotionTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/ForgetfulnessPotionTest.java
@@ -1,0 +1,100 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.potion.FORGETFULNESS_POTION;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test suite for the Forgetfulness Potion effect.
+ *
+ * <p>Verifies that the Forgetfulness Potion correctly decreases the player's experience in
+ * either spells or potions when consumed. Tests that at least one skill decreases to ensure
+ * the potion's intended effect of causing memory loss in magical studies.</p>
+ */
+public class ForgetfulnessPotionTest {
+    /**
+     * Shared mock Bukkit server instance for all tests.
+     *
+     * <p>Static field initialized once before all tests in this class. Reused across test instances
+     * to avoid expensive server setup/teardown for each test method.</p>
+     */
+    static ServerMock mockServer;
+
+    /**
+     * The plugin instance being tested.
+     *
+     * <p>Loaded once before all tests with the default configuration. Provides access to
+     * logger, scheduler, and other plugin API methods during tests.</p>
+     */
+    static Ollivanders2 testPlugin;
+
+    /**
+     * Initialize the mock Bukkit server before all tests.
+     *
+     * <p>Static setup method called once before all tests in this class. Creates the shared
+     * MockBukkit server instance that is reused across all test methods to avoid expensive
+     * server creation/destruction overhead.</p>
+     */
+    @BeforeAll
+    static void globalSetUp() {
+        Ollivanders2.testMode = true;
+
+        mockServer = MockBukkit.mock();
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+
+        // advance the server by 20 ticks to let the scheduler start (it has an initial delay of 20 ticks)
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
+    }
+
+    /**
+     * Test the Forgetfulness Potion's effect on skill experience.
+     *
+     * <p>This test verifies that when a player with known spell and potion skills drinks the
+     * Forgetfulness Potion, at least one of their skill levels decreases as a result of the
+     * potion's memory loss effect. The test sets up both spell and potion experience at level 100,
+     * then verifies that at least one skill level has been reduced after drinking the potion.</p>
+     */
+    @Test
+    void drinkTest() {
+        FORGETFULNESS_POTION potion = new FORGETFULNESS_POTION(testPlugin);
+        PlayerMock player = mockServer.addPlayer();
+
+        O2PotionType knownPotion = O2PotionType.HUNGER_POTION;
+        O2SpellType knownSpell = O2SpellType.ACCIO;
+        int skillLevel = 100;
+        TestCommon.setPlayerPotionExperience(testPlugin, player, knownPotion, skillLevel);
+        TestCommon.setPlayerSpellExperience(testPlugin, player, knownSpell, skillLevel);
+
+        potion.drink(player);
+
+        int potionSkillLevel = TestCommon.getPlayerPotionExperience(testPlugin, player, knownPotion);
+        int spellSkillLevel = TestCommon.getPlayerSpellExperience(testPlugin, player, knownSpell);
+
+        // either the spell skill decreased or the potion skill did
+        assertTrue((potionSkillLevel < skillLevel) || (spellSkillLevel < skillLevel), "Spell or potion skill did not decrease");
+    }
+
+    /**
+     * Tear down the mock Bukkit server after all tests complete.
+     *
+     * <p>Static teardown method called once after all tests in this class have finished.
+     * Releases the MockBukkit server resources to prevent memory leaks and allow clean
+     * test execution in subsequent test classes.</p>
+     */
+    @AfterAll
+    static void globalTearDown() {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/HerbicidePotionTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/HerbicidePotionTest.java
@@ -1,0 +1,106 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpellType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.ThrownPotion;
+import org.bukkit.event.entity.PotionSplashEvent;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+import java.io.File;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test suite for the Herbicide Potion effect.
+ *
+ * <p>Verifies that the Herbicide Potion correctly creates a HERBICIDE stationary spell effect
+ * when the potion splash event occurs. Tests the splash mechanic and stationary spell creation
+ * to ensure the potion functions as intended.</p>
+ */
+public class HerbicidePotionTest {
+    /**
+     * Shared mock Bukkit server instance for all tests.
+     *
+     * <p>Static field initialized once before all tests in this class. Reused across test instances
+     * to avoid expensive server setup/teardown for each test method.</p>
+     */
+    static ServerMock mockServer;
+
+    /**
+     * The plugin instance being tested.
+     *
+     * <p>Loaded once before all tests with the default configuration. Provides access to
+     * logger, scheduler, and other plugin API methods during tests.</p>
+     */
+    static Ollivanders2 testPlugin;
+
+    /**
+     * Initialize the mock Bukkit server before all tests.
+     *
+     * <p>Static setup method called once before all tests in this class. Creates the shared
+     * MockBukkit server instance that is reused across all test methods to avoid expensive
+     * server creation/destruction overhead.</p>
+     */
+    @BeforeAll
+    static void globalSetUp() {
+        Ollivanders2.testMode = true;
+
+        mockServer = MockBukkit.mock();
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+
+        // advance the server by 20 ticks to let the scheduler start (it has an initial delay of 20 ticks)
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
+    }
+
+    /**
+     * Test the Herbicide Potion's splash event behavior.
+     *
+     * <p>This test verifies that when a Herbicide Potion is splashed, it correctly creates a
+     * HERBICIDE stationary spell at the splash location. The test creates a thrown potion item,
+     * triggers a splash event, and then verifies that the stationary spell was created at the
+     * expected location.</p>
+     */
+    @Test
+    void doOnPotionSplashEventTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 4, 100);
+
+        ItemStack potionItemStack = Ollivanders2API.getPotions().getPotionItemStackByType(O2PotionType.HERBICIDE_POTION, 1);
+        assertNotNull(potionItemStack);
+
+        // Spawn the ThrownPotion entity
+        ThrownPotion thrownPotion = testWorld.spawn(location, ThrownPotion.class);
+        thrownPotion.setItem(potionItemStack);
+
+        PotionSplashEvent event = new PotionSplashEvent(thrownPotion, new HashMap<LivingEntity, Double>());
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+
+        assertTrue(Ollivanders2API.getStationarySpells().checkLocationForSpell(location, O2StationarySpellType.HERBICIDE), "Herbicide potion did not create herbicide stationary spell");
+    }
+
+    /**
+     * Tear down the mock Bukkit server after all tests complete.
+     *
+     * <p>Static teardown method called once after all tests in this class have finished.
+     * Releases the MockBukkit server resources to prevent memory leaks and allow clean
+     * test execution in subsequent test classes.</p>
+     */
+    @AfterAll
+    static void globalTearDown() {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/HungerPotionTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/HungerPotionTest.java
@@ -1,0 +1,29 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Test suite for the Hunger Potion effect.
+ *
+ * <p>Verifies that the Hunger Potion correctly applies the HUNGER effect to players
+ * when consumed. Tests both the player feedback message and the effect application to ensure
+ * the potion functions as intended.</p>
+ *
+ * @see PotionTestSuper for the base test infrastructure
+ */
+public class HungerPotionTest extends PotionTestSuper {
+    /**
+     * Set up the test by specifying the potion type to test.
+     *
+     * <p>Initializes the test to use the HUNGER_POTION potion type and the HUNGER effect.
+     * This method is called before each test to ensure the correct potion is being tested by the
+     * inherited drinkTest() method.</p>
+     */
+    @Override @BeforeEach
+    void setUp() {
+        potionType = O2PotionType.HUNGER_POTION;
+        effectType = O2EffectType.HUNGER;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/IcePotionTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/IcePotionTest.java
@@ -1,0 +1,29 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Test suite for the Ice Potion effect.
+ *
+ * <p>Verifies that the Ice Potion correctly applies the FIRE_RESISTANCE effect to players
+ * when consumed. Tests both the player feedback message and the effect application to ensure
+ * the potion functions as intended.</p>
+ *
+ * @see PotionTestSuper for the base test infrastructure
+ */
+public class IcePotionTest extends PotionTestSuper {
+    /**
+     * Set up the test by specifying the potion type to test.
+     *
+     * <p>Initializes the test to use the ICE_POTION potion type and the FIRE_RESISTANCE effect.
+     * This method is called before each test to ensure the correct potion is being tested by the
+     * inherited drinkTest() method.</p>
+     */
+    @Override @BeforeEach
+    void setUp() {
+        potionType = O2PotionType.ICE_POTION;
+        effectType = O2EffectType.FIRE_RESISTANCE;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/MemoryPotionTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/MemoryPotionTest.java
@@ -1,0 +1,29 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Test suite for the Memory Potion effect.
+ *
+ * <p>Verifies that the Memory Potion correctly applies the FAST_LEARNING effect to players
+ * when consumed. Tests both the player feedback message and the effect application to ensure
+ * the potion functions as intended.</p>
+ *
+ * @see PotionTestSuper for the base test infrastructure
+ */
+public class MemoryPotionTest extends PotionTestSuper {
+    /**
+     * Set up the test by specifying the potion type to test.
+     *
+     * <p>Initializes the test to use the MEMORY_POTION potion type and the FAST_LEARNING effect.
+     * This method is called before each test to ensure the correct potion is being tested by the
+     * inherited drinkTest() method.</p>
+     */
+    @Override @BeforeEach
+    void setUp() {
+        potionType = O2PotionType.MEMORY_POTION;
+        effectType = O2EffectType.FAST_LEARNING;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/O2PotionTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/O2PotionTest.java
@@ -1,0 +1,503 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.effect.HIGHER_SKILL;
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.item.O2ItemType;
+import net.pottercraft.ollivanders2.player.O2Player;
+import net.pottercraft.ollivanders2.potion.O2Potion;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class O2PotionTest {
+    /**
+     * Shared mock Bukkit server instance for all tests.
+     *
+     * <p>Static field initialized once before all tests in this class. Reused across test instances
+     * to avoid expensive server setup/teardown for each test method.</p>
+     */
+    static ServerMock mockServer;
+
+    /**
+     * The plugin instance being tested.
+     *
+     * <p>Loaded once before all tests with the default configuration. Provides access to
+     * logger, scheduler, and other plugin API methods during tests.</p>
+     */
+    static Ollivanders2 testPlugin;
+
+    /**
+     * Initialize the mock Bukkit server before all tests.
+     *
+     * <p>Static setup method called once before all tests in this class. Creates the shared
+     * MockBukkit server instance that is reused across all test methods to avoid expensive
+     * server creation/destruction overhead.</p>
+     */
+    @BeforeAll
+    static void globalSetUp() {
+        Ollivanders2.testMode = true;
+
+        mockServer = MockBukkit.mock();
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+
+        // advance the server by 20 ticks to let the scheduler start (it has an initial delay of 20 ticks)
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
+    }
+
+    /**
+     * Test getIngredientsText returns properly formatted ingredient list.
+     * <p>
+     * Since getIngredientsText() is protected, we test it indirectly through getText()
+     * which appends the ingredients text to the description. Verifies that:
+     * <ul>
+     * <li>The text contains "Ingredients:" header</li>
+     * <li>Each ingredient name appears in the text</li>
+     * <li>Each ingredient amount appears in the text</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    void getIngredientsTextTest() {
+        // Get a potion with known ingredients
+        O2PotionType potionType = O2PotionType.CURE_FOR_BOILS;
+        O2Potion potion = Ollivanders2API.getPotions().getPotionFromType(potionType);
+        assertNotNull(potion, "getPotionFromType should return a non-null potion");
+
+        Map<O2ItemType, Integer> ingredients = potion.getIngredients();
+        assertFalse(ingredients.isEmpty(), "Potion should have ingredients");
+
+        // getText() returns description + getIngredientsText()
+        String text = potion.getText();
+        assertNotNull(text, "getText should return non-null text");
+
+        // Verify the "Ingredients:" header is present
+        assertTrue(text.contains("Ingredients:"), "getText should contain 'Ingredients:' header");
+
+        // Verify each ingredient name and amount appears in the text
+        for (Map.Entry<O2ItemType, Integer> entry : ingredients.entrySet()) {
+            O2ItemType ingredientType = entry.getKey();
+            Integer amount = entry.getValue();
+
+            String ingredientName = Ollivanders2API.getItems().getItemNameByType(ingredientType);
+            assertNotNull(ingredientName, "Ingredient should have a name: " + ingredientType);
+
+            assertTrue(text.contains(ingredientName), "getText should contain ingredient name: " + ingredientName);
+            assertTrue(text.contains(amount.toString()), "getText should contain ingredient amount: " + amount);
+        }
+    }
+
+    /**
+     * Test getPotionType returns the potion type.
+     * <p>
+     * Simple getter - basic functionality verified by other tests that use getPotionType()
+     * to validate potion instances.
+     * </p>
+     */
+    @Test
+    void getPotionTypeTest() {
+        // simple getter, skipping tests
+    }
+
+    /**
+     * Test getName returns the potion name.
+     * <p>
+     * Simple getter - basic functionality verified by createPotionItemStackTest() which
+     * validates that the potion name matches the expected display name.
+     * </p>
+     */
+    @Test
+    void getNameTest() {
+        // simple getter, skipping tests
+    }
+
+    /**
+     * Test getIngredients returns the potion ingredients.
+     * <p>
+     * Simple getter - basic functionality verified by getIngredientsTextTest() and
+     * checkRecipeTest() which both validate that ingredients are returned correctly.
+     * </p>
+     */
+    @Test
+    void getIngredients() {
+        // simple getter, skipping tests
+    }
+
+    /**
+     * Test getText returns the potion description text.
+     * <p>
+     * Simple getter - basic functionality verified by getIngredientsTextTest() which
+     * validates that getText() returns the description with ingredients appended.
+     * </p>
+     */
+    @Test
+    void getTextTest() {
+        // simple getter, skipping tests
+    }
+
+    /**
+     * Test getFlavorText returns appropriate values based on flavor text availability.
+     * <p>
+     * Verifies that:
+     * <ul>
+     * <li>Potions without flavor text return null</li>
+     * <li>Potions with flavor text return a non-null, non-empty string</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    void getFlavorTextTest() {
+        // Test a potion without flavor text - should return null
+        O2Potion potionWithoutFlavor = Ollivanders2API.getPotions().getPotionFromType(O2PotionType.HERBICIDE_POTION);
+        assertNotNull(potionWithoutFlavor, "getPotionFromType should return a non-null potion for HERBICIDE_POTION");
+        assertNull(potionWithoutFlavor.getFlavorText(), "getFlavorText should return null for potion without flavor text");
+
+        // Test a potion with flavor text - should return a non-null string
+        O2Potion potionWithFlavor = Ollivanders2API.getPotions().getPotionFromType(O2PotionType.CURE_FOR_BOILS);
+        assertNotNull(potionWithFlavor, "getPotionFromType should return a non-null potion for CURE_FOR_BOILS");
+        String flavorText = potionWithFlavor.getFlavorText();
+        assertNotNull(flavorText, "getFlavorText should return non-null for potion with flavor text");
+        assertFalse(flavorText.isEmpty(), "getFlavorText should return non-empty string");
+    }
+
+    /**
+     * Test getMagicBranch returns the magic branch for potions.
+     * <p>
+     * Simple getter - always returns POTIONS branch for all O2Potion instances.
+     * Basic functionality verified by potion instantiation and usage tests.
+     * </p>
+     */
+    @Test
+    void getMagicBranchTest() {
+        // simple getter, skipping tests
+    }
+
+    /**
+     * Test getLevel returns the magic difficulty level for the potion.
+     * <p>
+     * Simple getter - basic functionality verified by setUsesModifierTest() which
+     * validates that the potion level is used correctly in modifier calculations.
+     * </p>
+     */
+    @Test
+    void getLevelTest() {
+        // simple getter, skipping tests
+    }
+
+    /**
+     * Test checkRecipe validates ingredient lists correctly.
+     * <p>
+     * Verifies that:
+     * <ul>
+     * <li>Exact matching ingredients return true</li>
+     * <li>Wrong number of ingredient types returns false</li>
+     * <li>Missing ingredient returns false</li>
+     * <li>Wrong ingredient amount returns false</li>
+     * <li>Empty ingredient map returns false</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    void checkRecipeTest() {
+        O2PotionType potionType = O2PotionType.CURE_FOR_BOILS;
+        O2Potion potion = Ollivanders2API.getPotions().getPotionFromType(potionType);
+        assertNotNull(potion, "getPotionFromType should return a non-null potion");
+
+        Map<O2ItemType, Integer> correctIngredients = potion.getIngredients();
+        assertFalse(correctIngredients.isEmpty(), "Potion should have ingredients");
+
+        // Exact match should return true
+        assertTrue(potion.checkRecipe(correctIngredients), "checkRecipe should return true for exact match");
+
+        // Empty map should return false
+        Map<O2ItemType, Integer> emptyIngredients = new HashMap<>();
+        assertFalse(potion.checkRecipe(emptyIngredients), "checkRecipe should return false for empty ingredients");
+
+        // Missing one ingredient should return false
+        Map<O2ItemType, Integer> missingIngredient = new HashMap<>(correctIngredients);
+        O2ItemType firstKey = missingIngredient.keySet().iterator().next();
+        missingIngredient.remove(firstKey);
+        assertFalse(potion.checkRecipe(missingIngredient), "checkRecipe should return false when missing an ingredient");
+
+        // Wrong amount should return false
+        Map<O2ItemType, Integer> wrongAmount = new HashMap<>(correctIngredients);
+        O2ItemType keyToModify = wrongAmount.keySet().iterator().next();
+        wrongAmount.put(keyToModify, wrongAmount.get(keyToModify) + 10);
+        assertFalse(potion.checkRecipe(wrongAmount), "checkRecipe should return false for wrong ingredient amount");
+
+        // Extra ingredient should return false
+        Map<O2ItemType, Integer> extraIngredient = new HashMap<>(correctIngredients);
+        // Find an ingredient type not in the recipe
+        for (O2ItemType itemType : O2ItemType.values()) {
+            if (!extraIngredient.containsKey(itemType)) {
+                extraIngredient.put(itemType, 1);
+                break;
+            }
+        }
+        assertFalse(potion.checkRecipe(extraIngredient), "checkRecipe should return false when extra ingredient present");
+    }
+
+    /**
+     * Test brew creates a valid potion and increments brew count.
+     * <p>
+     * Verifies that:
+     * <ul>
+     * <li>Brewing with checkCanBrew=false returns a valid potion</li>
+     * <li>The returned ItemStack has the correct potion type name</li>
+     * <li>The player's potion brew count is incremented</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    void brewTest() {
+        O2PotionType potionType = O2PotionType.CURE_FOR_BOILS;
+        O2Potion potion = Ollivanders2API.getPotions().getPotionFromType(potionType);
+        assertNotNull(potion, "getPotionFromType should return a non-null potion");
+
+        // Create a mock player
+        Player brewer = mockServer.addPlayer();
+        assertNotNull(brewer, "Mock server should create a player");
+
+        // Get initial potion count
+        int initialCount = testPlugin.getO2Player(brewer).getPotionCount(potionType);
+
+        // Brew with checkCanBrew=false to guarantee success
+        ItemStack result = potion.brew(brewer, false);
+        assertNotNull(result, "brew should return a non-null ItemStack");
+
+        // Verify the potion has correct metadata
+        assertNotNull(result.getItemMeta(), "Brewed potion should have item meta");
+        assertEquals(potionType.getPotionName(), result.getItemMeta().getDisplayName(),
+                "Brewed potion should have correct display name");
+
+        // Verify potion count was incremented
+        int newCount = testPlugin.getO2Player(brewer).getPotionCount(potionType);
+        assertEquals(initialCount + 1, newCount, "Potion brew count should be incremented");
+    }
+
+    /**
+     * Test createPotionItemStack creates correctly configured ItemStacks.
+     * <p>
+     * Verifies that:
+     * <ul>
+     * <li>Single potion (amount=1) is created correctly</li>
+     * <li>Multiple potions (amount > 1) are created correctly</li>
+     * <li>The display name matches the potion type name</li>
+     * <li>The ItemStack amount matches the requested amount</li>
+     * <li>The potion can be identified via findPotionByItemStack</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    void createPotionItemStackTest() {
+        O2PotionType potionType = O2PotionType.CURE_FOR_BOILS;
+        O2Potion potion = Ollivanders2API.getPotions().getPotionFromType(potionType);
+        assertNotNull(potion, "getPotionFromType should return a non-null potion");
+
+        // Test creating a single potion
+        ItemStack singlePotion = potion.createPotionItemStack(1);
+        assertNotNull(singlePotion, "createPotionItemStack should return a non-null ItemStack");
+        assertEquals(1, singlePotion.getAmount(), "Single potion should have amount 1");
+        assertNotNull(singlePotion.getItemMeta(), "Potion should have item meta");
+        assertEquals(potionType.getPotionName(), singlePotion.getItemMeta().getDisplayName(),
+                "Potion should have correct display name");
+
+        // Test creating multiple potions
+        int multiAmount = 5;
+        ItemStack multiplePotions = potion.createPotionItemStack(multiAmount);
+        assertNotNull(multiplePotions, "createPotionItemStack should return a non-null ItemStack for multiple");
+        assertEquals(multiAmount, multiplePotions.getAmount(), "Multiple potions should have correct amount");
+
+        // Verify the potion can be identified
+        O2Potion foundPotion = Ollivanders2API.getPotions().findPotionByItemStack(singlePotion);
+        assertNotNull(foundPotion, "findPotionByItemStack should identify the created potion");
+        assertEquals(potionType, foundPotion.getPotionType(), "Found potion should have correct type");
+    }
+
+    /**
+     * Test canBrew determines brewing success correctly.
+     * <p>
+     * Note: canBrew() is a private method, so it is tested indirectly through brew().
+     * When checkCanBrew=true, brew() calls canBrew() to determine success.
+     * </p>
+     * <p>
+     * Verifies that:
+     * <ul>
+     * <li>With maxSpellLevel enabled, brewing always succeeds</li>
+     * <li>The result is a valid potion (not a bad potion) when canBrew returns true</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    void canBrewTest() {
+        // canBrew() is private - test indirectly through brew() with checkCanBrew=true
+        O2PotionType potionType = O2PotionType.CURE_FOR_BOILS;
+        O2Potion potion = Ollivanders2API.getPotions().getPotionFromType(potionType);
+        assertNotNull(potion, "getPotionFromType should return a non-null potion");
+
+        Player brewer = mockServer.addPlayer();
+        assertNotNull(brewer, "Mock server should create a player");
+
+        // Enable maxSpellLevel to guarantee canBrew returns true
+        boolean originalMaxSpellLevel = Ollivanders2.maxSpellLevel;
+        try {
+            Ollivanders2.maxSpellLevel = true;
+
+            // Brew with checkCanBrew=true - should succeed because maxSpellLevel is enabled
+            ItemStack result = potion.brew(brewer, true);
+            assertNotNull(result, "brew should return a non-null ItemStack");
+
+            // Verify it's a valid potion (not a bad potion)
+            O2Potion foundPotion = Ollivanders2API.getPotions().findPotionByItemStack(result);
+            assertNotNull(foundPotion, "With maxSpellLevel enabled, brew should return a valid potion");
+            assertEquals(potionType, foundPotion.getPotionType(), "Brewed potion should have correct type");
+        } finally {
+            // Restore original setting
+            Ollivanders2.maxSpellLevel = originalMaxSpellLevel;
+        }
+    }
+
+    /**
+     * Test brewBadPotion creates a random invalid potion.
+     * <p>
+     * Verifies that:
+     * <ul>
+     * <li>The method returns a non-null ItemStack</li>
+     * <li>The potion has item meta with a display name</li>
+     * <li>The display name is one of the known bad potion names</li>
+     * <li>The potion is NOT identifiable as a valid O2Potion</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    void brewBadPotionTest() {
+        // Known bad potion names from brewBadPotion() implementation
+        List<String> badPotionNames = List.of(
+                "Watery Potion", "Slimy Potion", "Lumpy Potion",
+                "Cloudy Potion", "Smelly Potion", "Sticky Potion"
+        );
+
+        // Test multiple times since results are randomized
+        for (int i = 0; i < 10; i++) {
+            ItemStack badPotion = O2Potion.brewBadPotion();
+            assertNotNull(badPotion, "brewBadPotion should return a non-null ItemStack");
+
+            // Verify it has item meta
+            assertNotNull(badPotion.getItemMeta(), "Bad potion should have item meta");
+
+            // Verify display name is one of the bad potion names
+            String displayName = badPotion.getItemMeta().getDisplayName();
+            assertNotNull(displayName, "Bad potion should have a display name");
+            assertTrue(badPotionNames.contains(displayName),
+                    "Bad potion name '" + displayName + "' should be one of the known bad potion names");
+
+            // Verify it's NOT a valid O2Potion
+            O2Potion foundPotion = Ollivanders2API.getPotions().findPotionByItemStack(badPotion);
+            assertNull(foundPotion, "Bad potion should not be identifiable as a valid O2Potion");
+        }
+    }
+
+    /**
+     * Test setUsesModifier calculates brewing skill modifier correctly.
+     * <p>
+     * Note: setUsesModifier() is a protected method, so we use reflection to test it directly.
+     * The usesModifier field is public and can be verified after the method call.
+     * </p>
+     * <p>
+     * Verifies that:
+     * <ul>
+     * <li>With maxSpellLevel enabled, usesModifier is set to 200</li>
+     * <li>With maxSpellLevel disabled, usesModifier is based on potion count</li>
+     * <li>With HIGHER_SKILL effect, usesModifier is doubled</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    void setUsesModifierTest() throws Exception {
+        O2PotionType potionType = O2PotionType.CURE_FOR_BOILS;
+        O2Potion potion = Ollivanders2API.getPotions().getPotionFromType(potionType);
+        assertNotNull(potion, "getPotionFromType should return a non-null potion");
+
+        Player player = mockServer.addPlayer();
+        assertNotNull(player, "Mock server should create a player");
+
+        O2Player o2p = Ollivanders2API.getPlayers().getPlayer(player.getUniqueId());
+        assertNotNull(o2p, "Should have an O2Player for the mock player");
+
+        // Get the protected method via reflection
+        Method setUsesModifierMethod = O2Potion.class.getDeclaredMethod("setUsesModifier", O2Player.class);
+        setUsesModifierMethod.setAccessible(true);
+
+        // Test with maxSpellLevel enabled
+        boolean originalMaxSpellLevel = Ollivanders2.maxSpellLevel;
+        boolean originalUseYears = Ollivanders2.useYears;
+        try {
+            Ollivanders2.maxSpellLevel = true;
+            Ollivanders2.useYears = false;
+
+            setUsesModifierMethod.invoke(potion, o2p);
+            assertEquals(200.0, potion.usesModifier, "With maxSpellLevel enabled, usesModifier should be 200");
+
+            // Test with maxSpellLevel disabled - usesModifier should be based on potion count
+            Ollivanders2.maxSpellLevel = false;
+            int potionCount = o2p.getPotionCount(potionType);
+
+            setUsesModifierMethod.invoke(potion, o2p);
+            assertEquals((double) potionCount, potion.usesModifier,
+                    "With maxSpellLevel disabled, usesModifier should equal potion count");
+
+            // Test with HIGHER_SKILL effect - should double the modifier
+            // First increment potion count so we have a non-zero base
+            o2p.incrementPotionCount(potionType);
+            o2p.incrementPotionCount(potionType);
+            int newPotionCount = o2p.getPotionCount(potionType);
+
+            // Add HIGHER_SKILL effect
+            HIGHER_SKILL higherSkillEffect = new HIGHER_SKILL(testPlugin, 1200, false, player.getUniqueId());
+            Ollivanders2API.getPlayers().playerEffects.addEffect(higherSkillEffect);
+            mockServer.getScheduler().performTicks(20); // Allow effect to register
+
+            setUsesModifierMethod.invoke(potion, o2p);
+            assertEquals((double) newPotionCount * 2, potion.usesModifier,
+                    "With HIGHER_SKILL effect, usesModifier should be doubled");
+
+            // Clean up effect
+            Ollivanders2API.getPlayers().playerEffects.removeEffect(o2p.getID(), O2EffectType.HIGHER_SKILL);
+        } finally {
+            // Restore original settings
+            Ollivanders2.maxSpellLevel = originalMaxSpellLevel;
+            Ollivanders2.useYears = originalUseYears;
+        }
+    }
+
+    /**
+     * Tear down the mock Bukkit server after all tests complete.
+     *
+     * <p>Static teardown method called once after all tests in this class have finished.
+     * Releases the MockBukkit server resources to prevent memory leaks and allow clean
+     * test execution in subsequent test classes.</p>
+     */
+    @AfterAll
+    static void globalTearDown() {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/O2PotionTypeTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/O2PotionTypeTest.java
@@ -1,0 +1,173 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test suite for {@link O2PotionType} enum.
+ * <p>
+ * Verifies potion type lookup methods and ensures all potion types have unique names.
+ * </p>
+ */
+public class O2PotionTypeTest {
+    /**
+     * Shared mock Bukkit server instance for all tests.
+     *
+     * <p>Static field initialized once before all tests in this class. Reused across test instances
+     * to avoid expensive server setup/teardown for each test method.</p>
+     */
+    static ServerMock mockServer;
+
+    /**
+     * The plugin instance being tested.
+     *
+     * <p>Loaded fresh before each test method with the default configuration. Provides access to
+     * logger, scheduler, and other plugin API methods during tests.</p>
+     */
+    static Ollivanders2 testPlugin;
+
+    /**
+     * Initialize the mock Bukkit server before all tests.
+     *
+     * <p>Static setup method called once before all tests in this class. Creates the shared
+     * MockBukkit server instance that is reused across all test methods to avoid expensive
+     * server creation/destruction overhead.</p>
+     */
+    @BeforeAll
+    static void globalSetUp() {
+        Ollivanders2.testMode = true;
+
+        mockServer = MockBukkit.mock();
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+
+        // advance the server by 20 ticks to let the scheduler start (it has an initial delay of 20 ticks)
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
+    }
+
+    /**
+     * Test getClassName returns the implementation class.
+     * <p>
+     * Simple getter - basic functionality verified by potion instantiation tests.
+     * </p>
+     */
+    @Test
+    void getClassNameTest() {
+        // simple getter, verified by potion instantiation tests
+    }
+
+    /**
+     * Test getLevel returns the magic difficulty level.
+     * <p>
+     * Simple getter - basic functionality verified by potion brewing tests.
+     * </p>
+     */
+    @Test
+    void getLevelTest() {
+        // simple getter, verified by potion brewing tests
+    }
+
+    /**
+     * Test getPotionName returns the display name.
+     * <p>
+     * Simple getter - basic functionality verified by getPotionTypeByName tests.
+     * </p>
+     */
+    @Test
+    void getPotionNameTest() {
+        // simple getter, verified by getPotionTypeByName tests
+    }
+
+    /**
+     * Test getPotionTypeFromString parses enum name strings correctly.
+     */
+    @Test
+    void getPotionTypeFromStringTest() {
+        // invalid string should return null
+        assertNull(O2PotionType.getPotionTypeFromString("Invalid Potion"), "Invalid potion string should return null");
+
+        // valid enum name should return the correct type
+        O2PotionType expectedType = O2PotionType.ANIMAGUS_POTION;
+        O2PotionType potionType = O2PotionType.getPotionTypeFromString(expectedType.toString());
+        assertNotNull(potionType, "getPotionTypeFromString returned null for valid enum name");
+        assertEquals(expectedType, potionType, "getPotionTypeFromString returned wrong potion type");
+    }
+
+    /**
+     * Test getPotionTypeByName finds potions by their display name.
+     * <p>
+     * This is distinct from getPotionTypeFromString which uses enum names.
+     * Display names may include punctuation (e.g., "Baruffio's Brain Elixir").
+     * </p>
+     */
+    @Test
+    void getPotionTypeByNameTest() {
+        // invalid name should return null
+        assertNull(O2PotionType.getPotionTypeByName("Invalid Potion"), "Invalid potion name should return null");
+
+        // valid potion name should return the correct type
+        O2PotionType expectedType = O2PotionType.BABBLING_BEVERAGE;
+        O2PotionType potionType = O2PotionType.getPotionTypeByName(expectedType.getPotionName());
+        assertNotNull(potionType, "getPotionTypeByName returned null for valid potion name");
+        assertEquals(expectedType, potionType, "getPotionTypeByName returned wrong potion type");
+
+        // test a potion where enum.toString and potion name are different (apostrophe in name)
+        expectedType = O2PotionType.BARUFFIOS_BRAIN_ELIXIR;
+        potionType = O2PotionType.getPotionTypeByName(expectedType.getPotionName());
+        assertNotNull(potionType, "getPotionTypeByName returned null for Baruffio's Brain Elixir");
+        assertEquals(expectedType, potionType, "getPotionTypeByName returned wrong type for Baruffio's Brain Elixir");
+
+        // test case insensitivity
+        potionType = O2PotionType.getPotionTypeByName("babbling beverage");
+        assertNotNull(potionType, "getPotionTypeByName should be case-insensitive");
+        assertEquals(O2PotionType.BABBLING_BEVERAGE, potionType, "getPotionTypeByName case-insensitive lookup failed");
+    }
+
+    /**
+     * Verify every potion type has a unique display name.
+     * <p>
+     * Duplicate names would cause getPotionTypeByName to return incorrect results,
+     * so all potion names must be unique.
+     * </p>
+     */
+    @Test
+    void uniquePotionNamesTest() {
+        Map<String, List<O2PotionType>> grouped = Arrays.stream(O2PotionType.values())
+                .collect(Collectors.groupingBy(O2PotionType::getPotionName));
+
+        List<String> duplicates = grouped.entrySet().stream()
+                .filter(e -> e.getValue().size() > 1)
+                .map(Map.Entry::getKey)
+                .toList();
+
+        assertTrue(duplicates.isEmpty(), "Found duplicate potion names: " + duplicates);
+    }
+
+    /**
+     * Tear down the mock Bukkit server after all tests complete.
+     *
+     * <p>Static teardown method called once after all tests in this class have finished.
+     * Releases the MockBukkit server resources to prevent memory leaks and allow clean
+     * test execution in subsequent test classes.</p>
+     */
+    @AfterAll
+    static void globalTearDown() {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/O2PotionsTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/O2PotionsTest.java
@@ -1,0 +1,567 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.item.O2ItemType;
+import net.pottercraft.ollivanders2.potion.O2Potion;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import net.pottercraft.ollivanders2.potion.O2Potions;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.potion.PotionType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test suite for the {@link net.pottercraft.ollivanders2.potion.O2Potions} potion manager.
+ * <p>
+ * Verifies potion management functionality including potion instantiation, ingredient detection,
+ * brewing, and lookup operations. Tests ensure that potions are properly loaded, cached, and
+ * can be retrieved by various identifiers.
+ * </p>
+ */
+public class O2PotionsTest {
+    /**
+     * Shared mock Bukkit server instance for all tests.
+     *
+     * <p>Static field initialized once before all tests in this class. Reused across test instances
+     * to avoid expensive server setup/teardown for each test method.</p>
+     */
+    static ServerMock mockServer;
+
+    /**
+     * The plugin instance being tested.
+     *
+     * <p>Loaded once before all tests with the default configuration. Provides access to
+     * logger, scheduler, and other plugin API methods during tests.</p>
+     */
+    static Ollivanders2 testPlugin;
+
+    /**
+     * The test world used for all potion tests.
+     */
+    static World testWorld;
+
+    /**
+     * Initialize the mock Bukkit server before all tests.
+     *
+     * <p>Static setup method called once before all tests in this class. Creates the shared
+     * MockBukkit server instance that is reused across all test methods to avoid expensive
+     * server creation/destruction overhead.</p>
+     */
+    @BeforeAll
+    static void globalSetUp() {
+        Ollivanders2.testMode = true;
+
+        mockServer = MockBukkit.mock();
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+        testWorld = mockServer.addSimpleWorld("world");
+
+        // advance the server by 20 ticks to let the scheduler start (it has an initial delay of 20 ticks)
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
+    }
+
+    /**
+     * Test getAllPotionTypes returns a list of all loaded potion type enums.
+     * <p>
+     * Simple getter - basic functionality verified by other potion tests.
+     * </p>
+     */
+    @Test
+    void getAllPotionTypesTest() {
+        // simple getter, verified by potion instantiation tests
+    }
+
+    /**
+     * Test getAllPotions returns a collection of all loaded potion instances.
+     * <p>
+     * Verifies that:
+     * <ul>
+     * <li>The returned collection is not null</li>
+     * <li>The collection contains O2Potion instances (not null elements)</li>
+     * <li>The count matches expected loaded potions (all O2PotionType values minus those depending on disabled LibsDisguises)</li>
+     * <li>Each potion has a valid potion type set</li>
+     * <li>No duplicate potions exist in the collection</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    void getAllPotionsTest() {
+        Collection<O2Potion> allPotions = Ollivanders2API.getPotions().getAllPotions();
+        assertNotNull(allPotions, "getAllPotions should return a non-null collection");
+        assertFalse(allPotions.isEmpty(), "getAllPotions should return a non-empty collection of loaded potions");
+
+        // Verify all elements in the collection are valid O2Potion instances
+        for (O2Potion potion : allPotions) {
+            assertNotNull(potion, "getAllPotions should not contain null elements");
+            assertNotNull(potion.getPotionType(), "Each potion should have a valid potion type");
+        }
+
+        // Verify the count matches the expected number of loaded potions
+        // In test mode, all potions are loaded (LibsDisguises is considered enabled in test mode)
+        assertEquals(O2PotionType.values().length, allPotions.size(), "getAllPotions should return all loaded potion types");
+
+        // Verify no duplicate potions (check by potion type)
+        Set<O2PotionType> potionTypes = new HashSet<>();
+        for (O2Potion potion : allPotions) {
+            O2PotionType potionType = potion.getPotionType();
+            assertTrue(potionTypes.add(potionType), "getAllPotions should not contain duplicate potion types: " + potionType);
+        }
+    }
+
+    /**
+     * Test getAllPotionNames returns a list of all potion display names.
+     * <p>
+     * Verifies that:
+     * <ul>
+     * <li>The returned list is not null</li>
+     * <li>The list contains all O2PotionType display names</li>
+     * <li>The count matches the total number of potion types</li>
+     * <li>No names are null or empty</li>
+     * <li>All names are unique (verified through O2PotionTypeTest)</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    void getAllPotionNamesTest() {
+        List<String> allPotionNames = Ollivanders2API.getPotions().getAllPotionNames();
+        assertNotNull(allPotionNames, "getAllPotionNames should return a non-null list");
+        assertFalse(allPotionNames.isEmpty(), "getAllPotionNames should return a non-empty list of potion names");
+
+        // Verify the count matches the expected number of potion types
+        assertEquals(O2PotionType.values().length, allPotionNames.size(), "getAllPotionNames should return all potion type display names");
+
+        // Verify no null or empty names
+        for (String potionName : allPotionNames) {
+            assertNotNull(potionName, "getAllPotionNames should not contain null names");
+            assertFalse(potionName.isEmpty(), "getAllPotionNames should not contain empty names");
+        }
+
+        // Verify each potion type name is present in the list
+        for (O2PotionType potionType : O2PotionType.values()) {
+            assertTrue(allPotionNames.contains(potionType.getPotionName()), "getAllPotionNames should contain display name for " + potionType);
+        }
+    }
+
+    /**
+     * Test brewPotion creates a potion from cauldron ingredients (happy path).
+     */
+    @Test
+    void brewPotionTest() {
+        Block cauldron = createCauldronAt(200);
+        Location location = cauldron.getLocation();
+        O2PotionType expectedPotionType = O2PotionType.COMMON_ANTIDOTE_POTION;
+
+        // put ingredients at cauldron
+        Map<O2ItemType, Integer> ingredients = getIngredientsForPotion(expectedPotionType);
+        for (O2ItemType ingredientType : ingredients.keySet()) {
+            Integer amount = ingredients.get(ingredientType);
+            assertNotNull(amount, "Ingredient amount should not be null");
+            dropIngredientAt(location, ingredientType, amount);
+        }
+
+        PlayerMock player = mockServer.addPlayer();
+        TestCommon.setPlayerPotionExperience(testPlugin, player, expectedPotionType, 100);
+
+        ItemStack brewedPotion = Ollivanders2API.getPotions().brewPotion(cauldron, player);
+        assertNotNull(brewedPotion, "brewPotion should return a non-null potion for valid recipe");
+        O2Potion potion = Ollivanders2API.getPotions().findPotionByItemStack(brewedPotion);
+        assertNotNull(potion, "brewPotion result should be findable by itemstack");
+        assertEquals(expectedPotionType, potion.getPotionType(), "brewPotion should create the expected potion type");
+    }
+
+    /**
+     * Test brewPotion returns null when block is not a cauldron.
+     * <p>
+     * Verifies that brewPotion() rejects blocks that are not water cauldrons.
+     * </p>
+     */
+    @Test
+    void brewPotionNotCauldronTest() {
+        Location location = new Location(testWorld, 210, 4, 0);
+        Block notCauldron = testWorld.getBlockAt(location);
+        notCauldron.setType(Material.DIRT);
+
+        PlayerMock player = mockServer.addPlayer();
+
+        ItemStack result = Ollivanders2API.getPotions().brewPotion(notCauldron, player);
+        assertNull(result, "brewPotion should return null for non-cauldron blocks");
+    }
+
+    /**
+     * Test brewPotion returns null when cauldron is empty.
+     * <p>
+     * Verifies that brewPotion() rejects cauldrons with no ingredients.
+     * </p>
+     */
+    @Test
+    void brewPotionEmptyCauldronTest() {
+        Block cauldron = createCauldronAt(220);
+        PlayerMock player = mockServer.addPlayer();
+
+        ItemStack result = Ollivanders2API.getPotions().brewPotion(cauldron, player);
+        assertNull(result, "brewPotion should return null for empty cauldrons");
+    }
+
+    /**
+     * Test brewPotion returns bad potion when ingredients don't match any recipe.
+     * <p>
+     * Verifies that brewPotion() creates a bad potion when ingredients don't match any known potion recipe.
+     * </p>
+     */
+    @Test
+    void brewPotionUnknownRecipeTest() {
+        Block cauldron = createCauldronAt(230);
+        Location location = cauldron.getLocation();
+
+        // Add random O2Items that don't form a valid recipe
+        dropIngredientAt(location, O2ItemType.ACONITE, 1);
+        dropIngredientAt(location, O2ItemType.BEZOAR, 1);
+
+        PlayerMock player = mockServer.addPlayer();
+
+        ItemStack result = Ollivanders2API.getPotions().brewPotion(cauldron, player);
+        assertBadPotion(result, "unknown recipes");
+    }
+
+    /**
+     * Test brewPotion returns bad potion when ingredients match wrong amounts.
+     * <p>
+     * Verifies that brewPotion() creates a bad potion when ingredients are present but in wrong amounts.
+     * </p>
+     */
+    @Test
+    void brewPotionWrongAmountsTest() {
+        Block cauldron = createCauldronAt(240);
+        Location location = cauldron.getLocation();
+        O2PotionType potionType = O2PotionType.CURE_FOR_BOILS;
+
+        // Get correct ingredients but use wrong amounts (always 1 instead of correct amount)
+        Map<O2ItemType, Integer> correctIngredients = getIngredientsForPotion(potionType);
+        for (O2ItemType ingredientType : correctIngredients.keySet()) {
+            dropIngredientAt(location, ingredientType, 1);
+        }
+
+        PlayerMock player = mockServer.addPlayer();
+
+        ItemStack result = Ollivanders2API.getPotions().brewPotion(cauldron, player);
+        assertBadPotion(result, "wrong ingredient amounts");
+    }
+
+    /**
+     * Test brewPotion returns bad potion when ingredients are incomplete.
+     * <p>
+     * Verifies that brewPotion() creates a bad potion when only some of the required ingredients are present.
+     * </p>
+     */
+    @Test
+    void brewPotionIncompleteIngredientsTest() {
+        Block cauldron = createCauldronAt(250);
+        Location location = cauldron.getLocation();
+        O2PotionType potionType = O2PotionType.SLEEPING_DRAUGHT;
+
+        // Get correct ingredients but only add the first one
+        Map<O2ItemType, Integer> correctIngredients = getIngredientsForPotion(potionType);
+        O2ItemType firstIngredient = (O2ItemType) correctIngredients.keySet().toArray()[0];
+        Integer amount = correctIngredients.get(firstIngredient);
+        assertNotNull(amount, "Ingredient amount should not be null");
+
+        dropIngredientAt(location, firstIngredient, amount);
+
+        PlayerMock player = mockServer.addPlayer();
+
+        ItemStack result = Ollivanders2API.getPotions().brewPotion(cauldron, player);
+        assertBadPotion(result, "incomplete ingredients");
+    }
+
+    /**
+     * Get the ingredients required for brewing a specific potion type.
+     *
+     * @param potionType the potion type to get ingredients for
+     * @return a map of ingredient types to required amounts
+     */
+    Map<O2ItemType, Integer> getIngredientsForPotion(@NotNull O2PotionType potionType) {
+        O2Potion potion = Ollivanders2API.getPotions().getPotionFromType(potionType);
+        assertNotNull(potion);
+
+        Map<O2ItemType, Integer> ingredients = potion.getIngredients();
+        assertFalse(ingredients.isEmpty());
+
+        return ingredients;
+    }
+
+    /**
+     * Create a water cauldron at the specified x-coordinate.
+     * <p>
+     * Helper method to reduce boilerplate in brewPotion tests. Creates a cauldron
+     * at (x, 4, 0) in the test world.
+     * </p>
+     *
+     * @param x the x-coordinate for the cauldron location
+     * @return the Block set as a water cauldron
+     */
+    Block createCauldronAt(int x) {
+        Location location = new Location(testWorld, x, 4, 0);
+        Block cauldron = testWorld.getBlockAt(location);
+        cauldron.setType(Material.WATER_CAULDRON);
+        return cauldron;
+    }
+
+    /**
+     * Drop an ingredient item at the specified location.
+     * <p>
+     * Helper method to reduce boilerplate when adding ingredients to cauldrons.
+     * </p>
+     *
+     * @param location       the location to drop the ingredient
+     * @param ingredientType the type of ingredient to drop
+     * @param amount         the amount of the ingredient
+     */
+    void dropIngredientAt(@NotNull Location location, @NotNull O2ItemType ingredientType, int amount) {
+        ItemStack ingredient = ingredientType.getItem(amount);
+        assertNotNull(ingredient, "Failed to create ingredient: " + ingredientType);
+        testWorld.dropItem(location, ingredient);
+    }
+
+    /**
+     * Assert that the brewed result is a bad potion (not a valid O2Potion).
+     * <p>
+     * Helper method for tests that expect brewPotion to return a bad potion.
+     * Verifies the result is not null but cannot be found as a valid O2Potion.
+     * </p>
+     *
+     * @param result   the ItemStack result from brewPotion (may be null, will fail assertion)
+     * @param scenario description of the test scenario for assertion messages
+     */
+    void assertBadPotion(@Nullable ItemStack result, @NotNull String scenario) {
+        assertNotNull(result, "brewPotion should return a bad potion for " + scenario);
+        O2Potion potion = Ollivanders2API.getPotions().findPotionByItemStack(result);
+        assertNull(potion, "brewPotion should return a bad potion (not a valid O2Potion) for " + scenario);
+    }
+
+    /**
+     * Test findPotionByIngredients (private method) matches potion recipes against ingredients.
+     * <p>
+     * This is a private method tested indirectly through public API. Verifies that ingredient
+     * matching works correctly for exact matches, wrong amounts, missing ingredients, and empty maps.
+     * </p>
+     */
+    @Test
+    void findPotionByIngredientsTest() {
+        O2PotionType expectedPotionType = O2PotionType.BABBLING_BEVERAGE;
+
+        // right ingredients and amounts
+        Map<O2ItemType, Integer> ingredients = getIngredientsForPotion(expectedPotionType);
+        O2Potion potion = Ollivanders2API.getPotions().findPotionByIngredients(ingredients);
+        assertNotNull(potion, "findPotionByIngredients should find potion with correct ingredients and amounts");
+        assertEquals(expectedPotionType, potion.getPotionType(), "findPotionByIngredients should return correct potion type");
+
+        // right ingredients, wrong amounts
+        ingredients.replaceAll((ingredient, amount) -> 1);
+        potion = Ollivanders2API.getPotions().findPotionByIngredients(ingredients);
+        assertNull(potion, "findPotionByIngredients should return null for wrong ingredient amounts");
+
+        // incorrect ingredients
+        O2ItemType ingredient = (O2ItemType)ingredients.keySet().toArray()[0];
+        ingredients.remove(ingredient);
+        potion = Ollivanders2API.getPotions().findPotionByIngredients(ingredients);
+        assertNull(potion, "findPotionByIngredients should return null for missing ingredients");
+
+        // empty ingredients
+        ingredients.clear();
+        potion = Ollivanders2API.getPotions().findPotionByIngredients(ingredients);
+        assertNull(potion, "findPotionByIngredients should return null for empty ingredient map");
+    }
+
+    /**
+     * Test getIngredientsInCauldron (private method) detects items in cauldron regions.
+     * <p>
+     * This is a private method tested indirectly through public API. Verifies that only O2Items
+     * are detected, non-O2Items are ignored, and multiple ingredients are properly aggregated.
+     * </p>
+     */
+    @Test
+    void getIngredientsInCauldronTest() {
+        Block cauldron = createCauldronAt(100);
+        Location location = cauldron.getLocation();
+
+        // empty cauldron
+        Map<O2ItemType, Integer> ingredients = Ollivanders2API.getPotions().getIngredientsInCauldron(cauldron);
+        assertTrue(ingredients.isEmpty(), "getIngredientsInCauldron should return empty map for empty cauldron");
+
+        // items that are not O2Items
+        testWorld.dropItem(location, new ItemStack(Material.VINE, 1));
+        ingredients = Ollivanders2API.getPotions().getIngredientsInCauldron(cauldron);
+        assertTrue(ingredients.isEmpty(), "getIngredientsInCauldron should ignore non-O2Items");
+
+        // items that are O2Items
+        dropIngredientAt(location, O2ItemType.VALERIAN_SPRIGS, 1);
+        ingredients = Ollivanders2API.getPotions().getIngredientsInCauldron(cauldron);
+        assertFalse(ingredients.isEmpty(), "getIngredientsInCauldron should find O2Items");
+        assertEquals(1, ingredients.size(), "getIngredientsInCauldron should find exactly one ingredient type");
+
+        dropIngredientAt(location, O2ItemType.DITTANY, 1);
+        ingredients = Ollivanders2API.getPotions().getIngredientsInCauldron(cauldron);
+        assertEquals(2, ingredients.size(), "getIngredientsInCauldron should find two different ingredient types");
+    }
+
+    /**
+     * Test findPotionByItemMeta retrieves potions from item NBT metadata.
+     * <p>
+     * Verifies that:
+     * <ul>
+     * <li>Standard Minecraft potion items return null (not O2Potions)</li>
+     * <li>Empty item metadata returns null</li>
+     * <li>Valid O2Potion ItemStacks are correctly identified and retrieved</li>
+     * <li>The retrieved potion has the correct potion type set</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    void findPotionByItemMetaTest() {
+        // happy path use cases covered by brewPotionTest()
+        ItemStack itemStack = new ItemStack(Material.POTION, 1);
+
+        // empty meta
+        ItemMeta itemMeta = itemStack.getItemMeta();
+        assertNotNull(itemMeta, "ItemStack should have ItemMeta");
+        assertNull(Ollivanders2API.getPotions().findPotionByItemMeta(itemMeta), "Empty ItemMeta should return null");
+
+        // standard MC potion meta
+        PotionMeta potionMeta = (PotionMeta) itemStack.getItemMeta();
+        potionMeta.setBasePotionType(PotionType.HEALING);
+        assertNull(Ollivanders2API.getPotions().findPotionByItemMeta(potionMeta), "Standard MC potion meta should return null");
+
+        // O2Potion
+        O2PotionType expectedPotionType = O2PotionType.HERBICIDE_POTION;
+        ItemStack potionItemStack = Ollivanders2API.getPotions().getPotionItemStackByType(expectedPotionType, 2);
+        assertNotNull(potionItemStack, "getPotionItemStackByType should return a non-null ItemStack");
+        itemMeta = potionItemStack.getItemMeta();
+        assertNotNull(itemMeta, "O2Potion ItemStack should have ItemMeta");
+        O2Potion potion = Ollivanders2API.getPotions().findPotionByItemMeta(itemMeta);
+        assertNotNull(potion, "findPotionByItemMeta should find O2Potion from ItemMeta");
+        assertEquals(expectedPotionType, potion.getPotionType(), "findPotionByItemMeta should return correct potion type");
+    }
+
+    /**
+     * Test getPotionFromType instantiates potion classes from enum using reflection.
+     * <p>
+     * Verifies that:
+     * <ul>
+     * <li>A valid potion type returns a non-null O2Potion instance</li>
+     * <li>The returned potion has the correct potion type set</li>
+     * <li>All potion types in the enum can be successfully instantiated</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    void getPotionFromTypeTest() {
+        // Test a specific potion type
+        O2PotionType expectedType = O2PotionType.SLEEPING_DRAUGHT;
+        O2Potion potion = Ollivanders2API.getPotions().getPotionFromType(expectedType);
+        assertNotNull(potion, "getPotionFromType should return a non-null potion for valid type");
+        assertEquals(expectedType, potion.getPotionType(), "getPotionFromType should return potion with correct type");
+
+        // Verify all potion types can be instantiated via reflection
+        for (O2PotionType potionType : O2PotionType.values()) {
+            O2Potion instantiatedPotion = Ollivanders2API.getPotions().getPotionFromType(potionType);
+            assertNotNull(instantiatedPotion, "getPotionFromType should instantiate " + potionType);
+            assertEquals(potionType, instantiatedPotion.getPotionType(), "getPotionFromType returned wrong type for " + potionType);
+        }
+    }
+
+    /**
+     * Test getAllIngredientNames returns a list of all potion ingredient display names.
+     * <p>
+     * Verifies that:
+     * <ul>
+     * <li>The returned list is not null</li>
+     * <li>The list is not empty</li>
+     * <li>The count matches the ingredients list size</li>
+     * <li>No names are null or empty</li>
+     * <li>All names are unique (no duplicates)</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    void getAllIngredientNamesTest() {
+        List<String> allIngredientNames = O2Potions.getAllIngredientNames();
+        assertNotNull(allIngredientNames, "getAllIngredientNames should return a non-null list");
+        assertFalse(allIngredientNames.isEmpty(), "getAllIngredientNames should return a non-empty list");
+
+        // Verify the count matches the ingredients list
+        assertEquals(O2Potions.ingredients.size(), allIngredientNames.size(), "getAllIngredientNames should return names for all ingredients");
+
+        // Verify no null or empty names
+        for (String ingredientName : allIngredientNames) {
+            assertNotNull(ingredientName, "getAllIngredientNames should not contain null names");
+            assertFalse(ingredientName.isEmpty(), "getAllIngredientNames should not contain empty names");
+        }
+
+        // Verify all names are unique (no duplicates)
+        Set<String> uniqueNames = new HashSet<>(allIngredientNames);
+        assertEquals(allIngredientNames.size(), uniqueNames.size(), "getAllIngredientNames should not contain duplicate names");
+    }
+
+    /**
+     * Test isLoaded checks if a potion type is currently loaded.
+     * <p>
+     * Verifies that potion types in the cache are reported as loaded.
+     * Note: In test mode, all potions are loaded by default, so this primarily
+     * tests that the cache lookup works correctly.
+     * </p>
+     */
+    @Test
+    void isLoadedTest() {
+        // In test mode, all potions are loaded, so we verify that a potion is found in the cache
+        assertTrue(Ollivanders2API.getPotions().isLoaded(O2PotionType.HERBICIDE_POTION), "isLoaded should return true for potions in the cache");
+    }
+
+    /**
+     * Test getPotionEffectMagicLevel returns the magic level for potion effects.
+     * <p>
+     * Simple getter - basic functionality verified by FINITE_INCANTATEM spell tests.
+     * </p>
+     */
+    @Test
+    void getPotionEffectMagicLevelTest() {
+        // simple getter, verified by FINITE_INCANTATEM spell tests
+    }
+
+    /**
+     * Tear down the mock Bukkit server after all tests complete.
+     *
+     * <p>Static teardown method called once after all tests in this class have finished.
+     * Releases the MockBukkit server resources to prevent memory leaks and allow clean
+     * test execution in subsequent test classes.</p>
+     */
+    @AfterAll
+    static void globalTearDown() {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/OculusFelisTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/OculusFelisTest.java
@@ -1,0 +1,29 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Test suite for the Oculus Felis potion effect.
+ *
+ * <p>Verifies that the Oculus Felis potion correctly applies the NIGHT_VISION effect to players
+ * when consumed. Tests both the player feedback message and the effect application to ensure
+ * the potion functions as intended.</p>
+ *
+ * @see PotionTestSuper for the base test infrastructure
+ */
+public class OculusFelisTest extends PotionTestSuper {
+    /**
+     * Set up the test by specifying the potion type to test.
+     *
+     * <p>Initializes the test to use the OCULUS_FELIS potion type and the NIGHT_VISION effect.
+     * This method is called before each test to ensure the correct potion is being tested by the
+     * inherited drinkTest() method.</p>
+     */
+    @Override @BeforeEach
+    void setUp() {
+        potionType = O2PotionType.OCULUS_FELIS;
+        effectType = O2EffectType.NIGHT_VISION;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/PotionTestSuper.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/PotionTestSuper.java
@@ -1,0 +1,153 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.potion.O2Potion;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Abstract base class for potion effect testing.
+ *
+ * <p>Provides shared test infrastructure for testing individual potion effects. This superclass
+ * handles MockBukkit server initialization, plugin loading, and the common test flow for verifying
+ * that potions apply their expected effects to players. Child classes implement potion-specific
+ * test configuration by overriding the {@code setUp()} method.</p>
+ *
+ * <p>The test flow is as follows:</p>
+ * <ol>
+ *   <li>{@code globalSetUp()} - Called once before all tests to initialize the mock server and load the plugin</li>
+ *   <li>{@code setUp()} - Called before each test to set up potion-specific test state (implemented by child classes)</li>
+ *   <li>{@code drinkTest()} - Template test method that verifies the potion effect is applied correctly</li>
+ *   <li>{@code globalTearDown()} - Called once after all tests to clean up server resources</li>
+ * </ol>
+ *
+ * <p>Child classes must set both {@code potionType} and {@code effectType} fields in their {@code setUp()}
+ * method. The {@code potionType} specifies which potion to test, and {@code effectType} specifies which
+ * effect should be applied when the potion is consumed.</p>
+ */
+public abstract class PotionTestSuper {
+    /**
+     * Shared mock Bukkit server instance for all tests.
+     *
+     * <p>Static field initialized once before all tests in this class. Reused across test instances
+     * to avoid expensive server setup/teardown for each test method.</p>
+     */
+    static ServerMock mockServer;
+
+    /**
+     * The plugin instance being tested.
+     *
+     * <p>Loaded once before all tests with the default configuration. Provides access to
+     * logger, scheduler, and other plugin API methods during tests.</p>
+     */
+    static Ollivanders2 testPlugin;
+
+    /**
+     * The type of potion being tested.
+     *
+     * <p>Must be set by child classes in their {@code setUp()} method before tests run. The
+     * {@code drinkTest()} method uses this field to retrieve the correct potion instance from
+     * the API. If not set, the test will fail with an assertion error.</p>
+     */
+    O2PotionType potionType = null;
+
+    /**
+     * The effect this potion added to the player.
+     *
+     * <p>Must be set by child classes in their {@code setUp()} method before tests run. The
+     * {@code drinkTest()} method uses this field to check the correct effect was added. If not set,
+     * the test will fail with an assertion error.</p>
+     */
+    O2EffectType effectType = null;
+
+    /**
+     * Initialize the mock Bukkit server before all tests.
+     *
+     * <p>Static setup method called once before all tests in this class. Creates the shared
+     * MockBukkit server instance that is reused across all test methods to avoid expensive
+     * server creation/destruction overhead.</p>
+     */
+    @BeforeAll
+    static void globalSetUp() {
+        Ollivanders2.testMode = true;
+
+        mockServer = MockBukkit.mock();
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+
+        // advance the server by 20 ticks to let the scheduler start (it has an initial delay of 20 ticks)
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
+    }
+
+    /**
+     * Set up test-specific state before each test.
+     *
+     * <p>Called before each test method to initialize potion-specific test state. Child classes
+     * must implement this method to set the {@code potionType} field to the potion type being tested
+     * and the {@code effectType} field to the effect that should be applied when the potion is consumed.
+     * This allows the shared {@code drinkTest()} method to retrieve the correct potion instance and
+     * verify that the correct effect was applied.</p>
+     */
+    @BeforeEach
+    abstract void setUp();
+
+    /**
+     * Template test method that verifies potion effects are applied when consumed.
+     *
+     * <p>This test method provides the common testing flow for all potion tests:</p>
+     * <ol>
+     *   <li>Verifies that {@code potionType} was set by the child class's {@code setUp()} method</li>
+     *   <li>Retrieves the potion instance from the API</li>
+     *   <li>Creates a mock player and has them drink the potion</li>
+     *   <li>Advances the server by 200 ticks to allow effects to take place</li>
+     *   <li>Verifies that the player received the potion success message</li>
+     *   <li>Verifies that the expected effect (specified by {@code effectType}) was applied to the player</li>
+     * </ol>
+     *
+     * <p>Child classes must set both {@code potionType} and {@code effectType} in their {@code setUp()}
+     * method to properly initialize this template test.</p>
+     */
+    @Test
+    void drinkTest() {
+        assertNotNull(potionType, "potionType not set");
+        O2Potion potion = Ollivanders2API.getPotions().getPotionFromType(potionType);
+        assertNotNull(potion, "Failed to get O2Potion");
+
+        PlayerMock player = mockServer.addPlayer();
+        potion.drink(player);
+
+        // first check did they get the potion message
+        String potionMessage = player.nextMessage();
+        assertNotNull(potionMessage);
+        assertEquals(potion.getPotionSuccessMessage(), TestCommon.cleanChatMessage(potionMessage), "Player did not receive expected message after drinking potion");
+
+        // verify that the effect was added to the player
+        assertTrue(Ollivanders2API.getPlayers().playerEffects.hasEffect(player.getUniqueId(), effectType), effectType.name() + " not applied to player");
+    }
+
+    /**
+     * Tear down the mock Bukkit server after all tests complete.
+     *
+     * <p>Static teardown method called once after all tests in this class have finished.
+     * Releases the MockBukkit server resources to prevent memory leaks and allow clean
+     * test execution in subsequent test classes.</p>
+     */
+    @AfterAll
+    static void globalTearDown() {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/RegenerationPotionTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/RegenerationPotionTest.java
@@ -1,0 +1,29 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Test suite for the Regeneration Potion effect.
+ *
+ * <p>Verifies that the Regeneration Potion correctly applies the REGENERATION effect to players
+ * when consumed. Tests both the player feedback message and the effect application to ensure
+ * the potion functions as intended.</p>
+ *
+ * @see PotionTestSuper for the base test infrastructure
+ */
+public class RegenerationPotionTest extends PotionTestSuper {
+    /**
+     * Set up the test by specifying the potion type to test.
+     *
+     * <p>Initializes the test to use the REGENERATION_POTION potion type and the REGENERATION effect.
+     * This method is called before each test to ensure the correct potion is being tested by the
+     * inherited drinkTest() method.</p>
+     */
+    @Override @BeforeEach
+    void setUp() {
+        potionType = O2PotionType.REGENERATION_POTION;
+        effectType = O2EffectType.REGENERATION;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/SatiationPotionTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/SatiationPotionTest.java
@@ -1,0 +1,29 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Test suite for the Satiation Potion effect.
+ *
+ * <p>Verifies that the Satiation Potion correctly applies the SATIATION effect to players
+ * when consumed. Tests both the player feedback message and the effect application to ensure
+ * the potion functions as intended.</p>
+ *
+ * @see PotionTestSuper for the base test infrastructure
+ */
+public class SatiationPotionTest extends PotionTestSuper {
+    /**
+     * Set up the test by specifying the potion type to test.
+     *
+     * <p>Initializes the test to use the SATIATION_POTION potion type and the SATIATION effect.
+     * This method is called before each test to ensure the correct potion is being tested by the
+     * inherited drinkTest() method.</p>
+     */
+    @Override @BeforeEach
+    void setUp() {
+        potionType = O2PotionType.SATIATION_POTION;
+        effectType = O2EffectType.SATIATION;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/ShrinkingSolutionTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/ShrinkingSolutionTest.java
@@ -1,0 +1,29 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Test suite for the Shrinking Solution potion effect.
+ *
+ * <p>Verifies that the Shrinking Solution potion correctly applies the SHRINKING effect to players
+ * when consumed. Tests both the player feedback message and the effect application to ensure
+ * the potion functions as intended.</p>
+ *
+ * @see PotionTestSuper for the base test infrastructure
+ */
+public class ShrinkingSolutionTest extends PotionTestSuper {
+    /**
+     * Set up the test by specifying the potion type to test.
+     *
+     * <p>Initializes the test to use the SHRINKING_SOLUTION potion type and the SHRINKING effect.
+     * This method is called before each test to ensure the correct potion is being tested by the
+     * inherited drinkTest() method.</p>
+     */
+    @Override @BeforeEach
+    void setUp() {
+        potionType = O2PotionType.SHRINKING_SOLUTION;
+        effectType = O2EffectType.SHRINKING;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/SleepingDraughtTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/SleepingDraughtTest.java
@@ -1,0 +1,77 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.effect.AWAKE;
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import net.pottercraft.ollivanders2.potion.SLEEPING_DRAUGHT;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test suite for the Sleeping Draught potion effect.
+ *
+ * <p>Verifies that the Sleeping Draught potion correctly applies the SLEEPING effect to players
+ * when consumed. Tests both the player feedback message and the effect application. Additionally,
+ * tests the special behavior where players with the AWAKE effect are protected from the sleep effect.</p>
+ *
+ * @see PotionTestSuper for the base test infrastructure
+ */
+public class SleepingDraughtTest extends PotionTestSuper {
+    /**
+     * Set up the test by specifying the potion type to test.
+     *
+     * <p>Initializes the test to use the SLEEPING_DRAUGHT potion type and the SLEEPING effect.
+     * This method is called before each test to ensure the correct potion is being tested by the
+     * inherited drinkTest() method.</p>
+     */
+    @Override @BeforeEach
+    void setUp() {
+        potionType = O2PotionType.SLEEPING_DRAUGHT;
+        effectType = O2EffectType.SLEEPING;
+    }
+
+    /**
+     * Test that the AWAKE effect prevents the Sleeping Draught from inducing sleep.
+     *
+     * <p>Verifies the special interaction between the Sleeping Draught and the AWAKE effect.
+     * When a player with the AWAKE effect (immunity to sleep) drinks the Sleeping Draught, the potion should
+     * not apply the SLEEPING effect. Instead, the player should receive a special message indicating
+     * they are protected from the sleep effect due to their awake state.</p>
+     *
+     * <p>Test procedure:</p>
+     * <ol>
+     *   <li>Create a mock player and add the AWAKE effect to them</li>
+     *   <li>Have the player drink the Sleeping Draught</li>
+     *   <li>Verify the player receives the special AWAKE effect message</li>
+     *   <li>Verify that the SLEEPING effect was NOT applied to the player</li>
+     * </ol>
+     */
+    @Test
+    void awakeEffectTest() {
+        assertNotNull(potionType, "potionType not set");
+        SLEEPING_DRAUGHT potion = new SLEEPING_DRAUGHT(testPlugin);
+        assertNotNull(potion, "Failed to get O2Potion");
+
+        // add awake effect to player
+        PlayerMock player = mockServer.addPlayer();
+        AWAKE awake = new AWAKE(testPlugin, 1000, false, player.getUniqueId());
+        Ollivanders2API.getPlayers().playerEffects.addEffect(awake);
+        assertTrue(Ollivanders2API.getPlayers().playerEffects.hasEffect(player.getUniqueId(), awake.effectType));
+
+        potion.drink(player);
+
+        String potionMessage = player.nextMessage();
+        assertNotNull(potionMessage);
+        assertEquals(potion.getAwakeEffectMessage(), TestCommon.cleanChatMessage(potionMessage), "Player did not receive expected message after drinking potion");
+
+        assertFalse(Ollivanders2API.getPlayers().playerEffects.hasEffect(player.getUniqueId(), effectType), "SLEEPING effect added when player has AWAKE effect.");
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/SplashPotionTestSuper.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/SplashPotionTestSuper.java
@@ -1,0 +1,4 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+public class SplashPotionTestSuper {
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/StrengtheningSolutionTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/StrengtheningSolutionTest.java
@@ -1,0 +1,29 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Test suite for the Strengthening Solution potion effect.
+ *
+ * <p>Verifies that the Strengthening Solution potion correctly applies the STRENGTH effect to players
+ * when consumed. Tests both the player feedback message and the effect application to ensure
+ * the potion functions as intended.</p>
+ *
+ * @see PotionTestSuper for the base test infrastructure
+ */
+public class StrengtheningSolutionTest extends PotionTestSuper {
+    /**
+     * Set up the test by specifying the potion type to test.
+     *
+     * <p>Initializes the test to use the STRENGTHENING_SOLUTION potion type and the STRENGTH effect.
+     * This method is called before each test to ensure the correct potion is being tested by the
+     * inherited drinkTest() method.</p>
+     */
+    @Override @BeforeEach
+    void setUp() {
+        potionType = O2PotionType.STRENGTHENING_SOLUTION;
+        effectType = O2EffectType.STRENGTH;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/SwellingSolutionTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/SwellingSolutionTest.java
@@ -1,0 +1,29 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Test suite for the Swelling Solution potion effect.
+ *
+ * <p>Verifies that the Swelling Solution potion correctly applies the SWELLING effect to players
+ * when consumed. Tests both the player feedback message and the effect application to ensure
+ * the potion functions as intended.</p>
+ *
+ * @see PotionTestSuper for the base test infrastructure
+ */
+public class SwellingSolutionTest extends PotionTestSuper {
+    /**
+     * Set up the test by specifying the potion type to test.
+     *
+     * <p>Initializes the test to use the SWELLING_SOLUTION potion type and the SWELLING effect.
+     * This method is called before each test to ensure the correct potion is being tested by the
+     * inherited drinkTest() method.</p>
+     */
+    @Override @BeforeEach
+    void setUp() {
+        potionType = O2PotionType.SWELLING_SOLUTION;
+        effectType = O2EffectType.SWELLING;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/WeaknessTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/WeaknessTest.java
@@ -1,0 +1,29 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Test suite for the Weakness Potion effect.
+ *
+ * <p>Verifies that the Weakness Potion correctly applies the WEAKNESS effect to players
+ * when consumed. Tests both the player feedback message and the effect application to ensure
+ * the potion functions as intended.</p>
+ *
+ * @see PotionTestSuper for the base test infrastructure
+ */
+public class WeaknessTest extends PotionTestSuper {
+    /**
+     * Set up the test by specifying the potion type to test.
+     *
+     * <p>Initializes the test to use the WEAKNESS_POTION potion type and the WEAKNESS effect.
+     * This method is called before each test to ensure the correct potion is being tested by the
+     * inherited drinkTest() method.</p>
+     */
+    @Override @BeforeEach
+    void setUp() {
+        potionType = O2PotionType.WEAKNESS_POTION;
+        effectType = O2EffectType.WEAKNESS;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/WideyePotionTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/WideyePotionTest.java
@@ -1,0 +1,29 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Test suite for the Wideye Potion effect.
+ *
+ * <p>Verifies that the Wideye Potion correctly applies the AWAKE effect to players
+ * when consumed. Tests both the player feedback message and the effect application to ensure
+ * the potion functions as intended.</p>
+ *
+ * @see PotionTestSuper for the base test infrastructure
+ */
+public class WideyePotionTest extends PotionTestSuper {
+    /**
+     * Set up the test by specifying the potion type to test.
+     *
+     * <p>Initializes the test to use the WIDEYE_POTION potion type and the AWAKE effect.
+     * This method is called before each test to ensure the correct potion is being tested by the
+     * inherited drinkTest() method.</p>
+     */
+    @Override @BeforeEach
+    void setUp() {
+        potionType = O2PotionType.WIDEYE_POTION;
+        effectType = O2EffectType.AWAKE;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/WiggenweldPotionTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/WiggenweldPotionTest.java
@@ -1,0 +1,118 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.effect.SLEEPING;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.ThrownPotion;
+import org.bukkit.event.entity.PotionSplashEvent;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.io.File;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Test suite for the Wiggenweld Potion effect.
+ *
+ * <p>Verifies that the Wiggenweld Potion correctly removes the SLEEPING effect from players
+ * when splashed. Tests the splash mechanic and effect removal to ensure the potion functions
+ * as intended for curing sleep.</p>
+ */
+public class WiggenweldPotionTest {
+    /**
+     * Shared mock Bukkit server instance for all tests.
+     *
+     * <p>Static field initialized once before all tests in this class. Reused across test instances
+     * to avoid expensive server setup/teardown for each test method.</p>
+     */
+    static ServerMock mockServer;
+
+    /**
+     * The plugin instance being tested.
+     *
+     * <p>Loaded once before all tests with the default configuration. Provides access to
+     * logger, scheduler, and other plugin API methods during tests.</p>
+     */
+    static Ollivanders2 testPlugin;
+
+    /**
+     * Initialize the mock Bukkit server before all tests.
+     *
+     * <p>Static setup method called once before all tests in this class. Creates the shared
+     * MockBukkit server instance that is reused across all test methods to avoid expensive
+     * server creation/destruction overhead.</p>
+     */
+    @BeforeAll
+    static void globalSetUp() {
+        Ollivanders2.testMode = true;
+
+        mockServer = MockBukkit.mock();
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+
+        // advance the server by 20 ticks to let the scheduler start (it has an initial delay of 20 ticks)
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
+    }
+
+    /**
+     * Test the Wiggenweld Potion's splash event behavior.
+     *
+     * <p>This test verifies that when a Wiggenweld Potion is splashed, it correctly removes the
+     * SLEEPING effect from affected players. The test creates a player with an active SLEEPING effect,
+     * splashes the potion on them, and verifies that the sleep effect is removed.</p>
+     */
+    @Test
+    void doOnPotionSplashEventTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 4, 100);
+
+        ItemStack potionItemStack = Ollivanders2API.getPotions().getPotionItemStackByType(O2PotionType.WIGGENWELD_POTION, 1);
+        assertNotNull(potionItemStack);
+
+        // Spawn the ThrownPotion entity
+        ThrownPotion thrownPotion = testWorld.spawn(location, ThrownPotion.class);
+        thrownPotion.setItem(potionItemStack);
+
+        PlayerMock player = mockServer.addPlayer();
+        PlayerMock player2 = mockServer.addPlayer();
+        SLEEPING sleeping = new SLEEPING(testPlugin, 1000, false, player2.getUniqueId());
+        Ollivanders2API.getPlayers().playerEffects.addEffect(sleeping);
+        mockServer.getScheduler().performTicks(20);
+
+        HashMap<LivingEntity, Double> affectedEntities = new HashMap<>(){{
+            put(player2, 1.0);
+        }};
+        player.setLocation(location);
+        PotionSplashEvent event = new PotionSplashEvent(thrownPotion, player, null, BlockFace.DOWN, affectedEntities);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+
+        assertFalse(Ollivanders2API.getPlayers().playerEffects.hasEffect(player2.getUniqueId(), O2EffectType.SLEEPING));
+    }
+
+    /**
+     * Tear down the mock Bukkit server after all tests complete.
+     *
+     * <p>Static teardown method called once after all tests in this class have finished.
+     * Releases the MockBukkit server resources to prevent memory leaks and allow clean
+     * test execution in subsequent test classes.</p>
+     */
+    @AfterAll
+    static void globalTearDown() {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/WitSharpeningPotionTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/WitSharpeningPotionTest.java
@@ -1,0 +1,29 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Test suite for the Wit-Sharpening Potion effect.
+ *
+ * <p>Verifies that the Wit-Sharpening Potion correctly applies the IMPROVED_BOOK_LEARNING effect to players
+ * when consumed. Tests both the player feedback message and the effect application to ensure
+ * the potion functions as intended.</p>
+ *
+ * @see PotionTestSuper for the base test infrastructure
+ */
+public class WitSharpeningPotionTest extends PotionTestSuper {
+    /**
+     * Set up the test by specifying the potion type to test.
+     *
+     * <p>Initializes the test to use the WIT_SHARPENING_POTION potion type and the IMPROVED_BOOK_LEARNING effect.
+     * This method is called before each test to ensure the correct potion is being tested by the
+     * inherited drinkTest() method.</p>
+     */
+    @Override @BeforeEach
+    void setUp() {
+        potionType = O2PotionType.WIT_SHARPENING_POTION;
+        effectType = O2EffectType.IMPROVED_BOOK_LEARNING;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/WolfsbanePotionTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/WolfsbanePotionTest.java
@@ -1,0 +1,29 @@
+package net.pottercraft.ollivanders2.test.potion;
+
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * Test suite for the Wolfsbane Potion effect.
+ *
+ * <p>Verifies that the Wolfsbane Potion correctly applies the LYCANTHROPY_RELIEF effect to players
+ * when consumed. Tests both the player feedback message and the effect application to ensure
+ * the potion functions as intended.</p>
+ *
+ * @see PotionTestSuper for the base test infrastructure
+ */
+public class WolfsbanePotionTest extends PotionTestSuper {
+    /**
+     * Set up the test by specifying the potion type to test.
+     *
+     * <p>Initializes the test to use the WOLFSBANE_POTION potion type and the LYCANTHROPY_RELIEF effect.
+     * This method is called before each test to ensure the correct potion is being tested by the
+     * inherited drinkTest() method.</p>
+     */
+    @Override @BeforeEach
+    void setUp() {
+        potionType = O2PotionType.WOLFSBANE_POTION;
+        effectType = O2EffectType.LYCANTHROPY_RELIEF;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/testcommon/TestCommon.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/testcommon/TestCommon.java
@@ -1,6 +1,11 @@
 package net.pottercraft.ollivanders2.test.testcommon;
 
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.player.O2Player;
+import net.pottercraft.ollivanders2.potion.O2PotionType;
+import net.pottercraft.ollivanders2.spell.O2SpellType;
 import org.bukkit.Material;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -11,6 +16,7 @@ import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -43,17 +49,17 @@ public class TestCommon {
     }
 
     /**
-     * Compare the message received by a player to the expected message. This needs a helper because
-     * we need to strip chat color codes from the messages sent by the plugin.
+     * Remove Minecraft chat color codes from a message string.
      *
-     * @param expected the message we expected
-     * @param message the message received
-     * @return strippedMessage.equals(expected)
+     * <p>Strips all color codes (format: section sign followed by a hex digit) from the message
+     * to allow direct comparison with expected message text. This is necessary because the plugin
+     * adds color codes to messages, but tests need to compare the actual text content.</p>
+     *
+     * @param message the message received from the plugin
+     * @return the message with all chat color codes removed
      */
-    public static boolean messageEquals(@NotNull String expected, @NotNull String message) {
-        String strippedMessage = message.replaceAll("§.", "");
-
-        return strippedMessage.equals(expected);
+    public static String cleanChatMessage(@NotNull String message) {
+        return message.replaceAll("§.", "");
     }
 
     /**
@@ -217,5 +223,71 @@ public class TestCommon {
         }
 
         return false;
+    }
+
+    /**
+     * Set a players experience level with a specific potion
+     *
+     * @param testPlugin the plugin
+     * @param player the player
+     * @param potionType the potion type
+     * @param count the count to set experience to
+     */
+    static public void setPlayerPotionExperience(@NotNull Ollivanders2 testPlugin, @NotNull Player player, @NotNull O2PotionType potionType, int count) {
+        O2Player o2player = testPlugin.getO2Player(player);
+        assertNotNull(o2player, "Failed to find O2Player");
+
+        o2player.setPotionCount(potionType, count);
+    }
+
+    /**
+     * Get a player's experience count for a specific potion type.
+     *
+     * <p>Retrieves the player's experience level with a specific potion type from their O2Player profile.
+     * Used in tests to verify that potion experience has been correctly updated or modified.</p>
+     *
+     * @param testPlugin the plugin instance
+     * @param player the player to query
+     * @param potionType the potion type to get experience for
+     * @return the player's experience count for the specified potion type
+     */
+    static public int getPlayerPotionExperience(@NotNull Ollivanders2 testPlugin, @NotNull Player player, @NotNull O2PotionType potionType) {
+        O2Player o2player = testPlugin.getO2Player(player);
+        assertNotNull(o2player, "Failed to find O2Player");
+
+        return o2player.getPotionCount(potionType);
+    }
+
+    /**
+     * Set a players experience level with a specific spell
+     *
+     * @param testPlugin the plugin
+     * @param player the player
+     * @param spellType the spell type
+     * @param count the count to set experience to
+     */
+    static public void setPlayerSpellExperience(@NotNull Ollivanders2 testPlugin, @NotNull Player player, @NotNull O2SpellType spellType, int count) {
+        O2Player o2player = testPlugin.getO2Player(player);
+        assertNotNull(o2player, "Failed to find O2Player");
+
+        o2player.setSpellCount(spellType, count);
+    }
+
+    /**
+     * Get a player's experience count for a specific spell type.
+     *
+     * <p>Retrieves the player's experience level with a specific spell type from their O2Player profile.
+     * Used in tests to verify that spell experience has been correctly updated or modified.</p>
+     *
+     * @param testPlugin the plugin instance
+     * @param player the player to query
+     * @param spellType the spell type to get experience for
+     * @return the player's experience count for the specified spell type
+     */
+    static public int getPlayerSpellExperience(@NotNull Ollivanders2 testPlugin, @NotNull Player player, @NotNull O2SpellType spellType) {
+        O2Player o2player = testPlugin.getO2Player(player);
+        assertNotNull(o2player, "Failed to find O2Player");
+
+        return o2player.getSpellCount(spellType);
     }
 }

--- a/Ollivanders/test/resources/default_config.yml
+++ b/Ollivanders/test/resources/default_config.yml
@@ -21,7 +21,7 @@ chatColor: 5
 # Spell Casting
 #
 # https://github.com/Azami7/Ollivanders2/wiki/Configuration#spell-casting
-bookLearning: true
+bookLearning: false
 nonVerbalSpellCasting: false
 spellJournal: true
 hostileMobAnimagi: false


### PR DESCRIPTION
* added tests for potions package
* turned off book learning in test default config
* added FIRE_RESISTANCE, REGENERATION, SATIATION, and STRENGTH effects
* changed potions that set MC PotionEffects to set O2PotionEffects
* fixed typo in Forgetfulness Potion enum label
* fixed bug in SHRINKING_SOLUTION where the ingredient list was not finished
* added potion ingredients items
* added function to create a potion ItemStack by type
* added find potion by itemstack
* function renames for clarity
* added name to O2PotionType so we can have names like Baruffio's