### PR TITLE
Stationary spell tests part 1

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/CAVE_INIMICUM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/CAVE_INIMICUM.java
@@ -2,7 +2,6 @@ package net.pottercraft.ollivanders2.spell;
 
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpell;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -16,7 +15,7 @@ import java.util.ArrayList;
  * {@link net.pottercraft.ollivanders2.stationaryspell.CAVE_INIMICUM}
  *
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/Cave_inimicum">https://harrypotter.fandom.com/wiki/Cave_inimicum</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Cave_inimicum">https://harrypotter.fandom.com/wiki/Cave_inimicum</a>
  * @since 2.21
  */
 public class CAVE_INIMICUM extends StationarySpell {
@@ -56,10 +55,10 @@ public class CAVE_INIMICUM extends StationarySpell {
         radiusModifier = 1;
         flairSize = 10;
         centerOnCaster = true;
-        minRadius = 5;
-        maxRadius = 20;
-        minDuration = Ollivanders2Common.ticksPerSecond * 30;
-        maxDuration = Ollivanders2Common.ticksPerMinute * 30;
+        minRadius = net.pottercraft.ollivanders2.stationaryspell.CAVE_INIMICUM.minRadiusConfig;
+        maxRadius = net.pottercraft.ollivanders2.stationaryspell.CAVE_INIMICUM.maxRadiusConfig;
+        minDuration = net.pottercraft.ollivanders2.stationaryspell.CAVE_INIMICUM.minDurationConfig;
+        maxDuration = net.pottercraft.ollivanders2.stationaryspell.CAVE_INIMICUM.maxDurationConfig;
 
         initSpell();
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/PARTIS_TEMPORUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/PARTIS_TEMPORUS.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 /**
  * Temporarily disables a stationary spell's effects if it is your spell.
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Partis_Temporus">https://harrypotter.fandom.com/wiki/Partis_Temporus</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Partis_Temporus">https://harrypotter.fandom.com/wiki/Partis_Temporus</a>
  */
 public final class PARTIS_TEMPORUS extends O2Spell {
     // todo rework to actually match the books - part fire or water - https://harrypotter.fandom.com/wiki/Partis_Temporus
@@ -89,8 +89,8 @@ public final class PARTIS_TEMPORUS extends O2Spell {
                 stationarySpell.setActive(false);
                 stationarySpell.flair(10);
 
-                if (duration > stationarySpell.getDurationRemaining())
-                    duration = stationarySpell.getDurationRemaining();
+                if (duration > stationarySpell.getDuration())
+                    duration = stationarySpell.getDuration();
             }
         }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/REPELLO_MUGGLETON.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/REPELLO_MUGGLETON.java
@@ -1,7 +1,6 @@
 package net.pottercraft.ollivanders2.spell;
 
 import net.pottercraft.ollivanders2.O2MagicBranch;
-import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpell;
 import org.bukkit.entity.Player;
 
@@ -18,7 +17,7 @@ import java.util.ArrayList;
  *
  * @author Azami7
  * @version Ollivanders2
- * @see <a href = "https://harrypotter.fandom.com/wiki/Muggle-Repelling_Charm">https://harrypotter.fandom.com/wiki/Muggle-Repelling_Charm</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Muggle-Repelling_Charm">https://harrypotter.fandom.com/wiki/Muggle-Repelling_Charm</a>
  * @since 2.21
  */
 public final class REPELLO_MUGGLETON extends StationarySpell {
@@ -57,10 +56,10 @@ public final class REPELLO_MUGGLETON extends StationarySpell {
         radiusModifier = 1;
         flairSize = 10;
         centerOnCaster = true;
-        minRadius = 5;
-        maxRadius = 20;
-        minDuration = Ollivanders2Common.ticksPerSecond * 30;
-        maxDuration = Ollivanders2Common.ticksPerMinute * 30;
+        minRadius = net.pottercraft.ollivanders2.stationaryspell.REPELLO_MUGGLETON.minRadiusConfig;
+        maxRadius = net.pottercraft.ollivanders2.stationaryspell.REPELLO_MUGGLETON.maxRadiusConfig;
+        minDuration = net.pottercraft.ollivanders2.stationaryspell.REPELLO_MUGGLETON.minDurationConfig;
+        maxDuration = net.pottercraft.ollivanders2.stationaryspell.REPELLO_MUGGLETON.maxDurationConfig;
 
         initSpell();
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/ALIQUAM_FLOO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/ALIQUAM_FLOO.java
@@ -34,7 +34,7 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.ALIQUAM_FLOO}
  *
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/Floo_Network">https://harrypotter.fandom.com/wiki/Floo_Network</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Floo_Network">https://harrypotter.fandom.com/wiki/Floo_Network</a>
  */
 public class ALIQUAM_FLOO extends O2StationarySpell {
     /**
@@ -46,6 +46,15 @@ public class ALIQUAM_FLOO extends O2StationarySpell {
      * Radius for this spell is always 4
      */
     public static final int maxRadiusConfig = 4;
+
+    /**
+     * min duration for this spell - not used, aliquam floo is permanent
+     */
+    public static final int minDurationConfig = 1000;
+    /**
+     * max duration for this spell - not used, aliquam floo is permanent
+     */
+    public static final int maxDurationConfig = 1000;
 
     /**
      * The name of this floo location
@@ -89,8 +98,14 @@ public class ALIQUAM_FLOO extends O2StationarySpell {
      */
     public ALIQUAM_FLOO(@NotNull Ollivanders2 plugin) {
         super(plugin);
+        spellType = O2StationarySpellType.ALIQUAM_FLOO;
 
-        init();
+        permanent = true;
+
+        if (p.getConfig().isSet("soulFireFlooEffect"))
+            soulFireFlooEffect = p.getConfig().getBoolean("soulFireFlooEffect");
+
+        flooNetworkLocations.add(this);
     }
 
     /**
@@ -103,29 +118,24 @@ public class ALIQUAM_FLOO extends O2StationarySpell {
      */
     public ALIQUAM_FLOO(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, @NotNull String flooName) {
         super(plugin, pid, location);
-
-        minRadius = minRadiusConfig;
-        maxRadius = maxRadiusConfig;
-        this.flooName = flooName;
-
-        init();
-
-        common.printDebugMessage("Creating stationary spell type " + spellType.name(), null, null, false);
-    }
-
-    /**
-     * Common constructor steps
-     */
-    private void init() {
         spellType = O2StationarySpellType.ALIQUAM_FLOO;
+        permanent = true;
 
         if (p.getConfig().isSet("soulFireFlooEffect"))
             soulFireFlooEffect = p.getConfig().getBoolean("soulFireFlooEffect");
 
-        this.radius = minRadius = maxRadius = minRadiusConfig;
-        permanent = true;
+        this.flooName = flooName;
 
         flooNetworkLocations.add(this);
+
+        common.printDebugMessage("Creating stationary spell type " + spellType.name(), null, null, false);
+    }
+
+    void initRadiusAndDurationMinMax() {
+        minRadius = minRadiusConfig;
+        maxRadius = maxRadiusConfig;
+        minDuration = minDurationConfig; // not used - aliquam floo is permanent
+        maxDuration = maxDurationConfig; // not used - aliquam floo is permanent
     }
 
     /**
@@ -379,5 +389,10 @@ public class ALIQUAM_FLOO extends O2StationarySpell {
     @Override
     void doCleanUp() {
         stopWorking();
+    }
+
+    @Override
+    public boolean checkSpellDeserialization() {
+        return playerUUID != null && location != null && flooName != null && !flooName.isEmpty();
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/CAVE_INIMICUM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/CAVE_INIMICUM.java
@@ -17,26 +17,28 @@ import java.util.UUID;
  * {@link net.pottercraft.ollivanders2.spell.CAVE_INIMICUM}
  *
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/Cave_inimicum">https://harrypotter.fandom.com/wiki/Cave_inimicum</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Cave_inimicum">https://harrypotter.fandom.com/wiki/Cave_inimicum</a>
  * @since 2.21
  */
 public class CAVE_INIMICUM extends ConcealmentShieldSpell {
     /**
-     * the min radius for this spell
+     * min radius for this spell
      */
     public static final int minRadiusConfig = 5;
     /**
-     * the max radius for this spell
+     * max radius for this spell
      */
     public static final int maxRadiusConfig = 20;
     /**
-     * the min duration for this spell
+     * min duration for this spell
      */
     public static final int minDurationConfig = Ollivanders2Common.ticksPerSecond * 30;
     /**
-     * the max duration for this spell
+     * max duration for this spell
      */
     public static final int maxDurationConfig = Ollivanders2Common.ticksPerMinute * 30;
+
+    private final String proximityAlarmMessage = "A hostile entity approaches.";
 
     /**
      * Simple constructor used for deserializing saved stationary spells at server start. Do not use to cast spell.
@@ -47,11 +49,6 @@ public class CAVE_INIMICUM extends ConcealmentShieldSpell {
         super(plugin);
 
         spellType = O2StationarySpellType.CAVE_INIMICUM;
-
-        minRadius = minRadiusConfig;
-        maxRadius = maxRadiusConfig;
-        minDuration = minDurationConfig;
-        maxDuration = maxDurationConfig;
     }
 
     /**
@@ -70,7 +67,12 @@ public class CAVE_INIMICUM extends ConcealmentShieldSpell {
         proximityRadiusModifier = 5; // alarm if a player or hostile entity gets within 5 blocks of the spell area
 
         spellType = O2StationarySpellType.CAVE_INIMICUM;
+    }
 
+    /**
+     * Set the min/max values for radius and duration.
+     */
+    void initRadiusAndDurationMinMax() {
         minRadius = minRadiusConfig;
         maxRadius = maxRadiusConfig;
         minDuration = minDurationConfig;
@@ -84,10 +86,7 @@ public class CAVE_INIMICUM extends ConcealmentShieldSpell {
      * @return false, this spell conceals players in the area from everyone
      */
     protected boolean canSee(@NotNull LivingEntity entity) {
-        if (isLocationInside(entity.getLocation()))
-            return true;
-        else
-            return false;
+        return isLocationInside(entity.getLocation());
     }
 
     /**
@@ -97,7 +96,7 @@ public class CAVE_INIMICUM extends ConcealmentShieldSpell {
      * @return true, this spell does not affect targeting
      */
     @Override
-    protected boolean canTarget(@NotNull LivingEntity entity) {
+    public boolean canTarget(@NotNull LivingEntity entity) {
         return true;
     }
 
@@ -107,7 +106,7 @@ public class CAVE_INIMICUM extends ConcealmentShieldSpell {
      * @param entity the entity entering the area
      * @return true, this spell does not block entry in to the spell area
      */
-    protected boolean canEnter(@NotNull LivingEntity entity) {
+    public boolean canEnter(@NotNull LivingEntity entity) {
         return true;
     }
 
@@ -138,11 +137,7 @@ public class CAVE_INIMICUM extends ConcealmentShieldSpell {
      * @param entity the entity that triggered the alarm
      */
     protected boolean checkAlarm(@NotNull LivingEntity entity) {
-        if (EntityCommon.isHostile(entity)) {
-            return true;
-        }
-
-        return false;
+        return EntityCommon.isHostile(entity);
     }
 
     /**
@@ -153,9 +148,13 @@ public class CAVE_INIMICUM extends ConcealmentShieldSpell {
             return;
 
         for (Player player : getPlayersInsideSpellRadius()) {
-            player.sendMessage(Ollivanders2.chatColor + "A hostile entity approaches.");
+            player.sendMessage(Ollivanders2.chatColor + proximityAlarmMessage);
         }
 
         proximityCooldownTimer = proximityCooldownLimit;
+    }
+
+    public String getProximityAlarmMessage() {
+        return proximityAlarmMessage;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/COLLOPORTUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/COLLOPORTUS.java
@@ -21,7 +21,7 @@ import java.util.UUID;
  * {@link net.pottercraft.ollivanders2.spell.COLLOPORTUS}
  *
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/Locking_Spell">https://harrypotter.fandom.com/wiki/Locking_Spell</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Locking_Spell">https://harrypotter.fandom.com/wiki/Locking_Spell</a>
  * @since 2.21
  */
 public class COLLOPORTUS extends O2StationarySpell {
@@ -29,11 +29,19 @@ public class COLLOPORTUS extends O2StationarySpell {
      * the min radius for this spell
      */
     public static final int minRadiusConfig = 5;
-
     /**
      * the max radius for this spell
      */
     public static final int maxRadiusConfig = 5;
+    /**
+     * min duration for this spell - not used, colloportus is permanent
+     */
+    public static final int minDurationConfig = 1000;
+    /**
+     * max duration for this spell - not used, colloportus is permanent
+     */
+    public static final int maxDurationConfig = 1000;
+
 
     /**
      * Simple constructor used for deserializing saved stationary spells at server start. Do not use to cast spell.
@@ -45,7 +53,6 @@ public class COLLOPORTUS extends O2StationarySpell {
 
         spellType = O2StationarySpellType.COLLOPORTUS;
         permanent = true;
-        this.radius = minRadius = maxRadius = minRadiusConfig;
     }
 
     /**
@@ -59,14 +66,20 @@ public class COLLOPORTUS extends O2StationarySpell {
         super(plugin, pid, location);
 
         spellType = O2StationarySpellType.COLLOPORTUS;
-        minRadius = minRadiusConfig;
-        maxRadius = maxRadiusConfig;
+
         permanent = true;
 
-        radius = minRadius = maxRadius = minRadiusConfig;
-        duration = 10;
+        radius = minRadius;
+        duration = minDuration;
 
         common.printDebugMessage("Creating stationary spell type " + spellType.name(), null, null, false);
+    }
+
+    void initRadiusAndDurationMinMax() {
+        minRadius = minRadiusConfig;
+        maxRadius = maxRadiusConfig;
+        minDuration = minDurationConfig; // not used, colloportus is permanent
+        maxDuration = maxDurationConfig; // not used, colloportus is permanent
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HARMONIA_NECTERE_PASSUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HARMONIA_NECTERE_PASSUS.java
@@ -24,7 +24,7 @@ import java.util.UUID;
  *
  * @author Azami7
  * @version Ollivanders2
- * @see <a href = "https://harrypotter.fandom.com/wiki/Vanishing_Cabinet">https://harrypotter.fandom.com/wiki/Vanishing_Cabinet</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Vanishing_Cabinet">https://harrypotter.fandom.com/wiki/Vanishing_Cabinet</a>
  */
 public class HARMONIA_NECTERE_PASSUS extends O2StationarySpell {
     /**
@@ -36,6 +36,15 @@ public class HARMONIA_NECTERE_PASSUS extends O2StationarySpell {
      * the max radius for this spell
      */
     public static final int maxRadiusConfig = 1;
+
+    /**
+     * min duration for this spell - not used, harmonia is permanent
+     */
+    public static final int minDurationConfig = 1000;
+    /**
+     * max duration for this spell - not used, harmonia is permanent
+     */
+    public static final int maxDurationConfig = 1000;
 
     /**
      * The location of this cabinet's twin
@@ -66,7 +75,7 @@ public class HARMONIA_NECTERE_PASSUS extends O2StationarySpell {
         super(plugin);
 
         spellType = O2StationarySpellType.HARMONIA_NECTERE_PASSUS;
-        this.radius = minRadius = maxRadius = minRadiusConfig;
+        this.radius = minRadius;
         permanent = true;
     }
 
@@ -84,10 +93,17 @@ public class HARMONIA_NECTERE_PASSUS extends O2StationarySpell {
         spellType = O2StationarySpellType.HARMONIA_NECTERE_PASSUS;
         permanent = true;
 
-        radius = minRadius = maxRadius = minRadiusConfig;
+        radius = minRadius;
         duration = 10;
 
         this.twinCabinetLocation = twin;
+    }
+
+    void initRadiusAndDurationMinMax() {
+        minRadius = minRadiusConfig;
+        maxRadius = maxRadiusConfig;
+        minDuration = minDurationConfig; // not used, harmonia is permanent
+        maxDuration = maxDurationConfig; // not used, harmonia is permanent
     }
 
     /**
@@ -221,7 +237,7 @@ public class HARMONIA_NECTERE_PASSUS extends O2StationarySpell {
         Location fromLoc = event.getFrom(); // will never be null
 
         // make sure they actually moved locations, not turned head, etc
-        if (toLoc == null || Ollivanders2Common.locationEquals(toLoc, fromLoc))
+        if (Ollivanders2Common.locationEquals(toLoc, fromLoc))
             return;
 
         HARMONIA_NECTERE_PASSUS twin = getTwin();
@@ -250,5 +266,10 @@ public class HARMONIA_NECTERE_PASSUS extends O2StationarySpell {
 
     @Override
     void doCleanUp() {
+    }
+
+    @Override
+    public boolean checkSpellDeserialization() {
+        return playerUUID != null && location != null && twinCabinetLocation != null;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HERBICIDE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HERBICIDE.java
@@ -17,6 +17,26 @@ import java.util.Map;
 import java.util.UUID;
 
 public class HERBICIDE extends ThrownPotionStationarySpell {
+    /**
+     * min radius for this spell
+     */
+    public static final int minRadiusConfig = 5;
+    /**
+     * max radius for this spell
+     */
+    public static final int maxRadiusConfig = 20;
+    /**
+     * min duration for this spell
+     */
+    public static final int minDurationConfig = Ollivanders2Common.ticksPerSecond * 30;
+    /**
+     * max duration for this spell
+     */
+    public static final int maxDurationConfig = Ollivanders2Common.ticksPerMinute * 30;
+
+    /**
+     *
+     */
     Map<Material, Material> blocksReplacements = new HashMap<>() {{
         put(Material.ACACIA_LEAVES, Material.AIR);
         put(Material.ALLIUM, Material.AIR);
@@ -129,6 +149,9 @@ public class HERBICIDE extends ThrownPotionStationarySpell {
         put(Material.WITHER_ROSE, Material.AIR);
     }};
 
+    /**
+     *
+     */
     Map<Material, Material> blocksToItemReplacements = new HashMap<>() {{
         put(Material.ACACIA_SAPLING, Material.STICK);
         put(Material.BAMBOO, Material.BAMBOO);
@@ -173,6 +196,13 @@ public class HERBICIDE extends ThrownPotionStationarySpell {
 
         // check that world guard permissions allow this stationary spell at every location in the spell radius
         checkWorldGuard();
+    }
+
+    void initRadiusAndDurationMinMax() {
+        minRadius = minRadiusConfig;
+        maxRadius = maxRadiusConfig;
+        minDuration = minDurationConfig;
+        maxDuration = maxDurationConfig;
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HORCRUX.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HORCRUX.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * @author Azami7
  * @version Ollivanders2
- * @see <a href = "https://harrypotter.fandom.com/wiki/Horcrux-making_spell">https://harrypotter.fandom.com/wiki/Horcrux-making_spell</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Horcrux-making_spell">https://harrypotter.fandom.com/wiki/Horcrux-making_spell</a>
  * @since 2.21
  */
 public class HORCRUX extends O2StationarySpell {
@@ -44,6 +44,16 @@ public class HORCRUX extends O2StationarySpell {
      * the max radius for this spell
      */
     public static final int maxRadiusConfig = 3;
+
+    /**
+     * min duration for this spell - not used, horcrux is permanent
+     */
+    public static final int minDurationConfig = 1000;
+
+    /**
+     * max duration for this spell - not used, horcrux is permanent
+     */
+    public static final int maxDurationConfig = 1000;
 
     /**
      * The material type of the horcrux item
@@ -116,6 +126,13 @@ public class HORCRUX extends O2StationarySpell {
         itemLoaded = true;
 
         common.printDebugMessage("Creating stationary spell type " + spellType.name(), null, null, false);
+    }
+
+    void initRadiusAndDurationMinMax() {
+        minRadius = minRadiusConfig;
+        maxRadius = maxRadiusConfig;
+        minDuration = minDurationConfig; // not used - horcrux floo is permanent
+        maxDuration = maxDurationConfig; // not used - horcrux floo is permanent
     }
 
     /**
@@ -249,7 +266,7 @@ public class HORCRUX extends O2StationarySpell {
     void doOnPlayerMoveEvent(@NotNull PlayerMoveEvent event) {
         Location toLocation = event.getTo();
 
-        if (toLocation == null || !isLocationInside(toLocation))
+        if (!isLocationInside(toLocation))
             return;
 
         Player target = event.getPlayer();
@@ -316,5 +333,9 @@ public class HORCRUX extends O2StationarySpell {
 
     @Override
     void doCleanUp() {
+    }
+
+    public boolean checkSpellDeserialization() {
+        return playerUUID != null && location != null && horcruxMaterial != null;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/LUMOS_FERVENS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/LUMOS_FERVENS.java
@@ -69,11 +69,6 @@ public class LUMOS_FERVENS extends O2StationarySpell {
         super(plugin);
 
         spellType = O2StationarySpellType.LUMOS_FERVENS;
-        
-        minRadius = minRadiusConfig;
-        maxRadius = maxRadiusConfig;
-        minDuration = minDurationConfig;
-        maxDuration = maxDurationConfig;
     }
 
     /**
@@ -90,16 +85,21 @@ public class LUMOS_FERVENS extends O2StationarySpell {
 
         spellType = O2StationarySpellType.LUMOS_FERVENS;
         
-        minRadius = minRadiusConfig;
-        maxRadius = maxRadiusConfig;
-        minDuration = minDurationConfig;
-        maxDuration = maxDurationConfig;
-        
         setRadius(radius);
         setDuration(duration);
         
         // Create the initial soul fire
         createSoulFire();
+    }
+
+    /**
+     * Set the min/max values for radius and duration.
+     */
+    void initRadiusAndDurationMinMax() {
+        minRadius = minRadiusConfig;
+        maxRadius = maxRadiusConfig;
+        minDuration = minDurationConfig;
+        maxDuration = maxDurationConfig;
     }
 
     /**
@@ -256,7 +256,7 @@ public class LUMOS_FERVENS extends O2StationarySpell {
      * This is the stationary spell's effect. age() must be called in this if you want the spell to age and die eventually.
      */
     @Override
-    void upkeep() {
+    public void upkeep() {
         age();
     }
 
@@ -274,5 +274,9 @@ public class LUMOS_FERVENS extends O2StationarySpell {
         if (baseBlock != null && originalMaterial != null) {
             baseBlock.setType(originalMaterial);
         }
+    }
+
+    public boolean checkSpellDeserialization() {
+        return playerUUID != null && location != null && originalMaterial != null;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/MOLLIARE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/MOLLIARE.java
@@ -19,7 +19,7 @@ import java.util.UUID;
  *
  * @author Azami7
  * @version Ollivanders2
- * @see <a href = "https://harrypotter.fandom.com/wiki/Cushioning_Charm">https://harrypotter.fandom.com/wiki/Cushioning_Charm</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Cushioning_Charm">https://harrypotter.fandom.com/wiki/Cushioning_Charm</a>
  */
 public class MOLLIARE extends O2StationarySpell {
     /**
@@ -62,15 +62,18 @@ public class MOLLIARE extends O2StationarySpell {
     public MOLLIARE(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
         super(plugin, pid, location);
         spellType = O2StationarySpellType.MOLLIARE;
-        minRadius = minRadiusConfig;
-        maxRadius = maxRadiusConfig;
-        minDuration = minDurationConfig;
-        maxDuration = maxDurationConfig;
 
         setRadius(radius);
         setDuration(duration);
 
         common.printDebugMessage("Creating stationary spell type " + spellType.name(), null, null, false);
+    }
+
+    void initRadiusAndDurationMinMax() {
+        minRadius = minRadiusConfig;
+        maxRadius = maxRadiusConfig;
+        minDuration = minDurationConfig;
+        maxDuration = maxDurationConfig;
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/MUFFLIATO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/MUFFLIATO.java
@@ -21,7 +21,7 @@ import java.util.UUID;
  *
  * @author Azami7
  * @version Ollivanders2
- * @see <a href = "https://harrypotter.fandom.com/wiki/Muffliato_Charm">https://harrypotter.fandom.com/wiki/Muffliato_Charm</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Muffliato_Charm">https://harrypotter.fandom.com/wiki/Muffliato_Charm</a>
  */
 public class MUFFLIATO extends ShieldSpell {
     /**
@@ -64,15 +64,18 @@ public class MUFFLIATO extends ShieldSpell {
     public MUFFLIATO(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
         super(plugin, pid, location);
         spellType = O2StationarySpellType.MUFFLIATO;
-        minRadius = minRadiusConfig;
-        maxRadius = maxRadiusConfig;
-        minDuration = minDurationConfig;
-        maxDuration = maxDurationConfig;
 
         setRadius(radius);
         setDuration(duration);
 
         common.printDebugMessage("Creating stationary spell type " + spellType.name(), null, null, false);
+    }
+
+    void initRadiusAndDurationMinMax() {
+        minRadius = minRadiusConfig;
+        maxRadius = maxRadiusConfig;
+        minDuration = minDurationConfig;
+        maxDuration = maxDurationConfig;
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/NULLUM_APPAREBIT.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/NULLUM_APPAREBIT.java
@@ -24,7 +24,7 @@ import java.util.UUID;
  *
  * @author Azami7
  * @version Ollivanders2
- * @see <a href = "https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx">https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx">https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx</a>
  */
 public class NULLUM_APPAREBIT extends O2StationarySpell {
     /**
@@ -68,15 +68,17 @@ public class NULLUM_APPAREBIT extends O2StationarySpell {
         super(plugin, pid, location);
         spellType = O2StationarySpellType.NULLUM_APPAREBIT;
 
-        minRadius = minRadiusConfig;
-        maxRadius = maxRadiusConfig;
-        minDuration = minDurationConfig;
-        maxDuration = maxDurationConfig;
-
         setRadius(radius);
         setDuration(duration);
 
         common.printDebugMessage("Creating stationary spell type " + spellType.name(), null, null, false);
+    }
+
+    void initRadiusAndDurationMinMax() {
+        minRadius = minRadiusConfig;
+        maxRadius = maxRadiusConfig;
+        minDuration = minDurationConfig;
+        maxDuration = maxDurationConfig;
     }
 
     /**
@@ -168,8 +170,6 @@ public class NULLUM_APPAREBIT extends O2StationarySpell {
     @Override
     void doOnPlayerTeleportEvent(@NotNull PlayerTeleportEvent event) {
         Location destination = event.getTo();
-        if (destination == null)
-            return;
 
         if (isLocationInside(destination)) {
             event.setCancelled(true);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/NULLUM_EVANESCUNT.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/NULLUM_EVANESCUNT.java
@@ -24,7 +24,7 @@ import java.util.UUID;
  *
  * @author Azami7
  * @version Ollivanders2
- * @see <a href = "https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx">https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx">https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx</a>
  */
 public class NULLUM_EVANESCUNT extends O2StationarySpell {
     /**
@@ -51,16 +51,18 @@ public class NULLUM_EVANESCUNT extends O2StationarySpell {
         super(plugin, pid, location);
         spellType = O2StationarySpellType.NULLUM_EVANESCUNT;
 
+        setRadius(radius);
+        setDuration(duration);
+
+        common.printDebugMessage("Creating stationary spell type " + spellType.name(), null, null, false);
+    }
+
+    void initRadiusAndDurationMinMax() {
         // make min/max radius and duration the same as Nullum Apparebit
         minRadius = NULLUM_APPAREBIT.minRadiusConfig;
         maxRadius = NULLUM_APPAREBIT.maxRadiusConfig;
         minDuration = NULLUM_APPAREBIT.minDurationConfig;
         maxDuration = NULLUM_APPAREBIT.maxDurationConfig;
-
-        setRadius(radius);
-        setDuration(duration);
-
-        common.printDebugMessage("Creating stationary spell type " + spellType.name(), null, null, false);
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpellType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/O2StationarySpellType.java
@@ -9,88 +9,130 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Represents allowable stationary spells.
+ * Enumeration of all available stationary spells in Ollivanders2.
+ *
+ * <p>Each stationary spell type encapsulates the implementation class and magic level required
+ * to cast the spell. Stationary spells are area-of-effect spells that persist in a location
+ * and affect players within their radius.</p>
+ *
+ * <p>This enum provides utility methods for looking up spells by name, checking if a player is
+ * within a spell's radius, and retrieving spell metadata such as class and magic level.</p>
  *
  * @author Azami7
  * @version Ollivanders2
  */
 public enum O2StationarySpellType {
     /**
-     * {@link ALIQUAM_FLOO}
+     * Aliquam Floo: A Floo Network destination spell for stationary networks.
+     *
+     * @see ALIQUAM_FLOO
      */
     ALIQUAM_FLOO(ALIQUAM_FLOO.class, MagicLevel.EXPERT),
     /**
-     * {@link CAVE_INIMICUM}
+     * Cave Inimicum: A protective barrier spell that repels enemies.
+     *
+     * @see CAVE_INIMICUM
      */
     CAVE_INIMICUM(CAVE_INIMICUM.class, MagicLevel.NEWT),
     /**
-     * {@link COLLOPORTUS}
+     * Colloportus: Seals a passage magically. Requires expert level and can only be undone with Alohomora.
+     *
+     * @see COLLOPORTUS
      */
-    COLLOPORTUS(COLLOPORTUS.class, MagicLevel.EXPERT), // colloportus can only be undone with alohomora so we level to max to ensure other spells cannot undo it
+    COLLOPORTUS(COLLOPORTUS.class, MagicLevel.EXPERT),
     /**
-     * {@link HARMONIA_NECTERE_PASSUS}
+     * Harmonia Nectere Passus: A spell that creates harmony and binding effects.
+     *
+     * @see HARMONIA_NECTERE_PASSUS
      */
     HARMONIA_NECTERE_PASSUS(HARMONIA_NECTERE_PASSUS.class, MagicLevel.EXPERT),
     /**
-     * {@link HERBICIDE}
+     * Herbicide: Kills plants and vegetation in an area.
+     *
+     * @see HERBICIDE
      */
     HERBICIDE(HERBICIDE.class, MagicLevel.BEGINNER),
     /**
-     * {@link HORCRUX}
+     * Horcrux: Creates or manages Horcrux objects.
+     *
+     * @see HORCRUX
      */
     HORCRUX(HORCRUX.class, MagicLevel.EXPERT),
     /**
-     * {@link LUMOS_FERVENS}
+     * Lumos Fervens: Creates intense light and heat in an area.
+     *
+     * @see LUMOS_FERVENS
      */
     LUMOS_FERVENS(LUMOS_FERVENS.class, MagicLevel.OWL),
     /**
-     * {@link MOLLIARE}
+     * Molliare: A cushioning spell that softens impacts.
+     *
+     * @see MOLLIARE
      */
     MOLLIARE(MOLLIARE.class, MagicLevel.OWL),
     /**
-     * {@link MUFFLIATO}
+     * Muffliato: Mutes conversations within a specified area.
+     *
+     * @see MUFFLIATO
      */
     MUFFLIATO(MUFFLIATO.class, MagicLevel.NEWT),
     /**
-     * {@link NULLUM_APPAREBIT}
+     * Nullum Apparebit: Makes objects or effects invisible or undetectable.
+     *
+     * @see NULLUM_APPAREBIT
      */
     NULLUM_APPAREBIT(NULLUM_APPAREBIT.class, MagicLevel.EXPERT),
     /**
-     * {@link NULLUM_EVANESCUNT}
+     * Nullum Evanescunt: Causes objects or effects to vanish from an area.
+     *
+     * @see NULLUM_EVANESCUNT
      */
     NULLUM_EVANESCUNT(NULLUM_EVANESCUNT.class, MagicLevel.EXPERT),
     /**
-     * {@link PROTEGO_HORRIBILIS}
+     * Protego Horribilis: A protection curse that defends against attacks.
+     *
+     * @see PROTEGO_HORRIBILIS
      */
     PROTEGO_HORRIBILIS(PROTEGO_HORRIBILIS.class, MagicLevel.EXPERT),
     /**
-     * {@link PROTEGO_MAXIMA}
+     * Protego Maxima: A maximum-strength protective barrier spell.
+     *
+     * @see PROTEGO_MAXIMA
      */
     PROTEGO_MAXIMA(PROTEGO_MAXIMA.class, MagicLevel.EXPERT),
     /**
-     * {@link PROTEGO_TOTALUM}
+     * Protego Totalum: A comprehensive protective spell covering an entire area.
+     *
+     * @see PROTEGO_TOTALUM
      */
     PROTEGO_TOTALUM(PROTEGO_TOTALUM.class, MagicLevel.EXPERT),
     /**
-     * {@link REPELLO_MUGGLETON}
+     * Repello Muggleton: Repels non-magical people from a protected area.
+     *
+     * @see REPELLO_MUGGLETON
      */
     REPELLO_MUGGLETON(REPELLO_MUGGLETON.class, MagicLevel.NEWT);
 
     /**
-     * The class of stationary spell this creates
+     * The implementation class for this stationary spell.
+     *
+     * <p>Used to instantiate new instances of this spell type and access spell-specific behavior.</p>
      */
     private final Class<?> className;
 
     /**
-     * The level of this stationary spell, for use with counter-spells
+     * The magic level required to cast this stationary spell.
+     *
+     * <p>Used to determine compatibility with counter-spells and other magic interactions that depend
+     * on spell power levels.</p>
      */
     private final MagicLevel level;
 
     /**
-     * Constructor
+     * Constructs a new stationary spell type with the specified implementation class and magic level.
      *
-     * @param className the class this type represents
-     * @param level     the level of this stationary spell
+     * @param className the implementation class for this spell type (not null)
+     * @param level     the magic level required to cast this spell (not null)
      */
     O2StationarySpellType(@NotNull Class<?> className, @NotNull MagicLevel level) {
         this.className = className;
@@ -98,9 +140,9 @@ public enum O2StationarySpellType {
     }
 
     /**
-     * Get the class for this stationary spell
+     * Gets the implementation class for this stationary spell type.
      *
-     * @return the class name for this spell
+     * @return the Class object representing the implementation of this spell (never null)
      */
     @NotNull
     public Class<?> getClassName() {
@@ -108,9 +150,12 @@ public enum O2StationarySpellType {
     }
 
     /**
-     * Get the level of magic for this spell, for counter-spells
+     * Gets the magic level required to cast this stationary spell.
      *
-     * @return the level of this spell
+     * <p>The level is used to determine compatibility with counter-spells and defensive magic.
+     * A counter-spell must be of equal or higher level to successfully dispel this spell.</p>
+     *
+     * @return the magic level of this spell (never null)
      */
     @NotNull
     public MagicLevel getLevel() {
@@ -118,17 +163,21 @@ public enum O2StationarySpellType {
     }
 
     /**
-     * Get the spell by name
+     * Looks up a stationary spell type by its enum name (case-insensitive).
      *
-     * @param name the name of the spell
-     * @return the spell type or null if not found
+     * <p>The method converts the input string to uppercase and attempts to match it against
+     * the enum constant names. For example, "muffliato" or "MUFFLIATO" both resolve to
+     * {@link #MUFFLIATO}. Invalid names gracefully return null without throwing an exception.</p>
+     *
+     * @param name the name of the spell to look up (not null)
+     * @return the matching spell type, or null if no spell with that name exists
      */
     @Nullable
     public static O2StationarySpellType getStationarySpellTypeFromString(@NotNull String name) {
         O2StationarySpellType spellType = null;
 
         try {
-            spellType = O2StationarySpellType.valueOf(name);
+            spellType = O2StationarySpellType.valueOf(name.toUpperCase());
         }
         catch (Exception e) {
             // do nothing, this is expected if they send a string that is not a valid spell
@@ -138,9 +187,13 @@ public enum O2StationarySpellType {
     }
 
     /**
-     * Get the spell name for this spell type.
+     * Gets the human-readable name for this spell type.
      *
-     * @return the spell name for this spell type.
+     * <p>Transforms the enum constant name by replacing underscores with spaces and capitalizing
+     * the first letter of each word. For example, {@link #MUFFLIATO} becomes "Muffliato" and
+     * {@link #PROTEGO_MAXIMA} becomes "Protego Maxima".</p>
+     *
+     * @return the formatted spell name (never null)
      */
     @NotNull
     public String getSpellName() {
@@ -150,12 +203,16 @@ public enum O2StationarySpellType {
     }
 
     /**
-     * Is a player inside the radius of an instance of this stationary spell type?
+     * Checks whether a player is within the radius of an active stationary spell of this type.
      *
-     * @param player the player to check
-     * @return true if the player is within the radius of a stationary spell of this type, false otherwise
+     * <p>Retrieves all active stationary spells at the player's current location and checks if any
+     * are of this spell type. A player may be affected by multiple spell types simultaneously.</p>
+     *
+     * @param player the player to check (not null)
+     * @return true if the player is within the radius of at least one active spell of this type,
+     *         false otherwise
      */
-    public boolean isPlayerInsideStationary(Player player) {
+    public boolean isPlayerInsideStationarySpell(@NotNull Player player) {
         Location location = player.getLocation();
 
         for (O2StationarySpell stationarySpell : Ollivanders2API.getStationarySpells().getStationarySpellsAtLocation(location)) {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO_HORRIBILIS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO_HORRIBILIS.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * @author Azami7
  * @version Ollivanders2
- * @see <a href = "https://harrypotter.fandom.com/wiki/Protego_horribilis">https://harrypotter.fandom.com/wiki/Protego_horribilis</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Protego_horribilis">https://harrypotter.fandom.com/wiki/Protego_horribilis</a>
  */
 public class PROTEGO_HORRIBILIS extends ShieldSpell {
     /**
@@ -63,15 +63,18 @@ public class PROTEGO_HORRIBILIS extends ShieldSpell {
     public PROTEGO_HORRIBILIS(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
         super(plugin, pid, location);
         spellType = O2StationarySpellType.PROTEGO_HORRIBILIS;
-        minRadius = minRadiusConfig;
-        maxRadius = maxRadiusConfig;
-        minDuration = minDurationConfig;
-        maxDuration = maxDurationConfig;
 
         setRadius(radius);
         setDuration(duration);
 
         common.printDebugMessage("Creating stationary spell type " + spellType.name(), null, null, false);
+    }
+
+    void initRadiusAndDurationMinMax() {
+        minRadius = minRadiusConfig;
+        maxRadius = maxRadiusConfig;
+        minDuration = minDurationConfig;
+        maxDuration = maxDurationConfig;
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO_MAXIMA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO_MAXIMA.java
@@ -31,7 +31,7 @@ import java.util.UUID;
  *
  * @author Azami7
  * @version Ollivanders2
- * @see <a href = "https://harrypotter.fandom.com/wiki/Protego_Maxima">https://harrypotter.fandom.com/wiki/Protego_Maxima</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Protego_Maxima">https://harrypotter.fandom.com/wiki/Protego_Maxima</a>
  * @since 2.21
  */
 public class PROTEGO_MAXIMA extends ShieldSpell {
@@ -63,7 +63,7 @@ public class PROTEGO_MAXIMA extends ShieldSpell {
     /**
      * The maximum distance for an arrow, which is the furthest flying projectile.
      *
-     * @see <a href = "https://minecraft.fandom.com/wiki/Arrow">https://minecraft.fandom.com/wiki/Arrow</a>
+     * @see <a href="https://minecraft.fandom.com/wiki/Arrow">https://minecraft.fandom.com/wiki/Arrow</a>
      */
     private final int maxDistance = 120;
 
@@ -90,15 +90,18 @@ public class PROTEGO_MAXIMA extends ShieldSpell {
     public PROTEGO_MAXIMA(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
         super(plugin, pid, location);
         spellType = O2StationarySpellType.PROTEGO_MAXIMA;
-        minRadius = minRadiusConfig;
-        maxRadius = maxRadiusConfig;
-        minDuration = minDurationConfig;
-        maxDuration = maxDurationConfig;
 
         setRadius(radius);
         setDuration(duration);
 
         common.printDebugMessage("Creating stationary spell type " + spellType.name(), null, null, false);
+    }
+
+    void initRadiusAndDurationMinMax() {
+        minRadius = minRadiusConfig;
+        maxRadius = maxRadiusConfig;
+        minDuration = minDurationConfig;
+        maxDuration = maxDurationConfig;
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO_TOTALUM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/PROTEGO_TOTALUM.java
@@ -24,7 +24,7 @@ import java.util.UUID;
  *
  * @author Azami7
  * @version Ollivanders2
- * @see <a href = "https://harrypotter.fandom.com/wiki/Protego_totalum">https://harrypotter.fandom.com/wiki/Protego_totalum</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Protego_totalum">https://harrypotter.fandom.com/wiki/Protego_totalum</a>
  * @since 2.21
  */
 public class PROTEGO_TOTALUM extends ShieldSpell {
@@ -74,22 +74,24 @@ public class PROTEGO_TOTALUM extends ShieldSpell {
         super(plugin, pid, location);
         spellType = O2StationarySpellType.PROTEGO_TOTALUM;
 
-        minRadius = minRadiusConfig;
-        maxRadius = maxRadiusConfig;
-        minDuration = minDurationConfig;
-        maxDuration = maxDurationConfig;
-
         setRadius(radius);
         setDuration(duration);
 
         common.printDebugMessage("Creating stationary spell type " + spellType.name(), null, null, false);
     }
 
+    void initRadiusAndDurationMinMax() {
+        minRadius = minRadiusConfig;
+        maxRadius = maxRadiusConfig;
+        minDuration = minDurationConfig;
+        maxDuration = maxDurationConfig;
+    }
+
     /**
      * Age the spell by 1 tick
      */
     @Override
-    void upkeep() {
+    public void upkeep() {
         age();
 
         // check for hostile entities in the spell area and remove their AI do they do not move or attack
@@ -112,7 +114,7 @@ public class PROTEGO_TOTALUM extends ShieldSpell {
         Location toLoc = event.getTo();
         Location fromLoc = event.getFrom(); // will never be null
 
-        if (toLoc == null || toLoc.getWorld() == null || fromLoc.getWorld() == null)
+        if (toLoc.getWorld() == null || fromLoc.getWorld() == null)
             return;
 
         // they are already inside the protected area

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/REPELLO_MUGGLETON.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/REPELLO_MUGGLETON.java
@@ -1,6 +1,7 @@
 package net.pottercraft.ollivanders2.stationaryspell;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
@@ -10,10 +11,23 @@ import org.jetbrains.annotations.NotNull;
 import java.util.UUID;
 
 /**
- * The Muggle-Repelling -Repello Muggletum - is a charm that prevents Muggles from seeing or entering an area. Any
- * non-magic person gets close to the vicinity of the enchantment remembers something urgent to do and leave.
- * <p>
- * {@link net.pottercraft.ollivanders2.spell.REPELLO_MUGGLETON}
+ * The Muggle-Repelling Charm (Repello Muggleton) - a stationary concealment shield spell that prevents
+ * non-magical people from seeing or entering a protected area.
+ *
+ * <p>When a muggle attempts to enter the spell area, they are repelled with an inexplicable compulsion to
+ * go elsewhere - they remember urgent tasks or important appointments. Muggles also cannot see wizards or
+ * witches who are concealed within the spell area, nor can they hear conversations happening inside.
+ * Unlike some concealment spells, this charm does not trigger proximity alarms when muggles approach.</p>
+ *
+ * <p><strong>Behavior:</strong>
+ * <ul>
+ *   <li>Muggles cannot enter the spell area ({@link #canEnter(LivingEntity)} returns false)</li>
+ *   <li>Muggles cannot see wizards inside ({@link #canSee(LivingEntity)} returns false)</li>
+ *   <li>Muggles cannot hear conversations from inside ({@link #canHear(LivingEntity)} returns false)</li>
+ *   <li>All entities (including muggles) can target players inside without restriction</li>
+ *   <li>No proximity alarms are triggered when muggles approach the boundary</li>
+ * </ul>
+ * </p>
  *
  * @author Azami7
  * @version Ollivanders2
@@ -22,7 +36,34 @@ import java.util.UUID;
  */
 public class REPELLO_MUGGLETON extends ConcealmentShieldSpell {
     /**
-     * Simple constructor used for deserializing saved stationary spells at server start. Do not use to cast spell.
+     * Minimum spell radius in blocks (5 blocks).
+     * The smallest protected area that can be created with this spell.
+     */
+    public static final int minRadiusConfig = 5;
+
+    /**
+     * Maximum spell radius in blocks (20 blocks).
+     * The largest protected area that can be created with this spell.
+     */
+    public static final int maxRadiusConfig = 20;
+
+    /**
+     * Minimum spell duration in ticks (30 seconds).
+     * The shortest time a spell can persist after being cast.
+     */
+    public static final int minDurationConfig = Ollivanders2Common.ticksPerSecond * 30;
+
+    /**
+     * Maximum spell duration in ticks (30 minutes).
+     * The longest time a spell can persist after being cast.
+     */
+    public static final int maxDurationConfig = Ollivanders2Common.ticksPerMinute * 30;
+
+    /**
+     * Constructs a REPELLO_MUGGLETON spell from deserialized data.
+     *
+     * <p>Used only for loading saved spells from disk at server startup. This constructor should not be
+     * called directly when casting a new spell - use the full constructor instead.</p>
      *
      * @param plugin a callback to the MC plugin
      */
@@ -32,17 +73,19 @@ public class REPELLO_MUGGLETON extends ConcealmentShieldSpell {
         spellType = O2StationarySpellType.REPELLO_MUGGLETON;
 
         initMessages();
-
     }
 
     /**
-     * Constructor
+     * Constructs a new REPELLO_MUGGLETON spell cast by a player.
+     *
+     * <p>Creates the spell at the specified location with the given radius and duration.
+     * Initializes entry denial messages that muggles will see when blocked from entering.</p>
      *
      * @param plugin   a callback to the MC plugin
-     * @param pid      the player who cast the spell
+     * @param pid      the UUID of the player who cast the spell
      * @param location the center location of the spell
-     * @param radius   the radius for this spell
-     * @param duration the duration of the spell
+     * @param radius   the initial radius of the protected area in blocks
+     * @param duration the initial duration of the spell in ticks
      */
     public REPELLO_MUGGLETON(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
         super(plugin, pid, location, radius, duration);
@@ -52,19 +95,41 @@ public class REPELLO_MUGGLETON extends ConcealmentShieldSpell {
         initMessages();
     }
 
-    private void initMessages() {
-        messages.add("You just remembered you need to do something someplace else.");
-        messages.add("You just recalled an important appointment you need to get to somewhere else.");
-        messages.add("Why were you going that way? You want to go a different way.");
-        messages.add("You realize you don't actually want to go that way.");
-        messages.add("You hear someone behind you calling your name.");
+    /**
+     * Initializes the min/max radius and duration boundaries for this spell.
+     *
+     * <p>Sets the spell's radius and duration constraints to the configured values:
+     * radius 5-20 blocks, duration 30 seconds to 30 minutes.</p>
+     */
+    void initRadiusAndDurationMinMax() {
+        minRadius = minRadiusConfig;
+        maxRadius = maxRadiusConfig;
+        minDuration = minDurationConfig;
+        maxDuration = maxDurationConfig;
     }
 
     /**
-     * Is this entity a player and are they a Muggle?
+     * Initializes the entry denial messages muggles see when blocked.
+     *
+     * <p>Populates the spell's message list with various reasons that compel muggles to avoid entering
+     * the protected area. A random message from this list is shown to each muggle that attempts entry.</p>
+     */
+    private void initMessages() {
+        entryDenyMessages.add("You just remembered you need to do something someplace else.");
+        entryDenyMessages.add("You just recalled an important appointment you need to get to somewhere else.");
+        entryDenyMessages.add("Why were you going that way? You want to go a different way.");
+        entryDenyMessages.add("You realize you don't actually want to go that way.");
+        entryDenyMessages.add("You hear someone behind you calling your name.");
+    }
+
+    /**
+     * Checks if an entity is a muggle (non-magical person).
+     *
+     * <p>Only players can be muggles. Non-player entities (mobs, animals, etc.) are not considered muggles
+     * and are treated as magical beings for spell purposes.</p>
      *
      * @param entity the entity to check
-     * @return true if they are a muggle, false otherwise
+     * @return true if the entity is a player marked as a muggle, false otherwise
      */
     private boolean isMuggle(Entity entity) {
         if (entity instanceof Player) {
@@ -75,10 +140,13 @@ public class REPELLO_MUGGLETON extends ConcealmentShieldSpell {
     }
 
     /**
-     * Can this entity see players inside the spell area? Assumes the entity being checked is outside the spell area.
+     * Determines if an entity outside the spell can see players inside.
      *
-     * @param entity the entity looking inside the area
-     * @return true if the entity is not a Muggle, false otherwise
+     * <p>Muggles (non-magical people) cannot see wizards and witches concealed within the spell area.
+     * Only magical beings have the ability to perceive those inside the protected zone.</p>
+     *
+     * @param entity the entity outside the spell area checking visibility
+     * @return false if the entity is a muggle, true if they can see inside
      */
     protected boolean canSee(@NotNull LivingEntity entity) {
         boolean isMuggle = isMuggle(entity);
@@ -92,59 +160,76 @@ public class REPELLO_MUGGLETON extends ConcealmentShieldSpell {
     }
 
     /**
-     * Can this entity target players inside the spell area? Assumes the entity being checked is outside the spell area.
+     * Determines if an entity outside the spell can target players inside.
      *
-     * @param entity the entity targeting inside the area
-     * @return true, this spell does not prevent targeting
+     * <p>REPELLO_MUGGLETON does not prevent entities from targeting wizards inside the protected area.
+     * Unlike some concealment spells, it focuses on hiding and preventing entry rather than blocking attacks.</p>
+     *
+     * @param entity the entity outside the spell area attempting to target
+     * @return true - all entities (including muggles) can target inside this spell
      */
     @Override
-    protected boolean canTarget(@NotNull LivingEntity entity) {
+    public boolean canTarget(@NotNull LivingEntity entity) {
         return true;
     }
 
     /**
-     * Can this entity enter the spell area? Assumes the entity being checked is outside the spell area.
+     * Determines if an entity can enter the spell's protected area.
      *
-     * @param entity the entity entering the area
-     * @return true if the entity is not a Muggle, false otherwise
+     * <p>Only magical beings (wizards, witches, and non-player entities) can enter.
+     * Muggles are prevented from entering and receive an entry denial message explaining their compulsion to leave.</p>
+     *
+     * @param entity the entity attempting to enter the spell area
+     * @return false if the entity is a muggle, true if they can enter
      */
-    protected boolean canEnter(@NotNull LivingEntity entity) {
+    public boolean canEnter(@NotNull LivingEntity entity) {
         return !isMuggle(entity);
     }
 
     /**
-     * Can this entity "hear" sounds from inside the spell area? Assumes the entity being checked is outside the spell area.
+     * Determines if an entity outside the spell can hear conversations from inside.
      *
-     * @param entity the entity entering the area
-     * @return true if the entity is not a Muggle, false otherwise
+     * <p>Muggles cannot hear sounds from protected wizards inside the spell area.
+     * Non-muggles can hear conversations normally.</p>
+     *
+     * @param entity the entity outside the spell area checking hearing capability
+     * @return true if the entity is not a Muggle, false if muggles cannot hear
      */
     protected boolean canHear(@NotNull LivingEntity entity) {
         return !isMuggle(entity);
     }
 
     /**
-     * Check the proximity alarm conditions at the location.
-     * Repello Muggleton does not have a proximity alarm.
+     * Checks if a player near the spell boundary should trigger a proximity alarm.
      *
-     * @param player the player that triggered the alarm
+     * <p>REPELLO_MUGGLETON does not have proximity alarm functionality.
+     * This spell silently repels muggles without alerting the protected players.</p>
+     *
+     * @param player the player outside the spell near the proximity boundary
+     * @return always false - no alarms are triggered for this spell
      */
     protected boolean checkAlarm(@NotNull Player player) {
         return false;
     }
 
     /**
-     * Check the proximity alarm conditions at the location. Assumes that a check to determine that a proximity alarm
-     * should go off for this location has happened and called this.
+     * Checks if a non-player entity near the spell boundary should trigger a proximity alarm.
      *
-     * @param entity the entity that triggered the alarm
+     * <p>REPELLO_MUGGLETON does not have proximity alarm functionality.
+     * Hostile entities approaching the boundary do not trigger alerts.</p>
+     *
+     * @param entity the entity outside the spell near the proximity boundary
+     * @return always false - no alarms are triggered for this spell
      */
     protected boolean checkAlarm(@NotNull LivingEntity entity) {
         return false;
     }
 
     /**
-     * Do the proximity alarm action for this spell.
-     * Repello Muggleton does not have a proximity alarm.
+     * Executes the proximity alarm action for this spell.
+     *
+     * <p>This method does nothing for REPELLO_MUGGLETON since the spell
+     * does not have proximity alarm functionality.</p>
      */
     protected void proximityAlarm() {
     }

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/effect/BabblingTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/effect/BabblingTest.java
@@ -8,7 +8,6 @@ import org.bukkit.event.player.AsyncPlayerChatEvent;
 import java.util.HashSet;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test suite for the BABBLING effect.
@@ -78,7 +77,7 @@ public class BabblingTest extends EffectTestSuper {
 
             String actualChat = event.getMessage();
             if (!actualChat.equals(chat)) {
-                assertTrue(TestCommon.stringContainsListMatch(babbling.dictionary, actualChat), "Chat is not from the dictionary, chat: " + actualChat);
+                TestCommon.stringContainsListMatch(babbling.dictionary, actualChat);
                 chance = chance + 1;
             }
         }

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/HerbicidePotionTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/potion/HerbicidePotionTest.java
@@ -7,7 +7,6 @@ import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpellType;
 import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
 import org.bukkit.Location;
 import org.bukkit.World;
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.ThrownPotion;
 import org.bukkit.event.entity.PotionSplashEvent;
 import org.bukkit.inventory.ItemStack;
@@ -85,11 +84,11 @@ public class HerbicidePotionTest {
         ThrownPotion thrownPotion = testWorld.spawn(location, ThrownPotion.class);
         thrownPotion.setItem(potionItemStack);
 
-        PotionSplashEvent event = new PotionSplashEvent(thrownPotion, new HashMap<LivingEntity, Double>());
+        PotionSplashEvent event = new PotionSplashEvent(thrownPotion, new HashMap<>());
         mockServer.getPluginManager().callEvent(event);
         mockServer.getScheduler().performTicks(20);
 
-        assertTrue(Ollivanders2API.getStationarySpells().checkLocationForSpell(location, O2StationarySpellType.HERBICIDE), "Herbicide potion did not create herbicide stationary spell");
+        assertTrue(Ollivanders2API.getStationarySpells().checkLocationForStationarySpell(location, O2StationarySpellType.HERBICIDE), "Herbicide potion did not create herbicide stationary spell");
     }
 
     /**

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/CaveInimicumTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/CaveInimicumTest.java
@@ -1,0 +1,76 @@
+package net.pottercraft.ollivanders2.test.stationaryspell;
+
+import net.pottercraft.ollivanders2.stationaryspell.CAVE_INIMICUM;
+import net.pottercraft.ollivanders2.stationaryspell.ConcealmentShieldSpell;
+import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpellType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Test suite for the {@link CAVE_INIMICUM} stationary spell implementation.
+ *
+ * <p>Tests the cave inimicum protective barrier spell, which prevents hostile entities from entering
+ * a protected area. Inherits common concealment shield spell tests from {@link ConcealmentShieldSpellTest}
+ * and provides spell-specific factory methods for test setup.</p>
+ */
+public class CaveInimicumTest extends ConcealmentShieldSpellTest {
+    /**
+     * Gets the spell type for this test suite.
+     *
+     * @return {@link O2StationarySpellType#CAVE_INIMICUM}
+     */
+    @Override
+    O2StationarySpellType getSpellType() {
+        return O2StationarySpellType.CAVE_INIMICUM;
+    }
+
+    /**
+     * Creates a {@link CAVE_INIMICUM} spell instance for testing.
+     *
+     * <p>Constructs a new spell at the specified location cast by the given player, using default
+     * radius and duration values inherited from the parent test class.</p>
+     *
+     * @param caster   the player casting the spell (not null)
+     * @param location the center location for the spell (not null)
+     * @return a new CAVE_INIMICUM spell instance
+     */
+    @Override
+    CAVE_INIMICUM createStationarySpell(Player caster, Location location) {
+        return new CAVE_INIMICUM(testPlugin, caster.getUniqueId(), location, defaultRadius, defaultDuration);
+    }
+
+    /**
+     * CAVE_INIMICUM does not restrict player visibility based on spell type (all players visible).
+     *
+     * <p>Unlike REPELLO_MUGGLETON, CAVE_INIMICUM does not distinguish between muggles and non-muggles
+     * for visibility purposes. This test is a no-op placeholder to fulfill the abstract method contract.</p>
+     */
+    @Override @Test
+    void doOnEntityTargetEventTestVisibilityCheck() {}
+
+    /**
+     * Verifies that the caster receives the correct proximity alarm message.
+     *
+     * <p>When a hostile entity approaches the spell boundary, checks that:
+     * <ul>
+     *   <li>The caster receives a proximity alarm message</li>
+     *   <li>The message matches the spell's configured proximity alarm message</li>
+     * </ul>
+     * </p>
+     *
+     * @param caster the player who cast the spell (should receive alarm message)
+     * @param spell  the CAVE_INIMICUM spell instance (provides the expected alarm message)
+     */
+    @Override
+    void checkProximityAlarm(PlayerMock caster, ConcealmentShieldSpell spell) {
+        String message = caster.nextMessage();
+        assertNotNull(message, "Caster did not get a proximity alarm message");
+        assertEquals(((CAVE_INIMICUM)spell).getProximityAlarmMessage(), TestCommon.cleanChatMessage(message), "Proximity alarm message did not match expected");
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/ConcealmentShieldSpellTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/ConcealmentShieldSpellTest.java
@@ -1,0 +1,359 @@
+package net.pottercraft.ollivanders2.test.stationaryspell;
+
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
+import net.pottercraft.ollivanders2.stationaryspell.ConcealmentShieldSpell;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Skeleton;
+import org.bukkit.event.entity.EntityTargetEvent;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Abstract test suite for concealment shield spell implementations.
+ *
+ * <p>Provides common test cases for all concealment shield spell types. Tests verify core behaviors
+ * including spell lifecycle (upkeep), entity targeting prevention, visibility toggling, area entry
+ * restrictions, chat filtering, proximity alarms, and cleanup effects. Subclasses implement
+ * spell-specific factory methods and proximity alarm verification.</p>
+ */
+abstract public class ConcealmentShieldSpellTest extends O2StationarySpellTest {
+    /**
+     * Default spell radius for test instances (10 blocks).
+     * Used by createStationarySpell() implementations as the initial radius.
+     */
+    int defaultRadius = 10;
+
+    /**
+     * Default spell duration for test instances (1000 ticks).
+     * Used by createStationarySpell() implementations as the initial duration.
+     */
+    int defaultDuration = 1000;
+
+    /**
+     * Creates a concealment shield spell instance for testing.
+     *
+     * <p>Subclasses implement this to create their specific spell type with default radius
+     * and duration values at the specified location.</p>
+     *
+     * @param caster   the player casting the spell (not null)
+     * @param location the center location for the spell (not null)
+     * @return a new concealment shield spell instance of the subclass type
+     */
+    abstract ConcealmentShieldSpell createStationarySpell(Player caster, Location location);
+
+    /**
+     * Tests the spell lifecycle during upkeep (aging and death).
+     *
+     * <p>Verifies that:
+     * <ul>
+     *   <li>Calling upkeep() decrements the spell duration by 1</li>
+     *   <li>The spell remains alive until duration reaches 0</li>
+     *   <li>The spell is killed when upkeep() is called at duration 1</li>
+     * </ul>
+     * </p>
+     */
+    @Override @Test
+    void upkeepTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 200, 4, 100);
+        PlayerMock player = mockServer.addPlayer();
+        ConcealmentShieldSpell stationarySpell = createStationarySpell(player, location);
+
+        int duration = stationarySpell.getDuration();
+        stationarySpell.upkeep();
+        assertEquals(duration - 1, stationarySpell.getDuration(), "");
+
+        duration = stationarySpell.getDuration();
+        stationarySpell.age(duration - 1);
+        assertFalse(stationarySpell.isKilled(), "");
+        stationarySpell.upkeep();
+        assertTrue(stationarySpell.isKilled(), "");
+    }
+
+    /**
+     * Tests entity targeting prevention for spells that block targeting.
+     *
+     * <p>Verifies that:
+     * <ul>
+     *   <li>Entities outside the spell area cannot target players inside (event cancelled)</li>
+     *   <li>Entities outside the spell area can target players outside (event not cancelled)</li>
+     *   <li>The test skips for spell types that allow unrestricted targeting (canTarget returns true)</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    void doOnEntityTargetEventTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 4, 100);
+        PlayerMock caster = mockServer.addPlayer();
+
+        // create concealment shield spell
+        ConcealmentShieldSpell stationarySpell = createStationarySpell(caster, location);
+        Ollivanders2API.getStationarySpells().addStationarySpell(stationarySpell);
+
+        // set player inside the spell radius
+        caster.setLocation(location);
+
+        // spawn skeleton outside the spell radius
+        Location outsideLocation = new Location(location.getWorld(), location.getX() + stationarySpell.getMaxRadius() + 1, location.getY(), location.getZ());
+        Skeleton skeleton = testWorld.spawn(outsideLocation, Skeleton.class);
+
+        // this spell type allows targeting inside the area, skip this test
+        if (stationarySpell.canTarget(skeleton))
+            return;
+
+        // skeleton target the player inside the spell radius
+        EntityTargetEvent event = new EntityTargetEvent(skeleton, caster, EntityTargetEvent.TargetReason.CLOSEST_ENTITY);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(event.isCancelled(), "");
+
+        // move the player outside the spell radius, skeleton target the player
+        caster.setLocation(outsideLocation);
+        event = new EntityTargetEvent(skeleton, caster, EntityTargetEvent.TargetReason.CLOSEST_ENTITY);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(event.isCancelled(), "");
+    }
+
+    /**
+     * Tests visibility toggling as players move across spell boundaries.
+     *
+     * <p>Verifies that concealment rules are properly applied and updated when players move relative
+     * to the spell area. Tests all four scenarios:
+     * <ul>
+     *   <li>Player outside can't see caster inside; caster inside can see player outside</li>
+     *   <li>Both inside: both can see each other</li>
+     *   <li>Caster exits: player inside can still see caster outside; caster outside can't see player inside</li>
+     *   <li>Both outside: both can see each other</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    void doOnPlayerMoveEventTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 4, 100);
+        PlayerMock caster = mockServer.addPlayer();
+        PlayerMock player = mockServer.addPlayer();
+
+        caster.setLocation(location);
+        ConcealmentShieldSpell concealmentShieldSpell = createStationarySpell(caster, location);
+        Location outsideSpellLocation = new Location(location.getWorld(), location.getX(), location.getY(), location.getZ() + concealmentShieldSpell.getProximityRadius() + 1);
+        player.setLocation(outsideSpellLocation); // player just outside proximity radius
+
+        Ollivanders2API.getStationarySpells().addStationarySpell(concealmentShieldSpell);
+        mockServer.getScheduler().performTicks(20);
+        // player cannot see caster in the spell area but caster can see player outside
+        assertFalse(player.canSee(caster), "Player outside spell area can see caster inside the spell area");
+        assertTrue(caster.canSee(player), "Caster inside the spell area cannot see player outside the spell area");
+
+        player.setLocation(location); // move player in to the spell area
+        PlayerMoveEvent event = new PlayerMoveEvent(player, outsideSpellLocation, location);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+
+        // player can now see caster in the spell area and caster can still see player
+        assertTrue(player.canSee(caster), "Player inside the spell area cannot see caster inside the spell area");
+        assertTrue(caster.canSee(player), "Caster inside the spell area cannot see player inside the spell area");
+
+        caster.setLocation(outsideSpellLocation);
+        event = new PlayerMoveEvent(caster, location, outsideSpellLocation);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+
+        // player can still see caster now outside the spell area but caster cannot see player inside
+        assertTrue(player.canSee(caster), "Player inside the spell area cannot see caster outside the spell area");
+        assertFalse(caster.canSee(player), "Caster outside the spell area can see player inside the spell area");
+
+        player.setLocation(outsideSpellLocation);
+        event = new PlayerMoveEvent(player, location, outsideSpellLocation);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+
+        // caster can now see player outside the spell area, player can still see caster
+        assertTrue(player.canSee(caster), "Player outside the spell area cannot see caster outside the spell area");
+        assertTrue(caster.canSee(player), "Caster outside the spell area cannot see player outside the spell area");
+    }
+
+    /**
+     * Tests spell-specific visibility logic from the perspective of outside entities.
+     *
+     * <p>Subclasses implement this to verify spell-specific visibility rules, such as which types
+     * of entities (muggles, non-magical beings, etc.) can or cannot see concealed players inside
+     * the protected area.</p>
+     */
+    @Test
+    abstract void doOnEntityTargetEventTestVisibilityCheck();
+
+    /**
+     * Tests proximity alarm functionality when entities approach the spell boundary.
+     *
+     * <p>Verifies that:
+     * <ul>
+     *   <li>Proximity detection correctly identifies locations inside and outside the proximity radius</li>
+     *   <li>When an entity moves into the proximity alarm range, appropriate alarm actions occur</li>
+     *   <li>For spells with proximity alarms enabled, checkProximityAlarm() is invoked</li>
+     *   <li>For spells without proximity alarms, no messages are sent to the caster</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    void doOnPlayerMoveEventTestProximityCheck() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 4, 100);
+        PlayerMock caster = mockServer.addPlayer();
+        caster.setLocation(location);
+
+        // create concealment shield spell
+        ConcealmentShieldSpell concealmentShieldSpell = createStationarySpell(caster, location);
+        Location insideProximityLocation = new Location(testWorld, location.getX() + (concealmentShieldSpell.getProximityRadius() - 1), location.getY(), location.getZ());
+        Location outsideProximityLocation = new Location(testWorld, location.getX() + (concealmentShieldSpell.getProximityRadius() + 1), location.getY(), location.getZ());
+
+        // create a player outside the spell, near the proximity boundary
+        PlayerMock player = mockServer.addPlayer();
+        player.setLocation(outsideProximityLocation);
+
+        Ollivanders2API.getStationarySpells().addStationarySpell(concealmentShieldSpell);
+        mockServer.getScheduler().performTicks(20);
+
+        assertTrue(concealmentShieldSpell.isInProximity(insideProximityLocation), "insideProximityLocation is not within the proximity area");
+        assertFalse(concealmentShieldSpell.isInProximity(outsideProximityLocation), "outsideProximityLocation is inside the proximity area");
+
+        // move player to proximity boundary
+        player.setLocation(outsideProximityLocation);
+        PlayerMoveEvent event = new PlayerMoveEvent(player, outsideProximityLocation, insideProximityLocation);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(Ollivanders2Common.ticksPerSecond * 2);
+
+        if (concealmentShieldSpell.doesAlarmOnProximty()) {
+            // spell has proximity alarms
+            checkProximityAlarm(caster, concealmentShieldSpell);
+        }
+        else {
+            // spell does not send proximity alarm messages so caster should not have received any alarm message about the muggle approaching
+            assertNull(caster.nextMessage(), "Caster received unexpected proximity alarm message");
+        }
+    }
+
+    /**
+     * Helper method for subclasses to verify spell-specific proximity alarm behavior.
+     *
+     * <p>Called by doOnPlayerMoveEventTestProximityCheck() when a spell has proximity alarms enabled.
+     * Subclasses implement this to verify that appropriate alarm messages are sent or other
+     * alarm actions are triggered.</p>
+     *
+     * @param caster                   the player who cast the spell (inside the spell area)
+     * @param concealmentShieldSpell   the active concealment spell to check alarm behavior on
+     */
+    abstract void checkProximityAlarm(PlayerMock caster, ConcealmentShieldSpell concealmentShieldSpell);
+
+    /**
+     * Tests that chat from inside the spell area is blocked from reaching outside recipients.
+     *
+     * <p>Verifies that:
+     * <ul>
+     *   <li>A player outside the spell is initially in the chat recipients list</li>
+     *   <li>When the caster inside sends chat, the outside player is removed from recipients</li>
+     *   <li>The outside player never receives the chat message</li>
+     *   <li>Conversation within the spell area is concealed from outsiders</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    void doOnAsyncPlayerChatEventTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 4, 100);
+        PlayerMock caster = mockServer.addPlayer();
+        PlayerMock player = mockServer.addPlayer();
+        caster.setLocation(location);
+
+        ConcealmentShieldSpell concealmentShieldSpell = createStationarySpell(caster, location);
+        Ollivanders2API.getStationarySpells().addStationarySpell(concealmentShieldSpell);
+        mockServer.getScheduler().performTicks(20);
+
+        Location outsideLocation = new Location(location.getWorld(), (location.getX() + concealmentShieldSpell.getMaxRadius() + 1), location.getY(), location.getZ());
+        player.setLocation(outsideLocation);
+
+        String chat = "test chat";
+        HashSet<Player> recipients = new HashSet<>() {{
+            add(player);
+        }};
+
+        caster.sendMessage(chat);
+        AsyncPlayerChatEvent event = new AsyncPlayerChatEvent(false, caster, chat, recipients);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+
+        assertTrue(event.getRecipients().isEmpty(), "event.getRecipients() is not empty");
+        assertNull(player.nextMessage(), "Player saw chat when speaker inside spell area");
+    }
+
+    /**
+     * Tests visibility initialization for newly joined players.
+     *
+     * <p>Verifies that:
+     * <ul>
+     *   <li>When a player joins the server while a spell is active, they immediately have correct visibility</li>
+     *   <li>Players inside the spell area are correctly hidden from the newly joined player based on spell rules</li>
+     *   <li>The newly joined player can see the caster when appropriate (e.g., outside the spell area)</li>
+     *   <li>Visibility is properly initialized without requiring movement events</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    void doOnPlayerJoinEvent() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 4, 100);
+        PlayerMock caster = mockServer.addPlayer();
+        caster.setLocation(location);
+
+        ConcealmentShieldSpell concealmentShieldSpell = createStationarySpell(caster, location);
+        Ollivanders2API.getStationarySpells().addStationarySpell(concealmentShieldSpell);
+        mockServer.getScheduler().performTicks(20);
+
+        PlayerMock player = mockServer.addPlayer();
+        assertFalse(player.canSee(caster), "Caster in spell area not hidden from player outside at join");
+        assertTrue(caster.canSee(player), "Player hidden from caster on join");
+    }
+
+    /**
+     * Tests cleanup of concealment effects when the spell expires.
+     *
+     * <p>Verifies that:
+     * <ul>
+     *   <li>Players inside the spell are initially hidden from outside players</li>
+     *   <li>When the spell expires after its duration elapses, all concealment effects are removed</li>
+     *   <li>Previously hidden players become visible again to all other players</li>
+     *   <li>The spell's visibility effects are properly reversed on cleanup</li>
+     * </ul>
+     * </p>
+     */
+    @Test
+    void doCleanUp() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 4, 100);
+        PlayerMock caster = mockServer.addPlayer();
+        PlayerMock player = mockServer.addPlayer();
+        caster.setLocation(location);
+
+        ConcealmentShieldSpell concealmentShieldSpell = createStationarySpell(caster, location);
+        Ollivanders2API.getStationarySpells().addStationarySpell(concealmentShieldSpell);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(player.canSee(caster));
+
+        mockServer.getScheduler().performTicks(defaultDuration);
+        assertTrue(player.canSee(caster), "After spell ended, player still cannot see caster");
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/O2StationarySpellTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/O2StationarySpellTest.java
@@ -1,0 +1,271 @@
+package net.pottercraft.ollivanders2.test.stationaryspell;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpell;
+import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpellType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Cow;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+abstract public class O2StationarySpellTest {
+    /**
+     * Shared mock Bukkit server instance for all tests.
+     *
+     * <p>Static field initialized once before all tests in this class. Reused across test instances
+     * to avoid expensive server setup/teardown for each test method.</p>
+     */
+    static ServerMock mockServer;
+
+    /**
+     * The plugin instance being tested.
+     *
+     * <p>Loaded fresh before each test method with the default configuration. Provides access to
+     * logger, scheduler, and other plugin API methods during tests.</p>
+     */
+    static Ollivanders2 testPlugin;
+
+    /**
+     * Initialize the mock Bukkit server before all tests.
+     *
+     * <p>Static setup method called once before all tests in this class. Creates the shared
+     * MockBukkit server instance that is reused across all test methods to avoid expensive
+     * server creation/destruction overhead.</p>
+     */
+    @BeforeAll
+    static void globalSetUp() {
+        Ollivanders2.testMode = true;
+
+        mockServer = MockBukkit.mock();
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+
+        // advance the server by 20 ticks to let the scheduler start (it has an initial delay of 20 ticks)
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
+    }
+
+    abstract O2StationarySpellType getSpellType();
+
+    abstract O2StationarySpell createStationarySpell(Player caster, Location location);
+
+    @Test
+    void durationTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 4, 100);
+        PlayerMock player = mockServer.addPlayer();
+        O2StationarySpell stationarySpell = createStationarySpell(player, location);
+
+        int duration = stationarySpell.getDuration();
+        assertTrue(duration <= stationarySpell.getMaxDuration(), "");
+        assertTrue(duration >= stationarySpell.getMinDuration(), "");
+
+        // increase the duration to just under the max
+        int newDuration = stationarySpell.getMaxDuration() - 1;
+        stationarySpell.increaseDuration(newDuration - duration); // increase by the difference
+        assertEquals(newDuration, stationarySpell.getDuration(), "");
+        // increase over the max
+        newDuration = stationarySpell.getMaxDuration() + 1;
+        stationarySpell.increaseDuration(newDuration - duration); // increase by the difference
+        assertEquals(stationarySpell.getMaxDuration(), stationarySpell.getDuration(), "");
+    }
+
+    @Test
+    void radiusTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 200, 4, 100);
+        PlayerMock player = mockServer.addPlayer();
+        O2StationarySpell stationarySpell = createStationarySpell(player, location);
+
+        int radius = stationarySpell.getRadius();
+        assertTrue(radius <= stationarySpell.getMaxRadius(), "");
+        assertTrue(radius >= stationarySpell.getMinRadius(), "");
+
+        // increase to just over the max
+        int newRadius = stationarySpell.getMaxRadius() + 1;
+        stationarySpell.increaseRadius(newRadius - radius); // increase by difference
+        assertEquals(stationarySpell.getMaxRadius(), stationarySpell.getRadius(), "");
+
+        // decrease to the min radius
+        newRadius = stationarySpell.getMinRadius();
+        stationarySpell.decreaseRadius(stationarySpell.getRadius() - newRadius); // decrease by difference
+        assertEquals(stationarySpell.getMinRadius(), stationarySpell.getRadius(), "");
+
+        // decrease below the min radius, this should cause the spell to be killed
+        stationarySpell.decreaseRadius(1);
+        assertTrue(stationarySpell.isKilled(), "");
+    }
+
+    @Test
+    void getSpellTypeTest() {
+        // simple getter, skipping
+    }
+
+    @Test
+    void setActiveTest() {
+        // simple getter, skipping
+    }
+
+    @Test
+    void ageAndKillTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 200, 4, 100);
+        PlayerMock player = mockServer.addPlayer();
+        O2StationarySpell stationarySpell = createStationarySpell(player, location);
+
+        int duration = stationarySpell.getDuration();
+        stationarySpell.age();
+        if (stationarySpell.isPermanent())
+            assertEquals(duration, stationarySpell.getDuration(), "");
+        else
+            assertEquals(duration - 1, stationarySpell.getDuration(), "");
+
+        duration = stationarySpell.getDuration();
+        stationarySpell.age(duration - 1);
+        if (stationarySpell.isPermanent())
+            assertEquals(duration, stationarySpell.getDuration(), "");
+        else
+            assertEquals(1, stationarySpell.getDuration(), "");
+
+        stationarySpell.age(stationarySpell.getDuration());
+        if (stationarySpell.isPermanent())
+            assertFalse(stationarySpell.isKilled(), "");
+        else
+            assertTrue(stationarySpell.isKilled(), "");
+    }
+
+    @Test
+    void ageByPercentTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 200, 4, 100);
+        PlayerMock player = mockServer.addPlayer();
+        O2StationarySpell stationarySpell = createStationarySpell(player, location);
+
+        int duration = stationarySpell.getDuration();
+        double percent = 0.2;
+        int newDuration = duration - ((int)(duration * percent));
+
+        stationarySpell.ageByPercent(percent);
+        if (stationarySpell.isPermanent())
+            assertEquals(duration, stationarySpell.getDuration(), "");
+        else
+            assertEquals(newDuration, stationarySpell.getDuration(), "");
+    }
+
+    @Test
+    void isLocationInsideTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 200, 4, 100);
+        PlayerMock player = mockServer.addPlayer();
+        O2StationarySpell stationarySpell = createStationarySpell(player, location);
+
+        assertTrue(stationarySpell.isLocationInside(location), "");
+        assertFalse(stationarySpell.isLocationInside(new Location(location.getWorld(), location.getX(), location.getY() + stationarySpell.getMaxRadius() + 1, location.getZ())), "");
+    }
+
+    @Test
+    void getBlockTest() {
+        // simple getter, skipping
+    }
+
+    @Test
+    void entitiesRadiusTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 200, 4, 100);
+        PlayerMock player = mockServer.addPlayer();
+        O2StationarySpell stationarySpell = createStationarySpell(player, location);
+
+        List<LivingEntity> entitiesInRadius = stationarySpell.getLivingEntitiesInsideSpellRadius();
+        assertTrue(entitiesInRadius.isEmpty(), "");
+        List<Player> playersInRadius = stationarySpell.getPlayersInsideSpellRadius();
+        assertTrue(playersInRadius.isEmpty(), "");
+
+        player.setLocation(location);
+        entitiesInRadius = stationarySpell.getLivingEntitiesInsideSpellRadius();
+        assertEquals(1, entitiesInRadius.size(), "");
+        playersInRadius = stationarySpell.getPlayersInsideSpellRadius();
+        assertEquals(1, playersInRadius.size(), "");
+
+        testWorld.spawn(location, Cow.class);
+        entitiesInRadius = stationarySpell.getLivingEntitiesInsideSpellRadius();
+        assertEquals(2, entitiesInRadius.size(), "");
+        playersInRadius = stationarySpell.getPlayersInsideSpellRadius();
+        assertEquals(1, playersInRadius.size(), "");
+
+        PlayerMock player2 = mockServer.addPlayer();
+        player2.setLocation(new Location(location.getWorld(), location.getX(), location.getY(), location.getZ() + stationarySpell.getMaxRadius() + 1));
+        entitiesInRadius = stationarySpell.getLivingEntitiesInsideSpellRadius();
+        assertEquals(2, entitiesInRadius.size(), "");
+        playersInRadius = stationarySpell.getPlayersInsideSpellRadius();
+        assertEquals(1, playersInRadius.size(), "");
+    }
+
+    @Test
+    void flairTest() {
+        // test covered by Ollivanders2Common.flair tests
+    }
+
+    @Test
+    void getCasterIDTest() {
+        // simple getter, skipping
+    }
+
+    @Test
+    void isActiveTest() {
+        // simple getter, skipping
+    }
+
+    @Test
+    void isKilledTest() {
+        // simple getter, skipping
+    }
+
+    @Test
+    void getLocationTest() {
+        // simple getter, skipping
+    }
+
+    @Test
+    abstract void upkeepTest();
+
+    @Test
+    void checkSpellDeserializationTest() {
+        O2StationarySpell stationarySpell = Ollivanders2API.getStationarySpells().createStationarySpellByType(getSpellType());
+        assertNotNull(stationarySpell);
+
+        assertFalse(stationarySpell.checkSpellDeserialization(), "");
+
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 200, 4, 100);
+        PlayerMock player = mockServer.addPlayer();
+        stationarySpell = createStationarySpell(player, location);
+        assertTrue(stationarySpell.checkSpellDeserialization(), "");
+    }
+
+    /**
+     * Tear down the mock Bukkit server after all tests complete.
+     *
+     * <p>Static teardown method called once after all tests in this class have finished.
+     * Releases the MockBukkit server resources to prevent memory leaks and allow clean
+     * test execution in subsequent test classes.</p>
+     */
+    @AfterAll
+    static void globalTearDown() {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/O2StationarySpellTypeTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/O2StationarySpellTypeTest.java
@@ -1,0 +1,175 @@
+package net.pottercraft.ollivanders2.test.stationaryspell;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.stationaryspell.MUFFLIATO;
+import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpellType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test suite for {@link O2StationarySpellType}.
+ *
+ * <p>This test class verifies the behavior of the O2StationarySpellType enum, including spell
+ * name retrieval, type lookup, player location detection within spell areas, and uniqueness
+ * constraints. Tests use MockBukkit for server simulation and mock spell instances.</p>
+ */
+public class O2StationarySpellTypeTest {
+    /**
+     * Shared mock Bukkit server instance for all tests.
+     *
+     * <p>Static field initialized once before all tests in this class. Reused across test instances
+     * to avoid expensive server setup/teardown for each test method.</p>
+     */
+    static ServerMock mockServer;
+
+    /**
+     * The plugin instance being tested.
+     *
+     * <p>Loaded fresh before each test method with the default configuration. Provides access to
+     * logger, scheduler, and other plugin API methods during tests.</p>
+     */
+    static Ollivanders2 testPlugin;
+
+    /**
+     * Initialize the mock Bukkit server before all tests.
+     *
+     * <p>Static setup method called once before all tests in this class. Creates the shared
+     * MockBukkit server instance that is reused across all test methods to avoid expensive
+     * server creation/destruction overhead.</p>
+     */
+    @BeforeAll
+    static void globalSetUp() {
+        Ollivanders2.testMode = true;
+
+        mockServer = MockBukkit.mock();
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+
+        // advance the server by 20 ticks to let the scheduler start (it has an initial delay of 20 ticks)
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
+    }
+
+    /**
+     * Tests the {@link O2StationarySpellType#getClassName()} method.
+     *
+     * <p>This is a simple getter method; comprehensive behavior is tested indirectly through
+     * other test methods.</p>
+     */
+    @Test
+    void getClassNameTest() {
+        // simple getter, skipping tests
+    }
+
+    /**
+     * Tests the {@link O2StationarySpellType#getLevel()} method.
+     *
+     * <p>This is a simple getter method; comprehensive behavior is tested indirectly through
+     * other test methods.</p>
+     */
+    @Test
+    void getLevelTest() {
+        // simple getter, skipping tests
+    }
+
+    /**
+     * Tests the {@link O2StationarySpellType#getStationarySpellTypeFromString(String)} method.
+     *
+     * <p>Verifies that the method returns null for invalid spell names and correctly retrieves
+     * the appropriate spell type for valid spell names.</p>
+     */
+    @Test
+    void getStationarySpellTypeFromStringTest() {
+        O2StationarySpellType expectedType = O2StationarySpellType.HERBICIDE;
+
+        assertNull(O2StationarySpellType.getStationarySpellTypeFromString("Invalid String"), "");
+
+        O2StationarySpellType stationarySpellType = O2StationarySpellType.getStationarySpellTypeFromString(expectedType.getSpellName());
+        assertNotNull(stationarySpellType, "O2StationarySpellType.getStationarySpellTypeFromString(" + expectedType.getSpellName() + ") returned null");
+        assertEquals(expectedType, stationarySpellType, "");
+    }
+
+    /**
+     * Tests the {@link O2StationarySpellType#getSpellName()} method.
+     *
+     * <p>Verifies that the spell name is correctly retrieved for a spell type. Tests the
+     * HERBICIDE spell type to ensure it returns the expected name.</p>
+     */
+    @Test
+    void getSpellNameTest() {
+        assertEquals("Herbicide", O2StationarySpellType.HERBICIDE.getSpellName(), "");
+    }
+
+    /**
+     * Tests the {@link O2StationarySpellType#isPlayerInsideStationarySpell(org.bukkit.entity.Player)} method.
+     *
+     * <p>Verifies that the method correctly detects whether a player is within the radius of a
+     * stationary spell. Tests a MUFFLIATO spell with a 5-block radius, confirming detection when
+     * the player is inside the spell area and no detection when outside.</p>
+     */
+    @Test
+    void isPlayerInsideStationarySpellTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 4, 100);
+
+        PlayerMock player = mockServer.addPlayer();
+        player.setLocation(location);
+        MUFFLIATO muffliato = new MUFFLIATO(testPlugin, player.getUniqueId(), location, 5, 1000);
+        Ollivanders2API.getStationarySpells().addStationarySpell(muffliato);
+        mockServer.getScheduler().performTicks(20);
+
+        assertTrue(O2StationarySpellType.MUFFLIATO.isPlayerInsideStationarySpell(player), "");
+        player.setLocation(new Location(testWorld, 200, 4, 100));
+        assertFalse(O2StationarySpellType.MUFFLIATO.isPlayerInsideStationarySpell(player), "");
+    }
+
+    /**
+     * Tests that all stationary spells have unique names.
+     *
+     * <p>Verifies that every O2StationarySpellType enum constant has a distinct spell name.
+     * This constraint ensures that spells can be uniquely identified by name throughout the
+     * application.</p>
+     */
+    @Test
+    void uniquePotionNamesTest() {
+        Map<String, List<O2StationarySpellType>> grouped = Arrays.stream(O2StationarySpellType.values())
+                .collect(Collectors.groupingBy(O2StationarySpellType::getSpellName));
+
+        List<String> duplicates = grouped.entrySet().stream()
+                .filter(e -> e.getValue().size() > 1)
+                .map(Map.Entry::getKey)
+                .toList();
+
+        assertTrue(duplicates.isEmpty(), "Found duplicate stationary spell names: " + duplicates);
+    }
+
+    /**
+     * Tear down the mock Bukkit server after all tests complete.
+     *
+     * <p>Static teardown method called once after all tests in this class have finished.
+     * Releases the MockBukkit server resources to prevent memory leaks and allow clean
+     * test execution in subsequent test classes.</p>
+     */
+    @AfterAll
+    static void globalTearDown() {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/O2StationarySpellsTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/O2StationarySpellsTest.java
@@ -1,0 +1,342 @@
+package net.pottercraft.ollivanders2.test.stationaryspell;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.stationaryspell.ALIQUAM_FLOO;
+import net.pottercraft.ollivanders2.stationaryspell.CAVE_INIMICUM;
+import net.pottercraft.ollivanders2.stationaryspell.COLLOPORTUS;
+import net.pottercraft.ollivanders2.stationaryspell.HARMONIA_NECTERE_PASSUS;
+import net.pottercraft.ollivanders2.stationaryspell.HERBICIDE;
+import net.pottercraft.ollivanders2.stationaryspell.LUMOS_FERVENS;
+import net.pottercraft.ollivanders2.stationaryspell.MOLLIARE;
+import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpell;
+import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpellType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test suite for {@link net.pottercraft.ollivanders2.stationaryspell.O2StationarySpells} manager.
+ *
+ * <p>Tests the core functionality of the stationary spells manager including spell addition,
+ * removal, querying by location and type, and creation of spell instances via reflection.
+ * Event handler behavior is tested by individual spell implementation test classes.</p>
+ *
+ * <p>Note: Serialization/deserialization tests are deferred to integration tests to avoid
+ * file I/O dependencies that could cause flakiness in parallel test execution.</p>
+ */
+public class O2StationarySpellsTest {
+    /**
+     * Shared mock Bukkit server instance for all tests.
+     *
+     * <p>Static field initialized once before all tests in this class. Reused across test instances
+     * to avoid expensive server setup/teardown for each test method.</p>
+     */
+    static ServerMock mockServer;
+
+    /**
+     * Initialize the mock Bukkit server before all tests.
+     *
+     * <p>Static setup method called once before all tests in this class. Creates the shared
+     * MockBukkit server instance that is reused across all test methods to avoid expensive
+     * server creation/destruction overhead.</p>
+     */
+    @BeforeAll
+    static void globalSetUp() {
+        Ollivanders2.testMode = true;
+        mockServer = MockBukkit.mock();
+    }
+
+    /**
+     * Loads a fresh plugin instance with default configuration.
+     *
+     * <p>Each test method calls this to get a properly initialized plugin with all managers
+     * and event listeners registered. The server scheduler is advanced to complete plugin startup.</p>
+     *
+     * @return a fresh Ollivanders2 plugin instance
+     */
+    Ollivanders2 getMockPlugin() {
+        Ollivanders2 testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
+        return testPlugin;
+    }
+
+    /**
+     * Tests adding and removing stationary spells.
+     *
+     * <p>Verifies that a spell can be added to the manager, becomes available at its location,
+     * and is properly removed when marked as killed.</p>
+     */
+    @Test
+    void addAndRemoveStationarySpellTest() {
+        Ollivanders2 testPlugin = getMockPlugin();
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 4, 100);
+        PlayerMock player = mockServer.addPlayer();
+
+        LUMOS_FERVENS lumosFervens = new LUMOS_FERVENS(testPlugin, player.getUniqueId(), location, 5, 1000);
+
+        Ollivanders2API.getStationarySpells().addStationarySpell(lumosFervens);
+        assertTrue(lumosFervens.isActive(), "");
+        assertTrue(Ollivanders2API.getStationarySpells().checkLocationForStationarySpell(location, lumosFervens.getSpellType()), "");
+
+        Ollivanders2API.getStationarySpells().removeStationarySpell(lumosFervens);
+        assertTrue(lumosFervens.isKilled(), "");
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(Ollivanders2API.getStationarySpells().checkLocationForStationarySpell(location, lumosFervens.getSpellType()), "");
+    }
+
+    /**
+     * Tests retrieving active stationary spells.
+     *
+     * <p>Verifies that the manager correctly identifies active spells and excludes killed ones.</p>
+     */
+    @Test
+    void getActiveStationarySpellsTest() {
+        Ollivanders2 testPlugin = getMockPlugin();
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 4, 100);
+        PlayerMock player = mockServer.addPlayer();
+
+        List<O2StationarySpell> activeSpells = Ollivanders2API.getStationarySpells().getActiveStationarySpells();
+        assertTrue(activeSpells.isEmpty(), "");
+
+        ALIQUAM_FLOO aliquamFloo = new ALIQUAM_FLOO(testPlugin, player.getUniqueId(), location, "floo1");
+        Ollivanders2API.getStationarySpells().addStationarySpell(aliquamFloo);
+
+        activeSpells = Ollivanders2API.getStationarySpells().getActiveStationarySpells();
+        assertEquals(1, activeSpells.size(), "");
+
+        aliquamFloo.kill();
+        activeSpells = Ollivanders2API.getStationarySpells().getActiveStationarySpells();
+        assertTrue(activeSpells.isEmpty(), "");
+    }
+
+    /**
+     * Tests finding spells at a location.
+     *
+     * <p>Verifies that spells are correctly found at their location and removed from results when killed.</p>
+     */
+    @Test
+    void getStationarySpellsAtLocationTest() {
+        Ollivanders2 testPlugin = getMockPlugin();
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 4, 100);
+        PlayerMock player = mockServer.addPlayer();
+
+        List<O2StationarySpell> activeSpells = Ollivanders2API.getStationarySpells().getStationarySpellsAtLocation(location);
+        assertTrue(activeSpells.isEmpty(), "");
+
+        CAVE_INIMICUM caveInimicum = new CAVE_INIMICUM(testPlugin, player.getUniqueId(), location, 5, 1000);
+        Ollivanders2API.getStationarySpells().addStationarySpell(caveInimicum);
+        activeSpells = Ollivanders2API.getStationarySpells().getStationarySpellsAtLocation(location);
+        assertEquals(1, activeSpells.size(), "");
+
+        COLLOPORTUS colloportus = new COLLOPORTUS(testPlugin, player.getUniqueId(), location);
+        Ollivanders2API.getStationarySpells().addStationarySpell(colloportus);
+        activeSpells = Ollivanders2API.getStationarySpells().getStationarySpellsAtLocation(location);
+        assertEquals(2, activeSpells.size(), "");
+
+        caveInimicum.kill();
+        mockServer.getScheduler().performTicks(20);
+        activeSpells = Ollivanders2API.getStationarySpells().getStationarySpellsAtLocation(location);
+        assertEquals(1, activeSpells.size(), "");
+    }
+
+    /**
+     * Tests finding active spells of a specific type at a location.
+     *
+     * <p>Verifies that spells are filtered by both location and type, and that killed spells are excluded.</p>
+     */
+    @Test
+    void getActiveStationarySpellsAtLocationByTypeTest() {
+        Ollivanders2 testPlugin = getMockPlugin();
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 4, 100);
+        PlayerMock player = mockServer.addPlayer();
+
+        List<O2StationarySpell> activeSpells = Ollivanders2API.getStationarySpells().getActiveStationarySpellsAtLocationByType(location, O2StationarySpellType.CAVE_INIMICUM);
+        assertTrue(activeSpells.isEmpty(), "");
+
+        CAVE_INIMICUM caveInimicum = new CAVE_INIMICUM(testPlugin, player.getUniqueId(), location, 5, 1000);
+        Ollivanders2API.getStationarySpells().addStationarySpell(caveInimicum);
+        activeSpells = Ollivanders2API.getStationarySpells().getActiveStationarySpellsAtLocationByType(location, O2StationarySpellType.CAVE_INIMICUM);
+        assertEquals(1, activeSpells.size(), "");
+
+        caveInimicum = new CAVE_INIMICUM(testPlugin, player.getUniqueId(), location, 5, 1000);
+        Ollivanders2API.getStationarySpells().addStationarySpell(caveInimicum);
+        activeSpells = Ollivanders2API.getStationarySpells().getActiveStationarySpellsAtLocationByType(location, O2StationarySpellType.CAVE_INIMICUM);
+        assertEquals(2, activeSpells.size(), "");
+
+        COLLOPORTUS colloportus = new COLLOPORTUS(testPlugin, player.getUniqueId(), location);
+        Ollivanders2API.getStationarySpells().addStationarySpell(colloportus);
+        activeSpells = Ollivanders2API.getStationarySpells().getActiveStationarySpellsAtLocationByType(location, O2StationarySpellType.CAVE_INIMICUM);
+        assertEquals(2, activeSpells.size(), "");
+
+        caveInimicum.kill();
+        mockServer.getScheduler().performTicks(20);
+        activeSpells = Ollivanders2API.getStationarySpells().getActiveStationarySpellsAtLocationByType(location, O2StationarySpellType.CAVE_INIMICUM);
+        assertEquals(1, activeSpells.size(), "");
+    }
+
+    /**
+     * Tests checking for a spell of a specific type at a location.
+     *
+     * <p>Verifies that the manager correctly identifies whether a location has an active spell
+     * of a given type, and returns false when no spell of that type is present.</p>
+     */
+    @Test
+    void checkLocationForStationarySpellTest() {
+        Ollivanders2 testPlugin = getMockPlugin();
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 4, 100);
+        PlayerMock player = mockServer.addPlayer();
+
+        assertFalse(Ollivanders2API.getStationarySpells().checkLocationForStationarySpell(location, O2StationarySpellType.HARMONIA_NECTERE_PASSUS), "");
+
+        HERBICIDE herbicide = new HERBICIDE(testPlugin, player.getUniqueId(), location, 5, 1000);
+        Ollivanders2API.getStationarySpells().addStationarySpell(herbicide);
+        assertFalse(Ollivanders2API.getStationarySpells().checkLocationForStationarySpell(location, O2StationarySpellType.HARMONIA_NECTERE_PASSUS), "");
+
+        HARMONIA_NECTERE_PASSUS harmoniaNecterePassus = new HARMONIA_NECTERE_PASSUS(testPlugin, player.getUniqueId(), location, new Location(testWorld, 200, 4, 100));
+        Ollivanders2API.getStationarySpells().addStationarySpell(harmoniaNecterePassus);
+        assertTrue(Ollivanders2API.getStationarySpells().checkLocationForStationarySpell(location, O2StationarySpellType.HARMONIA_NECTERE_PASSUS), "");
+    }
+
+    /**
+     * Tests determining whether a location is inside a spell's radius.
+     *
+     * <p>Verifies that locations within a spell's radius return true and locations outside
+     * return false, using a radius-based distance check.</p>
+     */
+    @Test
+    void isInsideOfTest() {
+        Ollivanders2 testPlugin = getMockPlugin();
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 4, 100);
+        PlayerMock player = mockServer.addPlayer();
+
+        MOLLIARE molliare = new MOLLIARE(testPlugin, player.getUniqueId(), location, 5, 1000);
+        Ollivanders2API.getStationarySpells().addStationarySpell(molliare);
+
+        assertFalse(Ollivanders2API.getStationarySpells().isInsideOf(O2StationarySpellType.HERBICIDE, location), "");
+        assertTrue(Ollivanders2API.getStationarySpells().isInsideOf(O2StationarySpellType.MOLLIARE, location), "");
+        assertTrue(Ollivanders2API.getStationarySpells().isInsideOf(O2StationarySpellType.MOLLIARE, new Location(location.getWorld(), location.getX() + 1, location.getY(), location.getZ())), "");
+        assertFalse(Ollivanders2API.getStationarySpells().isInsideOf(O2StationarySpellType.MOLLIARE, new Location(location.getWorld(), location.getX() + 10, location.getY(), location.getZ())), "");
+    }
+
+    /**
+     * Tests the upkeep mechanism for active spells.
+     *
+     * <p>Note: Individual spell upkeep behavior is tested by each spell's specific test class.
+     * This test is included for completeness in test coverage.</p>
+     */
+    @Test
+    void upkeepTest() {
+        // tested by each spells upkeep tests
+    }
+
+    /**
+     * Tests persisting active spells to storage.
+     *
+     * <p>Note: Serialization/deserialization is deferred to integration tests to avoid file I/O
+     * dependencies and flakiness that could occur from parallel test execution modifying shared
+     * save files non-deterministically.</p>
+     */
+    @Test
+    void saveO2StationarySpellsTest() {
+        // cannot test this in unit tests because they run in parallel and each is
+        // altering the save files non-deterministically
+    }
+
+    /**
+     * Tests restoring persisted spells from storage.
+     *
+     * <p>Note: Serialization/deserialization is deferred to integration tests to avoid file I/O
+     * dependencies and flakiness that could occur from parallel test execution modifying shared
+     * save files non-deterministically.</p>
+     */
+    @Test
+    void loadO2StationarySpellsTest() {
+        // cannot test this in unit tests because they run in parallel and each is
+        // altering the save files non-deterministically
+    }
+
+    /**
+     * Tests creating spell instances via reflection by spell type.
+     *
+     * <p>Verifies that the reflection-based spell factory correctly instantiates all spell types,
+     * that created spells have the correct spell type, and that spells start inactive until
+     * their data is fully loaded. Tests both simple spells and spells with unique initialization
+     * requirements.</p>
+     */
+    @Test
+    void createStationarySpellByTypeTest() {
+        getMockPlugin(); // initialize plugin
+
+        // test creating a simple spell type
+        O2StationarySpell herbicide = Ollivanders2API.getStationarySpells().createStationarySpellByType(O2StationarySpellType.HERBICIDE);
+        assertNotNull(herbicide, "createStationarySpellByType should return a spell");
+        assertEquals(O2StationarySpellType.HERBICIDE, herbicide.getSpellType(), "Created spell should have correct type");
+        assertFalse(herbicide.isActive(), "Created spell should be inactive by default");
+
+        // test creating a spell with unique data requirements
+        O2StationarySpell aliquamFloo = Ollivanders2API.getStationarySpells().createStationarySpellByType(O2StationarySpellType.ALIQUAM_FLOO);
+        assertNotNull(aliquamFloo, "createStationarySpellByType should return a spell for ALIQUAM_FLOO");
+        assertEquals(O2StationarySpellType.ALIQUAM_FLOO, aliquamFloo.getSpellType(), "Created spell should have correct type");
+
+        // test creating multiple different spell types
+        for (O2StationarySpellType spellType : O2StationarySpellType.values()) {
+            O2StationarySpell spell = Ollivanders2API.getStationarySpells().createStationarySpellByType(spellType);
+            assertNotNull(spell, "createStationarySpellByType should return a spell for " + spellType);
+            assertEquals(spellType, spell.getSpellType(), "Created spell should have correct type for " + spellType);
+        }
+
+        // clean up any floo spells that were added to the static list
+        ALIQUAM_FLOO.flooNetworkLocations.clear();
+    }
+
+    /**
+     * Cleans up state after each test to ensure test isolation.
+     *
+     * <p>Kills all active spells and clears the static floo network list to prevent
+     * test pollution from affecting subsequent tests.</p>
+     */
+    @AfterEach
+    void cleanUp() {
+        // kill all active stationary spells
+        for (O2StationarySpell spell : Ollivanders2API.getStationarySpells().getActiveStationarySpells()) {
+            spell.kill();
+        }
+
+        // run upkeep to remove killed spells from the list
+        mockServer.getScheduler().performTicks(20);
+    }
+
+    /**
+     * Tear down the mock Bukkit server after all tests complete.
+     *
+     * <p>Static teardown method called once after all tests in this class have finished.
+     * Releases the MockBukkit server resources to prevent memory leaks and allow clean
+     * test execution in subsequent test classes.</p>
+     */
+    @AfterAll
+    static void globalTearDown() {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/RepelloMuggletonTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/RepelloMuggletonTest.java
@@ -1,0 +1,187 @@
+package net.pottercraft.ollivanders2.test.stationaryspell;
+
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
+import net.pottercraft.ollivanders2.player.O2Player;
+import net.pottercraft.ollivanders2.stationaryspell.ConcealmentShieldSpell;
+import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpellType;
+import net.pottercraft.ollivanders2.stationaryspell.REPELLO_MUGGLETON;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test suite for the {@link REPELLO_MUGGLETON} stationary spell implementation.
+ *
+ * <p>Tests the repel muggles protection spell, which prevents non-magical people from entering
+ * a protected area. Inherits common concealment shield spell tests from {@link ConcealmentShieldSpellTest}
+ * and provides spell-specific factory methods for test setup.</p>
+ */
+public class RepelloMuggletonTest extends ConcealmentShieldSpellTest {
+    /**
+     * Gets the spell type for this test suite.
+     *
+     * @return {@link O2StationarySpellType#REPELLO_MUGGLETON}
+     */
+    @Override
+    O2StationarySpellType getSpellType() {
+        return O2StationarySpellType.REPELLO_MUGGLETON;
+    }
+
+    /**
+     * Creates a {@link REPELLO_MUGGLETON} spell instance for testing.
+     *
+     * <p>Constructs a new spell at the specified location cast by the given player, using default
+     * radius and duration values inherited from the parent test class.</p>
+     *
+     * @param caster   the player casting the spell (not null)
+     * @param location the center location for the spell (not null)
+     * @return a new REPELLO_MUGGLETON spell instance
+     */
+    @Override
+    REPELLO_MUGGLETON createStationarySpell(Player caster, Location location) {
+        return new REPELLO_MUGGLETON(testPlugin, caster.getUniqueId(), location, defaultRadius, defaultDuration);
+    }
+
+    /**
+     * Tests REPELLO_MUGGLETON's prevention of muggle entry. Overrides parent function because
+     * repello muggleton only hides players from muggles.
+     *
+     * <p>Verifies that:
+     * <ul>
+     *   <li>Casters (non-muggles) can freely enter their own spell areas</li>
+     *   <li>Muggles are blocked from entering with a cancellation of the move event</li>
+     *   <li>Muggles receive an entry denial message from the configured list</li>
+     *   <li>Non-muggles can freely enter the spell area</li>
+     * </ul>
+     * </p>
+     */
+    @Override @Test
+    void doOnPlayerMoveEventTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 4, 100);
+        PlayerMock caster = mockServer.addPlayer();
+        O2Player casterO2Player = testPlugin.getO2Player(caster);
+        assertNotNull(casterO2Player, "Failed to find O2Player");
+        casterO2Player.setMuggle(false);
+
+        // create concealment shield spell
+        REPELLO_MUGGLETON repelloMuggleton = createStationarySpell(caster, location);
+        Ollivanders2API.getStationarySpells().addStationarySpell(repelloMuggleton);
+
+        Location outsideLocation = new Location(location.getWorld(), location.getX() + repelloMuggleton.getMaxRadius() + 1, location.getY(), location.getZ());
+        assertFalse(repelloMuggleton.isLocationInside(outsideLocation));
+
+        // caster can enter their own spell area
+        caster.setLocation(outsideLocation);
+        mockServer.getScheduler().performTicks(20);
+        caster.setLocation(location);
+
+        PlayerMoveEvent event = new PlayerMoveEvent(caster, outsideLocation, location);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(event.isCancelled());
+
+        // prevent a muggle from entering the area
+        PlayerMock muggle = mockServer.addPlayer();
+        O2Player muggleO2Player = testPlugin.getO2Player(muggle);
+        assertNotNull(muggleO2Player, "Failed to find O2Player");
+        muggleO2Player.setMuggle(true);
+        assertFalse(repelloMuggleton.canEnter(muggle), "stationarySpell.canEnter() returned true for muggle");
+
+        muggle.setLocation(outsideLocation);
+        event = new PlayerMoveEvent(muggle, outsideLocation, location);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(event.isCancelled(), "Muggle move event into spell area was not cancelled");
+        String message = muggle.nextMessage();
+        assertNotNull(message, "Muggle did not receive entry denial message");
+        TestCommon.containsStringMatch(repelloMuggleton.getEntryDenyMessages(), message);
+
+        // allow non-muggle to enter
+        muggleO2Player.setMuggle(false);
+        assertTrue(repelloMuggleton.canEnter(muggle), "stationarySpell.canEnter() returned false for non-muggle");
+        event = new PlayerMoveEvent(muggle, outsideLocation, location);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(event.isCancelled(), "Non-muggle move event into spell area was cancelled");
+    }
+
+    /**
+     * Tests REPELLO_MUGGLETON's visibility toggling from muggle perspective.
+     *
+     * <p>Verifies that:
+     * <ul>
+     *   <li>Muggles outside the spell can see wizards normally</li>
+     *   <li>When a wizard enters the spell area, they become invisible to outside muggles</li>
+     *   <li>When a wizard exits the spell area, they become visible again to outside muggles</li>
+     *   <li>The visibility changes are properly applied using MockBukkit hidePlayer/canSee mechanics</li>
+     * </ul>
+     * </p>
+     */
+    @Override @Test
+    void doOnEntityTargetEventTestVisibilityCheck() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 500, 4, 100);
+        PlayerMock caster = mockServer.addPlayer();
+        O2Player casterO2Player = testPlugin.getO2Player(caster);
+        assertNotNull(casterO2Player, "Failed to find O2Player");
+        casterO2Player.setMuggle(false);
+
+        // create concealment shield spell
+        ConcealmentShieldSpell repelloMuggleton = createStationarySpell(caster, location);
+        Ollivanders2API.getStationarySpells().addStationarySpell(repelloMuggleton);
+        Location outsideLocation = new Location(location.getWorld(), location.getX() + repelloMuggleton.getMaxRadius() + 1, location.getY(), location.getZ());
+
+        // add a muggle player outside the spell area
+        PlayerMock muggle = mockServer.addPlayer();
+        O2Player muggleO2Player = testPlugin.getO2Player(muggle);
+        assertNotNull(muggleO2Player, "Failed to find O2Player");
+        muggleO2Player.setMuggle(true);
+        muggle.setLocation(outsideLocation);
+        assertFalse(repelloMuggleton.isLocationInside(muggle.getLocation()));
+
+        // ensure MockBukkit hidePlayer/canSee work
+        muggle.hidePlayer(testPlugin, caster);
+        assertFalse(muggle.canSee(caster), "caster still visible after muggle.hidePlayer(testPlugin, caster)");
+        muggle.showPlayer(testPlugin, caster);
+        assertTrue(muggle.canSee(caster), "caster not visible after muggle.showPlayer(testPlugin, caster)");
+
+        // put player outside location and move them inside
+        caster.setLocation(outsideLocation);
+        assertFalse(repelloMuggleton.isLocationInside(caster.getLocation()), "Caster is not starting outside the spell area.");
+        assertTrue(muggle.canSee(caster), "Muggle cannot see caster outside of the spell area");
+        caster.setLocation(location);
+        PlayerMoveEvent event = new PlayerMoveEvent(caster, outsideLocation, location);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(event.isCancelled(), "PlayerMoveEvent canceled unexpectedly");
+        assertFalse(repelloMuggleton.getPlayersInsideSpellRadius().isEmpty(), "No player in spell area");
+        assertTrue(repelloMuggleton.isLocationInside(caster.getLocation()), "Caster did not move to a location inside the spell area.");
+        // player should now be hidden from player2
+        assertFalse(muggle.canSee(caster), "Muggle can still see caster inside spell area");
+
+        // move player back outside the spell
+        caster.setLocation(outsideLocation);
+        event = new PlayerMoveEvent(caster, location, outsideLocation);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(Ollivanders2Common.ticksPerSecond * 10);
+        // player2 can now see player
+        assertFalse(repelloMuggleton.isLocationInside(caster.getLocation()));
+        assertTrue(muggle.canSee(caster), "Muggle cannot see caster outside of spell area");
+    }
+
+    /**
+     * Repello muggleton does not have a proximity alarm
+     */
+    @Override
+    void checkProximityAlarm(PlayerMock caster, ConcealmentShieldSpell spell) {}
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/testcommon/TestCommon.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/testcommon/TestCommon.java
@@ -87,10 +87,7 @@ public class TestCommon {
     public static boolean isInPlayerInventory(@NotNull PlayerMock player, @NotNull Material itemType) {
         ItemStack itemStack = getPlayerInventoryItem(player, itemType);
 
-        if (itemStack == null)
-            return false;
-        else
-            return true;
+        return itemStack == null;
     }
 
     /**
@@ -104,10 +101,7 @@ public class TestCommon {
     public static boolean isInPlayerInventory(@NotNull PlayerMock player, @NotNull Material itemType, @NotNull String name) {
         ItemStack itemStack = getPlayerInventoryItem(player, itemType, name);
 
-        if (itemStack == null)
-            return false;
-        else
-            return true;
+        return itemStack == null;
     }
 
     /**
@@ -214,15 +208,18 @@ public class TestCommon {
      *
      * @param stringList the string list of substrings to match
      * @param string the string to check
-     * @return true if found, false otherwise
      */
-    static public boolean stringContainsListMatch(List<String> stringList, String string) {
+    static public void stringContainsListMatch(List<String> stringList, String string) {
+        boolean found = false;
+
         for (String subString : stringList) {
-            if (string.contains(subString))
-                return true;
+            if (string.contains(subString)) {
+                found = true;
+                break;
+            }
         }
 
-        return false;
+        assertTrue(found, "Did not find \"" + string + "\" in list.");
     }
 
     /**


### PR DESCRIPTION
* added ConcealmentShieldSpell tests
* refactored how min/max duration and radius worked in shield spells to ensure the values being used were the spell-specific ones
* refactored event handlers to abstract common logic
* refactored how stationary spells are set to active
* fixed getStationarySpellTypeFromString to handle all casing
* changed TestCommon so that stringContainsListMatch does assertions directly