### PR TITLE
More stationary spell tests

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/common/EntityCommon.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/common/EntityCommon.java
@@ -226,6 +226,23 @@ public class EntityCommon {
     }
 
     /**
+     * Get the item entity at a specific location
+     *
+     * @param location the location to get the item from
+     * @return the Item entity or null if none present at the location
+     */
+    @Nullable
+    public static Item getItemAtLocation(@NotNull Location location) {
+        for (Entity entity : location.getWorld().getEntities()) {
+            if (entity instanceof Item && entity.getLocation().equals(location)) {
+                return (Item) entity;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Gets item entities within a bounding box around a location.
      *
      * @param location the center location for the bounding box

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/HARMONIA_NECTERE_PASSUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/HARMONIA_NECTERE_PASSUS.java
@@ -70,6 +70,9 @@ public final class HARMONIA_NECTERE_PASSUS extends O2Spell {
         if (Ollivanders2.worldGuardEnabled)
             worldGuardFlags.add(Flags.BUILD);
 
+        if (Ollivanders2.testMode)
+            projectilePassThrough.addAll(Ollivanders2Common.doors);
+
         initSpell();
     }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spell.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spell.java
@@ -325,12 +325,15 @@ public abstract class O2Spell {
      * {@link #maxProjectileDistance} blocks before being automatically terminated.</p>
      */
     public void move() {
+        common.printDebugMessage("O2Spell.move: location is " + location.getX() + " , " + location.getY() + ", " + location.getZ(), null, null, false);
+
         // if this is somehow called when the spell is set to killed, or we've already hit a target, do nothing
         if (isKilled() || hasHitTarget())
             return;
 
         // if we have gone beyond the max distance, kill this spell
         if (projectileDistance > maxProjectileDistance) {
+            common.printDebugMessage("O2Spell.move: projectile reached max distance without hitting a target", null, null, false);
             kill();
             return;
         }
@@ -344,6 +347,7 @@ public abstract class O2Spell {
 
         // determine if this spell is allowed in this location per Ollivanders2 config and WorldGuard
         if (!isSpellAllowed()) {
+            common.printDebugMessage("O2Spell.move: spell not allowed here", null, null, false);
             kill();
             return;
         }
@@ -357,11 +361,13 @@ public abstract class O2Spell {
             return;
         }
 
-        world.playEffect(location, moveEffect, moveEffectData);
+        if (!Ollivanders2.testMode)
+            world.playEffect(location, moveEffect, moveEffectData);
 
         // check the block at this location, if it is not a pass-through block, stop the projectile and check the target
         Material targetBlockType = location.getBlock().getType();
         if (!projectilePassThrough.contains(targetBlockType)) {
+            common.printDebugMessage("O2Spell.move: spell hit " + targetBlockType, null, null, false);
             stopProjectile();
             checkTargetBlock();
         }
@@ -804,5 +810,12 @@ public abstract class O2Spell {
             player.sendMessage(Ollivanders2.chatColor + failureMessage);
         else
             common.printDebugMessage("failure message unset or 0 length", null, null, false);
+    }
+
+    /**
+     * For use by unit tests only so we can aim the spell since MockBukkit has not implemented player look at
+     */
+    public void setVector(Vector vector) {
+        this.vector = vector;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/ALIQUAM_FLOO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/ALIQUAM_FLOO.java
@@ -73,6 +73,16 @@ public class ALIQUAM_FLOO extends O2StationarySpell {
     public static final int maxDurationConfig = 1000;
 
     /**
+     * Message sent to player when the floo event happens successfully
+     */
+    public static final String successMessage = "Fire swirls around you.";
+
+    /**
+     * Message sent to player when the floo event is cancelled
+     */
+    public static final String cancelledMessage = "Nothing seems to happen.";
+
+    /**
      * The unique name of this floo network location (for teleportation destinations).
      */
     private String flooName;
@@ -419,10 +429,10 @@ public class ALIQUAM_FLOO extends O2StationarySpell {
 
                 if (!flooNetworkEvent.isCancelled()) {
                     p.addTeleportAction(player, flooNetworkEvent.getDestination());
-                    player.sendMessage(Ollivanders2.chatColor + "Fire swirls around you.");
+                    player.sendMessage(Ollivanders2.chatColor + successMessage);
                 }
                 else
-                    player.sendMessage(Ollivanders2.chatColor + "Nothing seems to happen.");
+                    player.sendMessage(Ollivanders2.chatColor + cancelledMessage);
 
                 stopWorking();
                 flooNetworkEvents.remove(player.getUniqueId());

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HORCRUX.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/HORCRUX.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import net.pottercraft.ollivanders2.common.EntityCommon;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -25,33 +26,50 @@ import net.pottercraft.ollivanders2.Ollivanders2;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Player will spawn here when killed, with all of their spell levels intact. Only fiendfyre can destroy it.
- * <p>
- * {@link net.pottercraft.ollivanders2.spell.ET_INTERFICIAM_ANIMAM_LIGAVERIS}
+ * A stationary spell that creates a horcrux - an anchor point for player resurrection with preserved power.
+ *
+ * <p>Horcrux creates a permanent magical anchor that allows the spell's caster to respawn at the
+ * horcrux location when killed, while retaining all spell levels and experience. The spell:
+ * <ul>
+ *   <li>Creates an anchor point as a physical item in the world</li>
+ *   <li>Prevents the player from losing spell levels on death</li>
+ *   <li>Prevents the player from losing experience on death</li>
+ *   <li>Respawns the player at the horcrux location</li>
+ *   <li>Applies debilitative effects (blindness, wither) to players near the horcrux</li>
+ *   <li>Protects the horcrux item from being picked up or despawning</li>
+ *   <li>Can only be destroyed by fiendfyre</li>
+ * </ul>
+ * </p>
+ *
+ * <p>The spell is permanent and persists across server restarts.</p>
  *
  * @author Azami7
- * @version Ollivanders2
  * @see <a href="https://harrypotter.fandom.com/wiki/Horcrux-making_spell">https://harrypotter.fandom.com/wiki/Horcrux-making_spell</a>
  * @since 2.21
  */
 public class HORCRUX extends O2StationarySpell {
     /**
-     * the min radius for this spell
+     * The message players see on death
+     */
+    public static final String deathMessage = "Death approaches but cannot claim your soul.";
+
+    /**
+     * Minimum spell radius (3 blocks) - effect range for debilitation effects.
      */
     public static final int minRadiusConfig = 3;
 
     /**
-     * the max radius for this spell
+     * Maximum spell radius (3 blocks) - effect range for debilitation effects.
      */
     public static final int maxRadiusConfig = 3;
 
     /**
-     * min duration for this spell - not used, horcrux is permanent
+     * Minimum spell duration (1000 ticks) - not used, horcrux is permanent.
      */
     public static final int minDurationConfig = 1000;
 
     /**
-     * max duration for this spell - not used, horcrux is permanent
+     * Maximum spell duration (1000 ticks) - not used, horcrux is permanent.
      */
     public static final int maxDurationConfig = 1000;
 
@@ -73,17 +91,12 @@ public class HORCRUX extends O2StationarySpell {
     /**
      * Keep track of the affected players
      */
-    private final Map<String, Integer> affectedPlayers = new HashMap<>();
+    private final Map<UUID, Integer> affectedPlayers = new HashMap<>();
 
     /**
      * How long to affect someone who gets too close to the horcrux
      */
-    private final int effectDuration = 200;
-
-    /**
-     * Was the horcrux item loaded (for use on restart)
-     */
-    private boolean itemLoaded = false;
+    public static final int effectDuration = Ollivanders2Common.ticksPerSecond * 15;
 
     private final String materialLabel = "itemType";
     private final String worldLabel = "world";
@@ -102,12 +115,15 @@ public class HORCRUX extends O2StationarySpell {
     }
 
     /**
-     * Constructor
+     * Constructs a new HORCRUX spell cast by a player.
      *
-     * @param plugin   a callback to the MC plugin
-     * @param pid      the player who cast the spell
-     * @param location the center location of the spell
-     * @param item     the horcrux object
+     * <p>Creates a permanent horcrux anchor at the specified location using the provided item.
+     * The player will respawn at this location when killed, retaining all spell levels and experience.</p>
+     *
+     * @param plugin   a callback to the MC plugin (not null)
+     * @param pid      the UUID of the player who cast the spell (not null)
+     * @param location the center location of the horcrux anchor (not null)
+     * @param item     the item representing the horcrux in the world (not null)
      */
     public HORCRUX(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, @NotNull Item item) {
         super(plugin);
@@ -123,11 +139,16 @@ public class HORCRUX extends O2StationarySpell {
         worldName = location.getWorld().getName();
         horcruxItem = item;
         horcruxMaterial = item.getItemStack().getType();
-        itemLoaded = true;
 
         common.printDebugMessage("Creating stationary spell type " + spellType.name(), null, null, false);
     }
 
+    /**
+     * Initializes the radius and duration constraints for this spell.
+     *
+     * <p>Sets fixed radius and duration values (not configurable). The spell is always permanent.</p>
+     */
+    @Override
     void initRadiusAndDurationMinMax() {
         minRadius = minRadiusConfig;
         maxRadius = maxRadiusConfig;
@@ -136,27 +157,33 @@ public class HORCRUX extends O2StationarySpell {
     }
 
     /**
-     * Upkeep for the spell
+     * Ages the spell and manages player debilitation effects.
+     *
+     * <p>Decrements the duration timers for affected players, removing them from the affected list
+     * when their duration expires.</p>
      */
     @Override
     public void upkeep() {
         // decrement all the affected cooldowns by a tick
-        ArrayList<String> iterator = new ArrayList<>(affectedPlayers.keySet());
+        ArrayList<UUID> iterator = new ArrayList<>(affectedPlayers.keySet());
 
-        for (String playerName : iterator) {
-            int duration = affectedPlayers.get(playerName) - 1;
+        for (UUID playerID : iterator) {
+            int duration = affectedPlayers.get(playerID) - 1;
 
             if (duration > 0)
-                affectedPlayers.replace(playerName, duration);
+                affectedPlayers.replace(playerID, duration);
             else
-                affectedPlayers.remove(playerName);
+                affectedPlayers.remove(playerID);
         }
     }
 
     /**
-     * Serialize all data specific to this spell so it can be saved.
+     * Serializes the horcrux's persistent data for server restart recovery.
      *
-     * @return a map of the serialized data
+     * <p>Saves the material type and world name so the horcrux item can be properly respawned
+     * when the server restarts. This ensures the horcrux persists across server restarts.</p>
+     *
+     * @return a map containing the horcrux material type and world name
      */
     @Override
     @NotNull
@@ -170,9 +197,13 @@ public class HORCRUX extends O2StationarySpell {
     }
 
     /**
-     * Deserialize the data for this spell and load the data to this spell.
+     * Deserializes the horcrux's persistent data when loading from server restart.
      *
-     * @param spellData a map of the saved spell data
+     * <p>Restores the material type and world name that were saved. If the material type
+     * is no longer valid (removed in a Minecraft update) or if required data is missing,
+     * the spell is destroyed.</p>
+     *
+     * @param spellData a map containing the saved horcrux material and world name
      */
     @Override
     public void deserializeSpellData(@NotNull Map<String, String> spellData) {
@@ -198,32 +229,41 @@ public class HORCRUX extends O2StationarySpell {
     }
 
     /**
-     * Respawn the horcrux item after a server start and the world is loaded. Ideally we'd use the WorldLoadEvent, but it
-     * seems to happen before the plugin listeners are registered (tried it, never fires) so load it the first time a
-     * player joins.
+     * Respawns the horcrux item on server restart when a player joins.
      *
-     * @param event the world load event
+     * <p>After a server restart, the horcrux item needs to be restored. Since the WorldLoadEvent
+     * fires before plugin listeners are registered, the horcrux item is respawned the first time
+     * any player joins the server. This method:
+     * <ul>
+     *   <li>Checks if the horcrux item already respawned naturally (by the game)</li>
+     *   <li>If not found, manually respawns the horcrux item at its original location</li>
+     *   <li>Marks the item as loaded so this process only happens once per restart</li>
+     * </ul>
+     * </p>
+     *
+     * @param event the player join event (not null)
      */
     @Override
     void doOnPlayerJoinEvent(@NotNull PlayerJoinEvent event) {
-        if (!itemLoaded) {
-            // did the game respawn the item?
-            for (Item itemsAtLocation : EntityCommon.getItemsInRadius(location, 1)) {
-                if (itemsAtLocation.getItemStack().getType() == horcruxMaterial) {
-                    horcruxItem = itemsAtLocation;
-                    return;
-                }
-            }
+        if (!event.getPlayer().getUniqueId().equals(playerUUID))
+            return;
 
-            // if not, respawn horcrux
+        // is the player's horcrux item spawned?
+        Item horcrux = EntityCommon.getItemAtLocation(location);
+
+        // there is no item here or some other item is here
+        if (horcrux == null || (horcrux.getItemStack().getType() != horcruxMaterial)) {
             respawnHorcruxItem();
-
-            itemLoaded = true;
         }
     }
 
     /**
-     * Respawn the horcrux item
+     * Creates and spawns the horcrux item at the spell location.
+     *
+     * <p>Spawns a new item entity at the horcrux location using the saved material type.
+     * The item will be protected from pickup and despawning by the spell's event handlers.</p>
+     *
+     * <p>If the world is invalid, logs an error and destroys the spell.</p>
      */
     private void respawnHorcruxItem() {
         World world = p.getServer().getWorld(worldName);
@@ -241,16 +281,26 @@ public class HORCRUX extends O2StationarySpell {
     }
 
     /**
-     * On player death, player keeps inventory, level, and experience.
+     * Protects the horcrux caster from losing progress on death.
      *
-     * @param event the event
+     * <p>When the player who created the horcrux dies, they are protected from the normal
+     * consequences of death:
+     * <ul>
+     *   <li>Inventory items are preserved (not dropped)</li>
+     *   <li>Experience level is preserved</li>
+     *   <li>Total experience points are preserved</li>
+     * </ul>
+     * The death message is customized to reflect the magical protection of the horcrux.</p>
+     *
+     * @param event the player death event (not null)
      */
     @Override
     void doOnPlayerDeathEvent(@NotNull PlayerDeathEvent event) {
         Player player = event.getEntity();
+        player.setRespawnLocation(location, true);
 
         if (player.getUniqueId().equals(playerUUID)) {
-            event.setDeathMessage("Death approaches but cannot claim your split soul.");
+            event.setDeathMessage(deathMessage);
             event.setKeepInventory(true);
             event.setKeepLevel(true);
             event.setNewTotalExp(player.getTotalExperience());
@@ -258,15 +308,22 @@ public class HORCRUX extends O2StationarySpell {
     }
 
     /**
-     * Affect players that get too close to the horcrux
+     * Applies debilitative effects to players who enter the horcrux area.
      *
-     * @param event the event
+     * <p>When a player (other than the horcrux caster) enters the spell radius:
+     * <ul>
+     *   <li>Applies blindness effect (amplifier level 2) for 200 ticks</li>
+     *   <li>Applies wither effect (amplifier level 1) for 200 ticks</li>
+     *   <li>Tracks the player to avoid reapplying effects until the cooldown expires</li>
+     * </ul>
+     * The horcrux caster is immune to these effects.</p>
+     *
+     * @param event the player move event (not null)
      */
     @Override
     void doOnPlayerMoveEvent(@NotNull PlayerMoveEvent event) {
         Location toLocation = event.getTo();
-
-        if (!isLocationInside(toLocation))
+        if (toLocation == null || !isLocationInside(toLocation))
             return;
 
         Player target = event.getPlayer();
@@ -278,21 +335,24 @@ public class HORCRUX extends O2StationarySpell {
         }
 
         // don't affect players already affected
-        if (affectedPlayers.containsKey(target.getName()))
+        if (affectedPlayers.containsKey(target.getUniqueId()))
             return;
 
         // add blindness and wither effects to player
         target.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, effectDuration, 2));
         target.addPotionEffect(new PotionEffect(PotionEffectType.WITHER, effectDuration, 1));
 
-        // add affected player to list so we keep re-adding these effects every time they move
-        affectedPlayers.put(target.getName(), effectDuration);
+        // add affected player to list so we don't keep re-adding these effects every time they move
+        affectedPlayers.put(target.getUniqueId(), effectDuration);
     }
 
     /**
-     * Handle item despawn events
+     * Prevents the horcrux item from despawning naturally.
      *
-     * @param event the item despawn event
+     * <p>Minecraft normally despawns dropped items after 5 minutes. This event handler
+     * ensures the horcrux item never despawns, protecting it from natural cleanup.</p>
+     *
+     * @param event the item despawn event (not null)
      */
     @Override
     void doOnItemDespawnEvent(@NotNull ItemDespawnEvent event) {
@@ -306,12 +366,18 @@ public class HORCRUX extends O2StationarySpell {
     }
 
     /**
-     * Handle items being picked up by entities
+     * Prevents entities from picking up the horcrux item.
      *
-     * @param event the event
+     * <p>Protects the horcrux item from being collected by mobs or players. The item
+     * remains untouchable at its location.</p>
+     *
+     * @param event the entity pickup item event (not null)
      */
     @Override
     void doOnEntityPickupItemEvent(@NotNull EntityPickupItemEvent event) {
+        if (horcruxItem == null) //this can happen on restart when things are not fully loaded yet
+            return;
+
         Item eventItem = event.getItem();
 
         if (eventItem.getUniqueId().equals(horcruxItem.getUniqueId()))
@@ -319,23 +385,59 @@ public class HORCRUX extends O2StationarySpell {
     }
 
     /**
-     * Handle items being picked up by things like hoppers
+     * Prevents hoppers and other inventory collectors from picking up the horcrux item.
      *
-     * @param event the event
+     * <p>Protects the horcrux item from being collected by hoppers, minecarts with hoppers,
+     * or other block inventory systems. The item cannot be moved or collected by any means.</p>
+     *
+     * @param event the inventory pickup item event (not null)
      */
     @Override
     void doOnInventoryItemPickupEvent(@NotNull InventoryPickupItemEvent event) {
+        if (horcruxItem == null) //this can happen on restart when things are not fully loaded yet
+            return;
+
         Item eventItem = event.getItem();
 
         if (eventItem.getUniqueId().equals(horcruxItem.getUniqueId()))
             event.setCancelled(true);
     }
 
+    /**
+     * Cleans up when the horcrux spell ends.
+     *
+     * <p>The horcrux spell requires no special cleanup on termination. The spell is permanent
+     * and only ends if explicitly destroyed through other means.</p>
+     */
     @Override
     void doCleanUp() {
     }
 
+    /**
+     * Validates that the spell was properly deserialized with all required data.
+     *
+     * <p>Checks that the following essential data was restored from the saved state:
+     * <ul>
+     *   <li>Player UUID (caster identification)</li>
+     *   <li>Location (horcrux position)</li>
+     *   <li>Horcrux material (item type)</li>
+     * </ul>
+     * If any required data is missing, the spell is invalid and should be destroyed.</p>
+     *
+     * @return true if all required data is present, false otherwise
+     */
+    @Override
     public boolean checkSpellDeserialization() {
         return playerUUID != null && location != null && horcruxMaterial != null;
+    }
+
+    /**
+     * Is this player currently affected by the horcrux?
+     *
+     * @param player the player to check
+     * @return true if they are affected, false otherwise
+     */
+    public boolean isAffected(Player player) {
+        return affectedPlayers.containsKey(player.getUniqueId());
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/NULLUM_APPAREBIT.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/NULLUM_APPAREBIT.java
@@ -18,29 +18,45 @@ import java.util.Map;
 import java.util.UUID;
 
 /**
- * Nullum apparebit creates a stationary spell which will not allow apparition into it.
- * <p>
- * {@link net.pottercraft.ollivanders2.spell.NULLUM_APPAREBIT}
+ * A stationary spell that prevents apparition and teleportation into the protected area.
+ *
+ * <p>Nullum Apparebit creates a powerful anti-apparition barrier that prevents outside entities
+ * from accessing the protected area through magical means. The spell blocks:
+ * <ul>
+ *   <li>Apparation by name into the spell area</li>
+ *   <li>Apparation by coordinates into the spell area</li>
+ *   <li>Teleportation into the spell area</li>
+ * </ul>
+ * </p>
+ *
+ * <p>This spell creates a magical sanctuary that cannot be breached by apparition or teleportation.</p>
  *
  * @author Azami7
- * @version Ollivanders2
  * @see <a href="https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx">https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx</a>
  */
 public class NULLUM_APPAREBIT extends O2StationarySpell {
     /**
-     * the min radius for this spell
+     * The message a player gets if they try to teleport or apparate in to the spell area
+     */
+    public static final String feedbackMessage = "A powerful magic protects that place.";
+
+    /**
+     * Minimum spell radius (5 blocks).
      */
     public static final int minRadiusConfig = 5;
+
     /**
-     * the max radius for this spell
+     * Maximum spell radius (50 blocks).
      */
     public static final int maxRadiusConfig = 50;
+
     /**
-     * the min duration for this spell
+     * Minimum spell duration (5 minutes).
      */
     public static final int minDurationConfig = Ollivanders2Common.ticksPerMinute * 5;
+
     /**
-     * the max duration for this spell
+     * Maximum spell duration (30 minutes).
      */
     public static final int maxDurationConfig = Ollivanders2Common.ticksPerMinute * 30;
 
@@ -56,13 +72,16 @@ public class NULLUM_APPAREBIT extends O2StationarySpell {
     }
 
     /**
-     * Constructor
+     * Constructs a new NULLUM_APPAREBIT spell cast by a player.
      *
-     * @param plugin   a callback to the MC plugin
-     * @param pid      the player who cast the spell
-     * @param location the center location of the spell
-     * @param radius   the radius for this spell
-     * @param duration the duration of the spell
+     * <p>Creates an anti-apparition barrier at the specified location with the given radius and
+     * duration. Outside entities cannot access the protected area through apparition or teleportation.</p>
+     *
+     * @param plugin   a callback to the MC plugin (not null)
+     * @param pid      the UUID of the player who cast the spell (not null)
+     * @param location the center location of the spell (not null)
+     * @param radius   the radius for this spell (will be clamped to min/max values)
+     * @param duration the duration of the spell in ticks (will be clamped to min/max values)
      */
     public NULLUM_APPAREBIT(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
         super(plugin, pid, location);
@@ -74,6 +93,12 @@ public class NULLUM_APPAREBIT extends O2StationarySpell {
         common.printDebugMessage("Creating stationary spell type " + spellType.name(), null, null, false);
     }
 
+    /**
+     * Initializes the radius and duration constraints for this spell.
+     *
+     * <p>Sets the spell's radius boundaries (5-50 blocks) and duration boundaries (5 to 30 minutes).</p>
+     */
+    @Override
     void initRadiusAndDurationMinMax() {
         minRadius = minRadiusConfig;
         maxRadius = maxRadiusConfig;
@@ -82,27 +107,45 @@ public class NULLUM_APPAREBIT extends O2StationarySpell {
     }
 
     /**
-     * Age the spell by 1 tick
+     * Ages the spell by one tick.
      */
     @Override
     public void upkeep() {
         age();
     }
 
+    /**
+     * Serializes the nullum apparebit spell data for persistence.
+     *
+     * <p>The spell has no extra data to serialize beyond the base spell properties,
+     * so this method returns an empty map.</p>
+     *
+     * @return an empty map (the spell has no custom data to serialize)
+     */
     @Override
     @NotNull
     public Map<String, String> serializeSpellData() {
         return new HashMap<>();
     }
 
+    /**
+     * Deserializes nullum apparebit spell data from saved state.
+     *
+     * <p>The spell has no extra data to deserialize, so this method does nothing.</p>
+     *
+     * @param spellData the serialized spell data map (not used)
+     */
     @Override
     public void deserializeSpellData(@NotNull Map<String, String> spellData) {
     }
 
     /**
-     * Prevent player apparating to this location
+     * Prevents players from apparating into the spell area by name.
      *
-     * @param event the apparate event
+     * <p>When a player attempts to apparate by name into the protected area, the apparition
+     * is cancelled and they receive feedback that the area is magically protected.</p>
+     *
+     * @param event the apparate by name event (not null)
      */
     @Override
     void doOnOllivandersApparateByNameEvent(@NotNull OllivandersApparateByNameEvent event) {
@@ -123,9 +166,12 @@ public class NULLUM_APPAREBIT extends O2StationarySpell {
     }
 
     /**
-     * Prevent player apparating to this location
+     * Prevents players from apparating into the spell area by coordinates.
      *
-     * @param event the apparate event
+     * <p>When a player attempts to apparate by coordinates into the protected area, the apparition
+     * is cancelled and they receive feedback that the area is magically protected.</p>
+     *
+     * @param event the apparate by coordinates event (not null)
      */
     @Override
     void doOnOllivandersApparateByCoordinatesEvent(@NotNull OllivandersApparateByCoordinatesEvent event) {
@@ -146,9 +192,12 @@ public class NULLUM_APPAREBIT extends O2StationarySpell {
     }
 
     /**
-     * Prevent entity teleporting to this location
+     * Prevents entities from teleporting into the spell area.
      *
-     * @param event the teleport event
+     * <p>When an entity attempts to teleport into the protected area, the teleportation is cancelled,
+     * preventing access to the sanctuary.</p>
+     *
+     * @param event the entity teleport event (not null)
      */
     @Override
     void doOnEntityTeleportEvent(@NotNull EntityTeleportEvent event) {
@@ -163,13 +212,18 @@ public class NULLUM_APPAREBIT extends O2StationarySpell {
     }
 
     /**
-     * Prevent player teleporting to this location
+     * Prevents players from teleporting into the spell area.
      *
-     * @param event the teleport event
+     * <p>When a player attempts to teleport into the protected area, the teleportation is cancelled
+     * and they receive feedback that the area is magically protected.</p>
+     *
+     * @param event the player teleport event (not null)
      */
     @Override
     void doOnPlayerTeleportEvent(@NotNull PlayerTeleportEvent event) {
         Location destination = event.getTo();
+        if (destination == null)
+            return;
 
         if (isLocationInside(destination)) {
             event.setCancelled(true);
@@ -186,16 +240,24 @@ public class NULLUM_APPAREBIT extends O2StationarySpell {
     }
 
     /**
-     * Feedback to the player when they try to apparate.
+     * Provides feedback to a player when they attempt to access the protected area.
      *
-     * @param player the player trying to teleport/apparate
+     * <p>Sends a message, plays a sound effect, and displays a visual flair to indicate
+     * the spell is preventing their access.</p>
+     *
+     * @param player the player attempting to apparate or teleport into the protected area (not null)
      */
     private void playerFeedback(@NotNull Player player) {
-        player.sendMessage(Ollivanders2.chatColor + "A powerful magic protects that place.");
+        player.sendMessage(Ollivanders2.chatColor + feedbackMessage);
         player.getWorld().playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, 1, 1);
         flair(5);
     }
 
+    /**
+     * Cleans up when the nullum apparebit spell ends.
+     *
+     * <p>The spell requires no special cleanup on termination.</p>
+     */
     @Override
     void doCleanUp() {
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/NULLUM_EVANESCUNT.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/stationaryspell/NULLUM_EVANESCUNT.java
@@ -18,15 +18,28 @@ import java.util.Map;
 import java.util.UUID;
 
 /**
- * Nullum evanescunt creates a stationary spell which will not allow apparition out of it.
- * <p>
- * {@link net.pottercraft.ollivanders2.spell.NULLUM_EVANESCUNT}
+ * A stationary spell that prevents apparition and teleportation out of the protected area.
+ *
+ * <p>Nullum Evanescunt creates a powerful anti-disapparition barrier that prevents entities
+ * from escaping through magical means. Those trapped inside cannot:
+ * <ul>
+ *   <li>Apparate by name to leave the spell area</li>
+ *   <li>Apparate by coordinates to leave the spell area</li>
+ *   <li>Teleport away from the spell area</li>
+ * </ul>
+ * </p>
+ *
+ * <p>Note: This spell uses min/max constraints from {@link NULLUM_APPAREBIT}.</p>
  *
  * @author Azami7
- * @version Ollivanders2
  * @see <a href="https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx">https://harrypotter.fandom.com/wiki/Anti-Disapparition_Jinx</a>
  */
 public class NULLUM_EVANESCUNT extends O2StationarySpell {
+    /**
+     * The message a player receives if they try to teleport or apparate out of the area
+     */
+    public static final String feedbackMessage = "A powerful magic protects this place.";
+
     /**
      * Simple constructor used for deserializing saved stationary spells at server start. Do not use to cast spell.
      *
@@ -39,13 +52,17 @@ public class NULLUM_EVANESCUNT extends O2StationarySpell {
     }
 
     /**
-     * Constructor
+     * Constructs a new 1 - spell cast by a player.
      *
-     * @param plugin   a callback to the MC plugin
-     * @param pid      the player who cast the spell
-     * @param location the center location of the spell
-     * @param radius   the radius for this spell
-     * @param duration the duration of the spell
+     * <p>Creates an anti-disapparition barrier at the specified location with the given radius
+     * and duration. Entities inside the protected area cannot escape through apparition or
+     * teleportation magic.</p>
+     *
+     * @param plugin   a callback to the MC plugin (not null)
+     * @param pid      the UUID of the player who cast the spell (not null)
+     * @param location the center location of the spell (not null)
+     * @param radius   the radius for this spell (will be clamped to min/max values)
+     * @param duration the duration of the spell in ticks (will be clamped to min/max values)
      */
     public NULLUM_EVANESCUNT(@NotNull Ollivanders2 plugin, @NotNull UUID pid, @NotNull Location location, int radius, int duration) {
         super(plugin, pid, location);
@@ -57,6 +74,17 @@ public class NULLUM_EVANESCUNT extends O2StationarySpell {
         common.printDebugMessage("Creating stationary spell type " + spellType.name(), null, null, false);
     }
 
+    /**
+     * Initializes the radius and duration constraints for this spell.
+     *
+     * <p>Uses the same constraints as {@link NULLUM_APPAREBIT}:
+     * <ul>
+     *   <li>Radius: 5-50 blocks</li>
+     *   <li>Duration: 5-30 minutes</li>
+     * </ul>
+     * </p>
+     */
+    @Override
     void initRadiusAndDurationMinMax() {
         // make min/max radius and duration the same as Nullum Apparebit
         minRadius = NULLUM_APPAREBIT.minRadiusConfig;
@@ -66,7 +94,7 @@ public class NULLUM_EVANESCUNT extends O2StationarySpell {
     }
 
     /**
-     * Age the spell by 1 tick
+     * Ages the spell by one tick.
      */
     @Override
     public void upkeep() {
@@ -74,9 +102,12 @@ public class NULLUM_EVANESCUNT extends O2StationarySpell {
     }
 
     /**
-     * Prevent player apparating to this location
+     * Prevents players from apparating away by name while inside the spell area.
      *
-     * @param event the apparate event
+     * <p>When a player inside the protected area attempts to apparate by name, the apparition
+     * is cancelled and they receive feedback that the area is magically protected.</p>
+     *
+     * @param event the apparate by name event (not null)
      */
     @Override
     void doOnOllivandersApparateByNameEvent(@NotNull OllivandersApparateByNameEvent event) {
@@ -98,9 +129,12 @@ public class NULLUM_EVANESCUNT extends O2StationarySpell {
     }
 
     /**
-     * Prevent player apparating to this location
+     * Prevents players from apparating away by coordinates while inside the spell area.
      *
-     * @param event the apparate event
+     * <p>When a player inside the protected area attempts to apparate by coordinates, the apparition
+     * is cancelled and they receive feedback that the area is magically protected.</p>
+     *
+     * @param event the apparate by coordinates event (not null)
      */
     @Override
     void doOnOllivandersApparateByCoordinatesEvent(@NotNull OllivandersApparateByCoordinatesEvent event) {
@@ -122,9 +156,12 @@ public class NULLUM_EVANESCUNT extends O2StationarySpell {
     }
 
     /**
-     * Prevent entity teleporting to this location
+     * Prevents entities from teleporting away while inside the spell area.
      *
-     * @param event the teleport event
+     * <p>When an entity inside the protected area attempts to teleport away, the teleportation
+     * is cancelled, trapping the entity inside the area.</p>
+     *
+     * @param event the entity teleport event (not null)
      */
     @Override
     void doOnEntityTeleportEvent(@NotNull EntityTeleportEvent event) {
@@ -138,9 +175,12 @@ public class NULLUM_EVANESCUNT extends O2StationarySpell {
     }
 
     /**
-     * Prevent player teleporting to this location
+     * Prevents players from teleporting away while inside the spell area.
      *
-     * @param event the teleport event
+     * <p>When a player inside the protected area attempts to teleport away, the teleportation
+     * is cancelled, and they receive feedback that the area is magically protected.</p>
+     *
+     * @param event the player teleport event (not null)
      */
     @Override
     void doOnPlayerTeleportEvent(@NotNull PlayerTeleportEvent event) {
@@ -162,26 +202,49 @@ public class NULLUM_EVANESCUNT extends O2StationarySpell {
     }
 
     /**
-     * Feedback to the player when they try to apparate.
+     * Provides feedback to a player when they attempt to escape the protected area.
      *
-     * @param player the player trying to teleport/apparate
+     * <p>Sends a message, plays a sound effect, and displays a visual flair to indicate
+     * the spell is preventing their escape.</p>
+     *
+     * @param player the player attempting to apparate or teleport away (not null)
      */
     private void playerFeedback(@NotNull Player player) {
-        player.sendMessage(Ollivanders2.chatColor + "A powerful magic protects this place.");
+        player.sendMessage(Ollivanders2.chatColor + feedbackMessage);
         player.getWorld().playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_PLING, 1, 1);
         flair(5);
     }
 
+    /**
+     * Serializes the nullum evanescunt spell data for persistence.
+     *
+     * <p>The spell has no extra data to serialize beyond the base spell properties,
+     * so this method returns an empty map.</p>
+     *
+     * @return an empty map (the spell has no custom data to serialize)
+     */
     @Override
     @NotNull
     public Map<String, String> serializeSpellData() {
         return new HashMap<>();
     }
 
+    /**
+     * Deserializes nullum evanescunt spell data from saved state.
+     *
+     * <p>The spell has no extra data to deserialize, so this method does nothing.</p>
+     *
+     * @param spellData the serialized spell data map (not used)
+     */
     @Override
     public void deserializeSpellData(@NotNull Map<String, String> spellData) {
     }
 
+    /**
+     * Cleans up when the nullum evanescunt spell ends.
+     *
+     * <p>The spell requires no special cleanup on termination.</p>
+     */
     @Override
     void doCleanUp() {
     }

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/common/EntityCommonTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/common/EntityCommonTest.java
@@ -7,6 +7,8 @@ import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Bee;
 import org.bukkit.entity.Cat;
 import org.bukkit.entity.Cow;
@@ -45,8 +47,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Unit tests for EntityCommon class.
  *
- * Tests entity search methods, item search methods, random entity type generation,
- * and hostility detection for various mob types.
+ * <p>Tests entity search methods, item search methods, random entity type generation,
+ * and hostility detection for various mob types.</p>
  */
 public class EntityCommonTest {
     static ServerMock mockServer;
@@ -440,6 +442,21 @@ public class EntityCommonTest {
         Bee bee = testWorld.spawn(new Location(testWorld, 930, 4, 930), Bee.class);
         bee.setTarget(null);
         assertFalse(EntityCommon.isHostile(bee), "EntityCommon.isHostile() should return false for mobs without targets");
+    }
+
+    @Test
+    void getItemAtLocationTest() {
+        Location location = new Location(testWorld, 1030, 40, 1030);
+        Block baseBlock = testWorld.getBlockAt(location).getRelative(BlockFace.DOWN);
+        baseBlock.setType(Material.DIRT);
+
+        testWorld.dropItem(location, new ItemStack(Material.COMPASS, 1));
+
+        Item item = EntityCommon.getItemAtLocation(location);
+        assertNotNull(item, "failed to find item at location");
+
+        item = EntityCommon.getItemAtLocation(baseBlock.getLocation());
+        assertNull(item, "found item at location where there is not an item");
     }
 
     /**

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/HarmoniaNecterePassusTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/HarmoniaNecterePassusTest.java
@@ -1,0 +1,89 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpellType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HarmoniaNecterePassusTest {
+    /**
+     * Shared mock Bukkit server instance for all tests.
+     *
+     * <p>Static field initialized once before all tests in this class. Reused across test instances
+     * to avoid expensive server setup/teardown for each test method.</p>
+     */
+    static ServerMock mockServer;
+
+    /**
+     * The plugin instance being tested.
+     *
+     * <p>Loaded fresh before each test method with the default configuration. Provides access to
+     * logger, scheduler, and other plugin API methods during tests.</p>
+     */
+    static Ollivanders2 testPlugin;
+
+    /**
+     * Initialize the mock Bukkit server before all tests.
+     *
+     * <p>Static setup method called once before all tests in this class. Creates the shared
+     * MockBukkit server instance that is reused across all test methods to avoid expensive
+     * server creation/destruction overhead.</p>
+     */
+    @BeforeAll
+    static void globalSetUp() {
+        Ollivanders2.testMode = true;
+
+        mockServer = MockBukkit.mock();
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+
+        // advance the server by 20 ticks to let the scheduler start (it has an initial delay of 20 ticks)
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
+    }
+
+    @Test
+    void doCheckEffectTest() {
+        World testWorld = mockServer.addSimpleWorld("world1");
+        Location location1 = new Location(testWorld, 100, 40, 100);
+        Location location2 = new Location(testWorld, 120, 40, 100);
+        PlayerMock caster = mockServer.addPlayer();
+
+        net.pottercraft.ollivanders2.test.stationaryspell.HarmoniaNecterePassusTest.createCabinet(location1, location2);
+        net.pottercraft.ollivanders2.test.stationaryspell.HarmoniaNecterePassusTest.createCabinet(location2, location1);
+
+        Location castLocation = new Location(testWorld, 100, 39, 102);
+        Location lookAt = new Location(testWorld, 100, 40, 101);
+        caster.setLocation(castLocation);
+
+        net.pottercraft.ollivanders2.spell.HARMONIA_NECTERE_PASSUS harmoniaSpell = new net.pottercraft.ollivanders2.spell.HARMONIA_NECTERE_PASSUS(testPlugin, caster, 1.0);
+        harmoniaSpell.setVector((location1.toVector().subtract(lookAt.toVector())));
+        Ollivanders2API.getSpells().addSpell(caster, harmoniaSpell);
+        mockServer.getScheduler().performTicks(20);
+
+        assertTrue(Ollivanders2API.getStationarySpells().checkLocationForStationarySpell(location1, O2StationarySpellType.HARMONIA_NECTERE_PASSUS));
+        assertTrue(Ollivanders2API.getStationarySpells().checkLocationForStationarySpell(location2, O2StationarySpellType.HARMONIA_NECTERE_PASSUS));
+    }
+
+    /**
+     * Tear down the mock Bukkit server after all tests complete.
+     *
+     * <p>Static teardown method called once after all tests in this class have finished.
+     * Releases the MockBukkit server resources to prevent memory leaks and allow clean
+     * test execution in subsequent test classes.</p>
+     */
+    @AfterAll
+    static void globalTearDown() {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/AliquamFlooTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/AliquamFlooTest.java
@@ -114,8 +114,8 @@ public class AliquamFlooTest {
     @Test
     void aliquamFlooTest() {
         World testWorld = mockServer.addSimpleWorld("world");
-        Location location1 = new Location(testWorld, 100, 4, 100);
-        Location location2 = new Location(testWorld, 200, 4, 200);
+        Location location1 = new Location(testWorld, 100, 40, 100);
+        Location location2 = new Location(testWorld, 200, 40, 200);
         String floo1Name = "One";
         String floo2Name = "Two";
         PlayerMock player = mockServer.addPlayer();
@@ -189,6 +189,9 @@ public class AliquamFlooTest {
         mockServer.getScheduler().performTicks(500);
         assertFalse(aliquamFloo1.isWorking(), "floo1 not disabled");
         assertEquals(location2, player.getLocation(), "Player not teleported to floo2");
+        String message = player.nextMessage();
+        assertNotNull(message, "Player did not receive successful floo event message");
+        assertEquals(ALIQUAM_FLOO.successMessage, TestCommon.cleanChatMessage(message), "Player did not receive expected success message");
 
         // player chatting floo name when fireplace inactive does nothing
         player.chat(floo1Name);
@@ -220,7 +223,7 @@ public class AliquamFlooTest {
         assertEquals(location1, player.getLocation(), "Player not teleported back to floo1");
 
         // player gets a message when teleport is successful
-        String message = player.nextMessage();
+        message = player.nextMessage();
         assertNotNull(message, "Player did not get message on floo event");
 
         // doCleanUp - fireplace is deactivated if floo spell is killed

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/HarmoniaNecterePassusTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/HarmoniaNecterePassusTest.java
@@ -1,0 +1,357 @@
+package net.pottercraft.ollivanders2.test.stationaryspell;
+
+import net.kyori.adventure.text.Component;
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.stationaryspell.HARMONIA_NECTERE_PASSUS;
+import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpell;
+import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpellType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.Sign;
+import org.bukkit.block.data.Openable;
+import org.bukkit.block.sign.Side;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test suite for the HARMONIA_NECTERE_PASSUS stationary spell.
+ *
+ * <p>Tests spell-specific behavior for the vanishing cabinet that creates paired portals
+ * between two locations. Verifies cabinet structural integrity, player teleportation mechanics,
+ * cooldown management, serialization, and deserialization validation.</p>
+ *
+ * @author Azami7
+ */
+public class HarmoniaNecterePassusTest {
+    /**
+     * Shared mock Bukkit server instance for all tests.
+     *
+     * <p>Static field initialized once before all tests in this class. Reused across test instances
+     * to avoid expensive server setup/teardown for each test method.</p>
+     */
+    static ServerMock mockServer;
+
+    /**
+     * The plugin instance being tested.
+     *
+     * <p>Loaded fresh before each test method with the default configuration. Provides access to
+     * logger, scheduler, and other plugin API methods during tests.</p>
+     */
+    static Ollivanders2 testPlugin;
+
+    /**
+     * Initialize the mock Bukkit server before all tests.
+     *
+     * <p>Static setup method called once before all tests in this class. Creates the shared
+     * MockBukkit server instance that is reused across all test methods to avoid expensive
+     * server creation/destruction overhead.</p>
+     */
+    @BeforeAll
+    static void globalSetUp() {
+        Ollivanders2.testMode = true;
+
+        mockServer = MockBukkit.mock();
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+
+        // advance the server by 20 ticks to let the scheduler start (it has an initial delay of 20 ticks)
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
+    }
+
+    /**
+     * Creates a vanishing cabinet structure for testing.
+     *
+     * <p>Builds a 3x3 cabinet with walls, a door, a sign, and a solid top. The sign at feet level
+     * contains the destination location information. Used by tests to set up valid cabinet structures.</p>
+     *
+     * @param fromLocation the location of the cabinet's feet (sign position)
+     * @param toLocation   the destination location (written on the sign)
+     */
+    public static void createCabinet(Location fromLocation, Location toLocation) {
+        Block feet = fromLocation.getBlock();
+        feet.setType(Material.OAK_SIGN);
+        Sign sign = (Sign)feet.getState();
+        sign.getSide(Side.FRONT).line(0, Component.text(toLocation.getWorld().getName()));
+        sign.getSide(Side.FRONT).line(1, Component.text(Integer.toString((int)toLocation.getX())));
+        sign.getSide(Side.FRONT).line(2, Component.text(Integer.toString((int)toLocation.getY())));
+        sign.getSide(Side.FRONT).line(3, Component.text(Integer.toString((int)toLocation.getZ())));
+
+        feet.getRelative(BlockFace.DOWN).setType(Material.STONE);
+        Block doorBlock = feet.getRelative(BlockFace.SOUTH);
+        doorBlock.setType(Material.OAK_DOOR);
+        Openable door = (Openable)doorBlock.getBlockData();
+        door.setOpen(true);
+        doorBlock.setBlockData(door);
+
+        feet.getRelative(BlockFace.WEST).setType(Material.OAK_PLANKS);
+        feet.getRelative(BlockFace.EAST).setType(Material.OAK_PLANKS);
+        feet.getRelative(BlockFace.NORTH).setType(Material.OAK_PLANKS);
+
+        Block eye = feet.getRelative(BlockFace.UP);
+        eye.getRelative(BlockFace.NORTH).setType(Material.OAK_PLANKS);
+        eye.getRelative(BlockFace.WEST).setType(Material.OAK_PLANKS);
+        eye.getRelative(BlockFace.EAST).setType(Material.OAK_PLANKS);
+        eye.getRelative(BlockFace.UP).setType(Material.OAK_SLAB);
+
+        // upper half of the door
+        doorBlock = eye.getRelative(BlockFace.SOUTH);
+        doorBlock.setType(Material.OAK_DOOR);
+        door = (Openable)doorBlock.getBlockData();
+        door.setOpen(true);
+        doorBlock.setBlockData(door);
+    }
+
+    /**
+     * Tests cabinet structural integrity checking and spell destruction.
+     *
+     * <p>Verifies that spells are killed when cabinets don't exist, persist when cabinets are valid,
+     * and are killed when cabinet structure is damaged.</p>
+     */
+    @Test
+    void upkeepCabinetIntegrityTest() {
+        World testWorld = mockServer.addSimpleWorld("world1");
+        Location location1 = new Location(testWorld, 100, 40, 100);
+        Location location2 = new Location(testWorld, 120, 40, 100);
+        PlayerMock caster = mockServer.addPlayer();
+
+        HARMONIA_NECTERE_PASSUS harmoniaNecterePassus1 = new HARMONIA_NECTERE_PASSUS(testPlugin, caster.getUniqueId(), location1, location2);
+        Ollivanders2API.getStationarySpells().addStationarySpell(harmoniaNecterePassus1);
+        HARMONIA_NECTERE_PASSUS harmoniaNecterePassus2 = new HARMONIA_NECTERE_PASSUS(testPlugin, caster.getUniqueId(), location2, location1);
+        Ollivanders2API.getStationarySpells().addStationarySpell(harmoniaNecterePassus2);
+        mockServer.getScheduler().performTicks(20);
+
+        // cabinets do not exist so spells should be killed
+        assertTrue(harmoniaNecterePassus1.isKilled(), "spell 1 not killed when no cabinet exists");
+        assertTrue(harmoniaNecterePassus2.isKilled(), "spell 2 not killed when no cabinet exists");
+
+        // spells persist when there is a valid cabinet
+        HarmoniaNecterePassusTest.createCabinet(location1, location2);
+        HarmoniaNecterePassusTest.createCabinet(location2, location1);
+
+        harmoniaNecterePassus1 = new HARMONIA_NECTERE_PASSUS(testPlugin, caster.getUniqueId(), location1, location2);
+        Ollivanders2API.getStationarySpells().addStationarySpell(harmoniaNecterePassus1);
+        harmoniaNecterePassus2 = new HARMONIA_NECTERE_PASSUS(testPlugin, caster.getUniqueId(), location2, location1);
+        Ollivanders2API.getStationarySpells().addStationarySpell(harmoniaNecterePassus2);
+        mockServer.getScheduler().performTicks(20);
+
+        assertFalse(harmoniaNecterePassus1.isKilled(), "spell 1 killed unexpectedly");
+        assertFalse(harmoniaNecterePassus2.isKilled(), "spell 2 killed unexpectedly");
+
+        // spell is killed if a cabinet is damaged
+        location1.getBlock().setType(Material.OAK_PLANKS);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(harmoniaNecterePassus1.isKilled(), "spell 1 not killed when twin cabinet damaged");
+        assertTrue(harmoniaNecterePassus2.isKilled(), "spell 2 not killed when cabinet damaged");
+    }
+
+    /**
+     * Tests in-use cooldown tracking and expiration.
+     *
+     * <p>Verifies that players are tracked as using a cabinet after entering, remain tracked
+     * in the cooldown period after leaving, and are removed from tracking after cooldown expires.</p>
+     */
+    @Test
+    void upkeepInUseByTest() {
+        World testWorld = mockServer.addSimpleWorld("world1");
+        Location location1 = new Location(testWorld, 200, 40, 100);
+        Location location2 = new Location(testWorld, 220, 40, 100);
+        PlayerMock caster = mockServer.addPlayer();
+
+        HarmoniaNecterePassusTest.createCabinet(location1, location2);
+        HarmoniaNecterePassusTest.createCabinet(location2, location1);
+
+        HARMONIA_NECTERE_PASSUS harmoniaNecterePassus1 = new HARMONIA_NECTERE_PASSUS(testPlugin, caster.getUniqueId(), location1, location2);
+        Ollivanders2API.getStationarySpells().addStationarySpell(harmoniaNecterePassus1);
+        HARMONIA_NECTERE_PASSUS harmoniaNecterePassus2 = new HARMONIA_NECTERE_PASSUS(testPlugin, caster.getUniqueId(), location2, location1);
+        Ollivanders2API.getStationarySpells().addStationarySpell(harmoniaNecterePassus2);
+        mockServer.getScheduler().performTicks(20);
+
+        // caster near cabinet
+        Location nearCabinet1 = new Location(testWorld, 200, 39, 102);
+        caster.setLocation(nearCabinet1);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(harmoniaNecterePassus1.isUsing(caster), "caster set to using cabinet before entry");
+
+        // move caster in to the cabinet
+        caster.setLocation(location1);
+        // we have to manually trigger a player move event
+        PlayerMoveEvent event = new PlayerMoveEvent(caster, nearCabinet1, location1);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(harmoniaNecterePassus1.isUsing(caster), "caster not set to using cabinet after entry");
+
+        // move caster out of cabinet, now in inUse cooldown
+        caster.setLocation(nearCabinet1);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(harmoniaNecterePassus1.isUsing(caster), "caster not set to using cabinet after leaving, during cooldown");
+
+        // expire the cooldown
+        mockServer.getScheduler().performTicks(HARMONIA_NECTERE_PASSUS.cooldown);
+        assertFalse(harmoniaNecterePassus1.isUsing(caster), "caster set to using cabinet after cooldown expired");
+    }
+
+    /**
+     * Tests finding the twin cabinet.
+     *
+     * <p>Verifies that getTwin() correctly locates the paired cabinet by its location.</p>
+     */
+    @Test
+    void getTwinTest() {
+        World testWorld = mockServer.addSimpleWorld("world1");
+        Location location1 = new Location(testWorld, 300, 40, 100);
+        Location location2 = new Location(testWorld, 320, 40, 100);
+        PlayerMock caster = mockServer.addPlayer();
+
+        HarmoniaNecterePassusTest.createCabinet(location1, location2);
+        HarmoniaNecterePassusTest.createCabinet(location2, location1);
+
+        HARMONIA_NECTERE_PASSUS harmoniaNecterePassus1 = new HARMONIA_NECTERE_PASSUS(testPlugin, caster.getUniqueId(), location1, location2);
+        Ollivanders2API.getStationarySpells().addStationarySpell(harmoniaNecterePassus1);
+        HARMONIA_NECTERE_PASSUS harmoniaNecterePassus2 = new HARMONIA_NECTERE_PASSUS(testPlugin, caster.getUniqueId(), location2, location1);
+        Ollivanders2API.getStationarySpells().addStationarySpell(harmoniaNecterePassus2);
+        mockServer.getScheduler().performTicks(20);
+
+        HARMONIA_NECTERE_PASSUS twin1 = harmoniaNecterePassus1.getTwin();
+        assertNotNull(twin1, "harmonia 1 getTwin() returned null");
+        assertEquals(harmoniaNecterePassus2, twin1, "getTwin() did not return expected spell");
+    }
+
+    @Test
+    void isUsingTest() {
+        // tested by upkeepInUseByTest
+    }
+
+    /**
+     * Tests player teleportation between cabinets.
+     *
+     * <p>Verifies that players entering a cabinet are teleported to the twin, null destination
+     * locations don't cause teleportation, and cooldown prevents immediate re-teleportation
+     * when arriving at the twin cabinet.</p>
+     */
+    @Test
+    void doOnPlayerMoveEventTest () {
+        World testWorld = mockServer.addSimpleWorld("world1");
+        Location location1 = new Location(testWorld, 400, 40, 100);
+        Location location2 = new Location(testWorld, 420, 40, 100);
+        PlayerMock caster = mockServer.addPlayer();
+        Location nearCabinet1 = new Location(testWorld, 400, 39, 102);
+        caster.setLocation(nearCabinet1);
+
+        HarmoniaNecterePassusTest.createCabinet(location1, location2);
+        HarmoniaNecterePassusTest.createCabinet(location2, location1);
+
+        HARMONIA_NECTERE_PASSUS harmoniaNecterePassus1 = new HARMONIA_NECTERE_PASSUS(testPlugin, caster.getUniqueId(), location1, location2);
+        Ollivanders2API.getStationarySpells().addStationarySpell(harmoniaNecterePassus1);
+        HARMONIA_NECTERE_PASSUS harmoniaNecterePassus2 = new HARMONIA_NECTERE_PASSUS(testPlugin, caster.getUniqueId(), location2, location1);
+        Ollivanders2API.getStationarySpells().addStationarySpell(harmoniaNecterePassus2);
+        mockServer.getScheduler().performTicks(20);
+
+        // null to location should not cause anything to happen
+        PlayerMoveEvent event = new PlayerMoveEvent(caster, nearCabinet1, null);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(harmoniaNecterePassus1.isUsing(caster), "doOnPlayerMoveEvent not short circuited by null to location");
+        assertEquals(nearCabinet1, caster.getLocation(), "Caster was teleported when to location was null in PlayerMoveEvent");
+
+        // player moving in to the vanishing cabinet should get teleported to the twin
+        caster.setLocation(location1);
+        event = new PlayerMoveEvent(caster, nearCabinet1, location1);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(200); // give long enough for the teleport event to happen
+        assertEquals(location2, caster.getLocation(), "caster not teleported to the twin location");
+
+        // make sure caster cannot get immediately teleported back
+        Location nearCabinet2 = new Location(testWorld, 420, 40, 102);
+        event = new PlayerMoveEvent(caster, nearCabinet2, location2);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(harmoniaNecterePassus2.isUsing(caster), "doOnPlayerMoveEvent not short circuited by player twin inUse cooldown");
+    }
+
+    /**
+     * Tests serialization and deserialization of vanishing cabinet spell data.
+     *
+     * <p>Verifies that the twin cabinet location is correctly serialized to a map, and that
+     * deserializing valid data restores the twin location. Also verifies that deserializing
+     * with missing twin location data does not set the twin location.</p>
+     */
+    @Test
+    void serializeAndDeserializeSpellDataTest() {
+        World testWorld = mockServer.addSimpleWorld("world1");
+        Location location1 = new Location(testWorld, 500, 40, 100);
+        Location location2 = new Location(testWorld, 520, 40, 100);
+        PlayerMock caster = mockServer.addPlayer();
+
+        HARMONIA_NECTERE_PASSUS spell = new HARMONIA_NECTERE_PASSUS(testPlugin, caster.getUniqueId(), location1, location2);
+
+        // serialize and verify data contains twin location
+        Map<String, String> spellData = spell.serializeSpellData();
+        assertFalse(spellData.isEmpty(), "serialized spell data is empty");
+
+        // deserialize valid data into a new spell and verify twin is restored
+        HarmoniaNecterePassusTest.createCabinet(location1, location2);
+        HarmoniaNecterePassusTest.createCabinet(location2, location1);
+
+        HARMONIA_NECTERE_PASSUS deserialized = new HARMONIA_NECTERE_PASSUS(testPlugin, caster.getUniqueId(), location1, location2);
+        Ollivanders2API.getStationarySpells().addStationarySpell(deserialized);
+        deserialized.deserializeSpellData(spellData);
+        assertFalse(deserialized.isKilled(), "spell killed after deserializing valid data");
+
+        // deserialize with empty data does not crash
+        HARMONIA_NECTERE_PASSUS emptyDeserialized = new HARMONIA_NECTERE_PASSUS(testPlugin, caster.getUniqueId(), location1, location2);
+        emptyDeserialized.deserializeSpellData(new HashMap<>());
+        assertFalse(emptyDeserialized.isKilled(), "spell killed after deserializing empty data");
+    }
+
+    /**
+     * Tests spell deserialization validation.
+     *
+     * <p>Verifies that a spell created via the deserialization constructor fails
+     * checkSpellDeserialization() because it lacks required data (player UUID, location,
+     * and twin cabinet location), while a properly initialized spell passes validation.</p>
+     */
+    @Test
+    void checkSpellDeserializationTest() {
+        O2StationarySpell stationarySpell = Ollivanders2API.getStationarySpells().createStationarySpellByType(O2StationarySpellType.HARMONIA_NECTERE_PASSUS);
+        assertNotNull(stationarySpell);
+        assertFalse(stationarySpell.checkSpellDeserialization(), "Deserialized spell should fail check without required data");
+
+        World testWorld = mockServer.addSimpleWorld("world1");
+        Location location1 = new Location(testWorld, 600, 40, 100);
+        Location location2 = new Location(testWorld, 620, 40, 100);
+        PlayerMock caster = mockServer.addPlayer();
+
+        HARMONIA_NECTERE_PASSUS spell = new HARMONIA_NECTERE_PASSUS(testPlugin, caster.getUniqueId(), location1, location2);
+        assertTrue(spell.checkSpellDeserialization(), "Properly initialized spell failed deserialization check");
+    }
+
+    /**
+     * Tear down the mock Bukkit server after all tests complete.
+     *
+     * <p>Static teardown method called once after all tests in this class have finished.
+     * Releases the MockBukkit server resources to prevent memory leaks and allow clean
+     * test execution in subsequent test classes.</p>
+     */
+    @AfterAll
+    static void globalTearDown() {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/HerbicideTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/HerbicideTest.java
@@ -1,0 +1,144 @@
+package net.pottercraft.ollivanders2.test.stationaryspell;
+
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.stationaryspell.HERBICIDE;
+import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpellType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.Ageable;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test suite for the HERBICIDE stationary spell.
+ *
+ * <p>Tests spell-specific behavior for the plant destruction effect that eliminates all plant
+ * life within the protected area. Inherits common stationary spell tests from the base class
+ * and adds tests for the plant killing mechanics including block replacement, item drops,
+ * and crop aging.</p>
+ *
+ * @author Azami7
+ */
+public class HerbicideTest extends O2StationarySpellTest {
+    /**
+     * Gets the spell type being tested.
+     *
+     * @return {@link O2StationarySpellType#HERBICIDE}
+     */
+    @Override
+    O2StationarySpellType getSpellType() {
+        return O2StationarySpellType.HERBICIDE;
+    }
+
+    /**
+     * Creates a HERBICIDE spell instance for testing.
+     *
+     * <p>Constructs a new spell at the specified location with the minimum radius and duration values.</p>
+     *
+     * @param caster   the player casting the spell (not null)
+     * @param location the center location of the spell (not null)
+     * @return a new HERBICIDE spell instance (not null)
+     */
+    @Override
+    HERBICIDE createStationarySpell(Player caster, Location location) {
+        return new HERBICIDE(testPlugin, caster.getUniqueId(), location, HERBICIDE.minRadiusConfig, HERBICIDE.minDurationConfig);
+    }
+
+    /**
+     * Tests the upkeep behavior and plant destruction mechanics.
+     *
+     * <p>Verifies that the spell correctly:
+     * <ul>
+     *   <li>Replaces plant blocks with dead alternatives (flowers to air, mossy blocks to non-mossy)</li>
+     *   <li>Drops items for saplings and bamboo</li>
+     *   <li>Resets crop age to 0</li>
+     *   <li>Leaves non-plant blocks unaffected (snow)</li>
+     *   <li>Does not affect blocks outside the spell radius</li>
+     * </ul>
+     * </p>
+     */
+    @Override @Test
+    void upkeepTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 200, 40, 100);
+        Location outsideLocation = new Location(location.getWorld(), location.getX(), location.getY(), location.getZ() + HERBICIDE.maxRadiusConfig + 1);
+        PlayerMock caster = mockServer.addPlayer();
+
+        Block plant1 = testWorld.getBlockAt(location);
+        plant1.setType(Material.ORANGE_TULIP); // should turn in to AIR
+        Block plant2 = plant1.getRelative(BlockFace.EAST);
+        plant2.setType(Material.MOSSY_STONE_BRICK_WALL); // should turn in to brick wall
+        Block plant3 = plant1.getRelative(BlockFace.WEST);
+        plant3.setType(Material.ACACIA_SAPLING); // should turn in to a stick
+
+        Block crop = plant1.getRelative(BlockFace.DOWN);
+        crop.setType(Material.WHEAT);
+
+        Block nonPlant = plant1.getRelative(BlockFace.NORTH);
+        nonPlant.setType(Material.SNOW);
+
+        Block plant5 = testWorld.getBlockAt(outsideLocation);
+        plant5.setType(Material.ORANGE_TULIP);
+
+        HERBICIDE herbicide = createStationarySpell(caster, location);
+        Ollivanders2API.getStationarySpells().addStationarySpell(herbicide);
+        mockServer.getScheduler().performTicks(200);
+
+        // plant blocks inside spell area are changed
+        assertTrue(herbicide.isLocationInside(plant1.getLocation()));
+        assertEquals(Material.AIR, plant1.getType(), "Tulip plant not expected material");
+        assertTrue(herbicide.isLocationInside(plant2.getLocation()));
+        assertEquals(Material.STONE_BRICK_WALL, plant2.getType(), "Mossy stone brick wall not expected material");
+
+        assertTrue(herbicide.isLocationInside(plant3.getLocation()));
+        assertEquals(Material.AIR, plant3.getType(), "Acacia sapling not removed");
+        List<Item> items = TestCommon.getAllItems(testWorld);
+        assertFalse(items.isEmpty(), "acacia sapling not replaced by item");
+        assertEquals(Material.STICK, items.getFirst().getItemStack().getType(), "Acacia sapling item not expected type");
+
+        // clean up item
+        items.getFirst().remove();
+        mockServer.getScheduler().performTicks(20);
+
+        // add bamboo plant, which also turns in to an item
+        Block plant4 = plant1.getRelative(BlockFace.SOUTH);
+        plant4.setType(Material.BAMBOO); // should turn into a bamboo stick
+
+        mockServer.getScheduler().performTicks(200);
+        assertTrue(herbicide.isLocationInside(plant4.getLocation()));
+        items = TestCommon.getAllItems(testWorld);
+        assertFalse(items.isEmpty(), "bamboo shoot not replaced by item");
+        assertEquals(Material.BAMBOO, items.getFirst().getItemStack().getType(), "bamboo item not expected type");
+
+        // crop blocks killed
+        assertTrue(herbicide.isLocationInside(crop.getLocation()));
+        assertEquals(Material.WHEAT, crop.getType(), "crop type changed");
+        BlockData cropData = crop.getBlockData();
+        assertInstanceOf(Ageable.class, cropData);
+        assertEquals(0, ((Ageable)cropData).getAge(), "crop age not set to 0");
+
+        // non-plant blocks inside spell area are unaffected
+        assertTrue(herbicide.isLocationInside(nonPlant.getLocation()));
+        assertEquals(Material.SNOW, nonPlant.getType(), "Snow block affected");
+
+        // plant blocks outside spell area are unaffected
+        assertFalse(herbicide.isLocationInside(plant5.getLocation()));
+        assertEquals(Material.ORANGE_TULIP, plant5.getType(), "tulip outside spell area affected");
+
+        // age() is tested by ageAndKillTest
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/HorcruxTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/HorcruxTest.java
@@ -1,0 +1,385 @@
+package net.pottercraft.ollivanders2.test.stationaryspell;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.common.EntityCommon;
+import net.pottercraft.ollivanders2.stationaryspell.HORCRUX;
+import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpell;
+import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpellType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.damage.DamageSource;
+import org.bukkit.damage.DamageType;
+import org.bukkit.entity.Item;
+import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.event.entity.ItemDespawnEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.InventoryPickupItemEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test suite for the HORCRUX stationary spell.
+ *
+ * <p>Tests spell-specific behavior for the resurrection anchor that allows players to respawn
+ * at the horcrux location when killed. Verifies protection of the horcrux item, player
+ * resurrection mechanics, debilitation effects on nearby players, and cooldown management.</p>
+ *
+ * @author Azami7
+ */
+public class HorcruxTest {
+    /**
+     * Shared mock Bukkit server instance for all tests.
+     *
+     * <p>Static field initialized once before all tests in this class. Reused across test instances
+     * to avoid expensive server setup/teardown for each test method.</p>
+     */
+    static ServerMock mockServer;
+
+    /**
+     * The plugin instance being tested.
+     *
+     * <p>Loaded fresh before each test method with the default configuration. Provides access to
+     * logger, scheduler, and other plugin API methods during tests.</p>
+     */
+    static Ollivanders2 testPlugin;
+
+    /**
+     * Initialize the mock Bukkit server before all tests.
+     *
+     * <p>Static setup method called once before all tests in this class. Creates the shared
+     * MockBukkit server instance that is reused across all test methods to avoid expensive
+     * server creation/destruction overhead.</p>
+     */
+    @BeforeAll
+    static void globalSetUp() {
+        Ollivanders2.testMode = true;
+
+        mockServer = MockBukkit.mock();
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+
+        // advance the server by 20 ticks to let the scheduler start (it has an initial delay of 20 ticks)
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
+    }
+
+    @Test
+    void upkeepTest() {
+        // tested by doOnPlayerMoveEventTest()
+    }
+
+    /**
+     * Tests horcrux item respawning on player join.
+     *
+     * <p>Verifies that when a player who owns a horcrux rejoins the server, the horcrux item
+     * is respawned at its original location if it had been removed or despawned.</p>
+     */
+    @Test
+    void doOnPlayerJoinEventTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 200, 40, 100);
+        PlayerMock caster = mockServer.addPlayer();
+
+        // create a solid base so that the horcrux item stays in place, all blocks are air by default so the dropped item would fall
+        Block baseBlock = testWorld.getBlockAt(location).getRelative(BlockFace.DOWN);
+        baseBlock.setType(Material.DIRT);
+
+        // create horcrux
+        HORCRUX horcrux = new HORCRUX(testPlugin, caster.getUniqueId(), location, testWorld.dropItem(location, new ItemStack(Material.COMPASS, 1)));
+        Ollivanders2API.getStationarySpells().addStationarySpell(horcrux);
+        mockServer.getScheduler().performTicks(20);
+
+        Item horcruxItem = EntityCommon.getItemAtLocation(location);
+        assertNotNull(horcruxItem);
+
+        // log player off and remove item
+        caster.disconnect();
+        horcruxItem.remove();
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(horcruxItem.isDead());
+
+        // log player back on and confirm the horcrux is respawned
+        caster.reconnect();
+        PlayerJoinEvent event = new PlayerJoinEvent(caster, "message");
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+
+        Item newHorcruxItem = EntityCommon.getItemAtLocation(location);
+        assertNotNull(newHorcruxItem, "Horcrux item not respawned on player join");
+        assertEquals(horcruxItem.getItemStack().getType(), newHorcruxItem.getItemStack().getType(), "respawned horcrux item not expected type");
+    }
+
+    /**
+     * Tests player death handling with horcrux resurrection.
+     *
+     * <p>Verifies that when the horcrux owner dies, they are respawned at the horcrux location
+     * and their spell level and experience are preserved despite death.</p>
+     */
+    @Test
+    void doOnPlayerDeathEventTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 300, 40, 100);
+        Location otherLocation = new Location(location.getWorld(), location.getX() + 10, location.getY(), location.getZ());
+        PlayerMock caster = mockServer.addPlayer();
+
+        HORCRUX horcrux = new HORCRUX(testPlugin, caster.getUniqueId(), location, testWorld.dropItem(location, new ItemStack(Material.SPECTRAL_ARROW, 1)));
+        Ollivanders2API.getStationarySpells().addStationarySpell(horcrux);
+        mockServer.getScheduler().performTicks(20);
+
+        caster.setLocation(otherLocation);
+        caster.setRespawnLocation(otherLocation, true);
+        assertNotNull(caster.getRespawnLocation());
+        int expectedLevel = 10;
+        caster.setLevel(expectedLevel);
+        int expectedExperience = 100;
+        caster.setTotalExperience(expectedExperience);
+
+        DamageSource damageSource = DamageSource.builder(DamageType.IN_FIRE)
+                .withDamageLocation(caster.getLocation())  // location of the fire block
+                .build();
+
+        PlayerDeathEvent event = new PlayerDeathEvent(caster, damageSource, new ArrayList<>(), 10, 90, 90, 9, "you have died");
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+
+        // player should be teleported to their horcrux location
+        assertNotNull(caster.getRespawnLocation());
+        assertEquals(location, caster.getRespawnLocation(), "Caster respawn location not set to horcrux location");
+        assertEquals(expectedLevel, caster.getLevel(), "Caster level affected by death");
+        assertEquals(expectedExperience, caster.getTotalExperience(), "Caster experience affected by death");
+    }
+
+    /**
+     * Tests player debilitation effects and cooldown mechanics.
+     *
+     * <p>Verifies that non-owner players entering the horcrux radius receive blindness and wither effects,
+     * the horcrux owner is immune to these effects, and the spell implements a cooldown preventing
+     * repeated effect applications. Also tests upkeep behavior for cooldown decrements.</p>
+     */
+    @Test
+    void doOnPlayerMoveEventTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 40, 100);
+        PlayerMock caster = mockServer.addPlayer();
+
+        HORCRUX horcrux = new HORCRUX(testPlugin, caster.getUniqueId(), location, testWorld.dropItem(location, new ItemStack(Material.APPLE, 1)));
+        Ollivanders2API.getStationarySpells().addStationarySpell(horcrux);
+        mockServer.getScheduler().performTicks(20);
+
+        // a player is affected by the horcrux if they are in its radius
+        PlayerMock player = mockServer.addPlayer();
+        Location outsideLocation = new Location(location.getWorld(), location.getX() + HORCRUX.maxRadiusConfig + 1, location.getY(), location.getZ());
+        player.setLocation(outsideLocation);
+        assertFalse(horcrux.isLocationInside(player.getLocation()));
+
+        PlayerMoveEvent event = new PlayerMoveEvent(player, outsideLocation, location);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+
+        assertTrue(horcrux.isAffected(player), "Player was not affected when moving within the radius of a horcrux");
+        assertTrue(player.hasPotionEffect(PotionEffectType.BLINDNESS), "blindness effect not added");
+        assertTrue(player.hasPotionEffect(PotionEffectType.WITHER), "wither effect not added");
+
+        // the caster is not affected by the horcrux
+        caster.setLocation(outsideLocation);
+        assertFalse(horcrux.isLocationInside(caster.getLocation()));
+
+        event = new PlayerMoveEvent(caster, outsideLocation, location);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+
+        assertFalse(horcrux.isAffected(caster), "horcrux affected caster");
+        assertFalse(caster.hasPotionEffect(PotionEffectType.BLINDNESS), "blindness effect added to caster");
+        assertFalse(caster.hasPotionEffect(PotionEffectType.WITHER), "wither effect added to caster");
+
+        // upkeep prevents a player being affected again too soon by the horcrux and decrements the cooldown
+        // test upkeep here since it needs the code above for set up
+        PotionEffect potionEffect = player.getPotionEffect(PotionEffectType.BLINDNESS);
+        assertNotNull(potionEffect);
+        int duration = potionEffect.getDuration();
+
+        player.setLocation(outsideLocation);
+        event = new PlayerMoveEvent(player, outsideLocation, location);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+
+        potionEffect = player.getPotionEffect(PotionEffectType.BLINDNESS);
+        assertNotNull(potionEffect);
+        // potion duration should have gone down
+        assertTrue(duration > potionEffect.getDuration(), "Potion duration increased when player moved back in horcrux range while cooldown still running");
+
+        player.setLocation(outsideLocation);
+        mockServer.getScheduler().performTicks(HORCRUX.effectDuration);
+        assertFalse(horcrux.isAffected(player), "player still affected after cooldown time past");
+    }
+
+    /**
+     * Tests horcrux item despawn protection.
+     *
+     * <p>Verifies that the horcrux item cannot be despawned naturally, preventing its loss
+     * during server cleanup of dropped items.</p>
+     */
+    @Test
+    void doOnItemDespawnEventTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 400, 40, 100);
+        PlayerMock caster = mockServer.addPlayer();
+
+        HORCRUX horcrux = new HORCRUX(testPlugin, caster.getUniqueId(), location, testWorld.dropItem(location, new ItemStack(Material.APPLE, 1)));
+        Ollivanders2API.getStationarySpells().addStationarySpell(horcrux);
+        mockServer.getScheduler().performTicks(20);
+
+        Item horcruxItem = EntityCommon.getItemAtLocation(location);
+        assertNotNull(horcruxItem);
+        ItemDespawnEvent event = new ItemDespawnEvent(horcruxItem, location);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+
+        assertTrue(event.isCancelled(), "horcrux item despawn event not canceled");
+    }
+
+    /**
+     * Tests horcrux item entity pickup protection.
+     *
+     * <p>Verifies that the horcrux item cannot be picked up by any entity (players, mobs),
+     * keeping it protected at its location.</p>
+     */
+    @Test
+    void doOnEntityPickupItemEventTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 500, 40, 100);
+        PlayerMock caster = mockServer.addPlayer();
+
+        HORCRUX horcrux = new HORCRUX(testPlugin, caster.getUniqueId(), location, testWorld.dropItem(location, new ItemStack(Material.APPLE, 1)));
+        Ollivanders2API.getStationarySpells().addStationarySpell(horcrux);
+        mockServer.getScheduler().performTicks(20);
+
+        Item horcruxItem = EntityCommon.getItemAtLocation(location);
+        assertNotNull(horcruxItem);
+        EntityPickupItemEvent event = new EntityPickupItemEvent(caster, horcruxItem, 0);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+
+        assertTrue(event.isCancelled(), "entity item pickup event not cancelled");
+    }
+
+    /**
+     * Tests horcrux item inventory system pickup protection.
+     *
+     * <p>Verifies that the horcrux item cannot be collected by inventory systems like hoppers,
+     * minecarts with hoppers, or other automated item collectors.</p>
+     */
+    @Test
+    void doOnInventoryItemPickupEventTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 600, 40, 100);
+        PlayerMock caster = mockServer.addPlayer();
+
+        HORCRUX horcrux = new HORCRUX(testPlugin, caster.getUniqueId(), location, testWorld.dropItem(location, new ItemStack(Material.APPLE, 1)));
+        Ollivanders2API.getStationarySpells().addStationarySpell(horcrux);
+        mockServer.getScheduler().performTicks(20);
+
+        Item horcruxItem = EntityCommon.getItemAtLocation(location);
+        assertNotNull(horcruxItem);
+        Inventory inventory = Bukkit.createInventory(null, InventoryType.HOPPER);
+        InventoryPickupItemEvent event = new InventoryPickupItemEvent(inventory, horcruxItem);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+
+        assertTrue(event.isCancelled(), "inventory item pickup event not cancelled");
+    }
+
+    /**
+     * Tests serialization and deserialization of horcrux spell data.
+     *
+     * <p>Verifies that the horcrux material type and world name are correctly serialized to a map,
+     * and that deserializing valid data restores the spell state. Also verifies that deserializing
+     * with an invalid material name kills the spell, and that missing data kills the spell.</p>
+     */
+    @Test
+    void serializeAndDeserializeSpellDataTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 700, 40, 100);
+        PlayerMock caster = mockServer.addPlayer();
+
+        HORCRUX horcrux = new HORCRUX(testPlugin, caster.getUniqueId(), location, testWorld.dropItem(location, new ItemStack(Material.DIAMOND, 1)));
+
+        // serialize and verify data
+        Map<String, String> spellData = horcrux.serializeSpellData();
+        assertFalse(spellData.isEmpty(), "serialized spell data is empty");
+        assertEquals(Material.DIAMOND.toString(), spellData.get("itemType"), "serialized material not correct");
+        assertEquals(testWorld.getName(), spellData.get("world"), "serialized world not correct");
+
+        // deserialize valid data into a new spell created with the full constructor
+        // the full constructor is needed because kill() requires a non-null playerUUID
+        HORCRUX deserialized = new HORCRUX(testPlugin, caster.getUniqueId(), location, testWorld.dropItem(location, new ItemStack(Material.STICK, 1)));
+        deserialized.deserializeSpellData(spellData);
+        assertFalse(deserialized.isKilled(), "spell killed after deserializing valid data");
+
+        // deserialize with invalid material kills the spell
+        HORCRUX invalidMaterial = new HORCRUX(testPlugin, caster.getUniqueId(), location, testWorld.dropItem(location, new ItemStack(Material.STICK, 1)));
+        Map<String, String> badMaterialData = new HashMap<>();
+        badMaterialData.put("itemType", "NOT_A_REAL_MATERIAL");
+        badMaterialData.put("world", testWorld.getName());
+        invalidMaterial.deserializeSpellData(badMaterialData);
+        assertTrue(invalidMaterial.isKilled(), "spell not killed after deserializing invalid material");
+    }
+
+    /**
+     * Tests spell deserialization validation.
+     *
+     * <p>Verifies that a horcrux created via the deserialization constructor fails
+     * checkSpellDeserialization() because it lacks required data (player UUID, location,
+     * and horcrux material), while a properly initialized spell passes validation.</p>
+     */
+    @Test
+    void checkSpellDeserializationTest() {
+        O2StationarySpell stationarySpell = Ollivanders2API.getStationarySpells().createStationarySpellByType(O2StationarySpellType.HORCRUX);
+        assertNotNull(stationarySpell);
+        assertFalse(stationarySpell.checkSpellDeserialization(), "Deserialized spell should fail check without required data");
+
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 800, 40, 100);
+        PlayerMock caster = mockServer.addPlayer();
+
+        HORCRUX horcrux = new HORCRUX(testPlugin, caster.getUniqueId(), location, testWorld.dropItem(location, new ItemStack(Material.APPLE, 1)));
+        assertTrue(horcrux.checkSpellDeserialization(), "Properly initialized horcrux failed deserialization check");
+    }
+
+    /**
+     * Tear down the mock Bukkit server after all tests complete.
+     *
+     * <p>Static teardown method called once after all tests in this class have finished.
+     * Releases the MockBukkit server resources to prevent memory leaks and allow clean
+     * test execution in subsequent test classes.</p>
+     */
+    @AfterAll
+    static void globalTearDown() {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/NullumApparebitTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/NullumApparebitTest.java
@@ -1,0 +1,200 @@
+package net.pottercraft.ollivanders2.test.stationaryspell;
+
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.spell.events.OllivandersApparateByCoordinatesEvent;
+import net.pottercraft.ollivanders2.spell.events.OllivandersApparateByNameEvent;
+import net.pottercraft.ollivanders2.stationaryspell.NULLUM_APPAREBIT;
+import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpellType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Rabbit;
+import org.bukkit.event.entity.EntityTeleportEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test suite for the NULLUM_APPAREBIT stationary spell.
+ *
+ * <p>Tests spell-specific behavior for the anti-apparition barrier that prevents entities
+ * from entering the protected area through apparition or teleportation. Inherits common
+ * stationary spell tests from the base class and adds tests for event handling specific to
+ * this spell's escape-prevention mechanics.</p>
+ *
+ * @author Azami7
+ */
+public class NullumApparebitTest extends O2StationarySpellTest {
+    /**
+     * Gets the spell type being tested.
+     *
+     * @return {@link O2StationarySpellType#NULLUM_APPAREBIT}
+     */
+    @Override
+    O2StationarySpellType getSpellType() {
+        return O2StationarySpellType.NULLUM_APPAREBIT;
+    }
+
+    /**
+     * Creates a NULLUM_APPAREBIT spell instance for testing.
+     *
+     * <p>Constructs a new spell at the specified location with the minimum radius and duration values.</p>
+     *
+     * @param caster   the player casting the spell (not null)
+     * @param location the center location of the spell (not null)
+     * @return a new NULLUM_APPAREBIT spell instance (not null)
+     */
+    @Override
+    NULLUM_APPAREBIT createStationarySpell(Player caster, Location location) {
+        return new NULLUM_APPAREBIT(testPlugin, caster.getUniqueId(), location, NULLUM_APPAREBIT.minRadiusConfig, NULLUM_APPAREBIT.minDurationConfig);
+    }
+
+    /**
+     * Tests upkeep behavior (skipped - covered by base class tests).
+     *
+     * <p>The upkeep method only performs aging, which is already tested comprehensively by the inherited
+     * ageAndKillTest() from the base test class.</p>
+     */
+    @Override @Test
+    void upkeepTest() {
+    }
+
+    /**
+     * Tests apparate by name and coordinates event handling.
+     *
+     * <p>Verifies that players outside the spell area cannot apparate in by name or coordinates,
+     * while players inside the spell area can freely apparate out. Confirms that both blocked and
+     * allowed apparations are handled correctly, and that players receive feedback when their
+     * entry attempts are prevented.</p>
+     */
+    @Test
+    void doOnOllivandersApparateEventsTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 4, 100);
+        Location outsideLocation = new Location(location.getWorld(), location.getX(), location.getY(), location.getZ() + NULLUM_APPAREBIT.maxRadiusConfig + 1);
+        PlayerMock caster = mockServer.addPlayer();
+
+        NULLUM_APPAREBIT nullumApparebit = createStationarySpell(caster, location);
+        Ollivanders2API.getStationarySpells().addStationarySpell(nullumApparebit);
+        mockServer.getScheduler().performTicks(20);
+
+        // player cannot apparate in to spell area
+        caster.setLocation(outsideLocation);
+        assertFalse(nullumApparebit.isLocationInside(caster.getLocation()));
+        OllivandersApparateByNameEvent event = new OllivandersApparateByNameEvent(caster, location, "inside");
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(event.isCancelled(), "player allowed apparate in to spell area by name");
+
+        // check player got feedback message
+        mockServer.getScheduler().performTicks(200);
+        String message = caster.nextMessage();
+        assertNotNull(message, "Player did not get feedback message when trying to apparate in by name");
+        assertEquals(NULLUM_APPAREBIT.feedbackMessage, TestCommon.cleanChatMessage(message), "player did not get expected feedback message");
+
+        OllivandersApparateByCoordinatesEvent event2 = new OllivandersApparateByCoordinatesEvent(caster, location);
+        mockServer.getPluginManager().callEvent(event2);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(event2.isCancelled(), "player allowed apparate in to spell area by coordinates");
+
+        // check player got feedback message
+        mockServer.getScheduler().performTicks(200);
+        message = caster.nextMessage();
+        assertNotNull(message, "Player did not get feedback message when trying to apparate in by name");
+        assertEquals(NULLUM_APPAREBIT.feedbackMessage, TestCommon.cleanChatMessage(message), "player did not get expected feedback message");
+
+        // player inside the spell area can apparate out
+        caster.setLocation(location);
+        assertTrue(nullumApparebit.isLocationInside(caster.getLocation()));
+        event = new OllivandersApparateByNameEvent(caster, outsideLocation, "outside");
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(event.isCancelled(), "player inside spell area prevented from apparating out by name");
+
+        event2 = new OllivandersApparateByCoordinatesEvent(caster, outsideLocation);
+        mockServer.getPluginManager().callEvent(event2);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(event2.isCancelled(), "player inside spell area prevented from apparating out by coordinates");
+    }
+
+    /**
+     * Tests entity teleport event handling.
+     *
+     * <p>Verifies that non-player entities outside the spell area are prevented from teleporting in,
+     * while entities inside the spell area can freely teleport out of the protected area.</p>
+     */
+    @Test
+    void doOnEntityTeleportEventTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 200, 4, 100);
+        Location outsideLocation = new Location(location.getWorld(), location.getX(), location.getY(), location.getZ() + NULLUM_APPAREBIT.maxRadiusConfig + 1);
+        PlayerMock caster = mockServer.addPlayer();
+
+        NULLUM_APPAREBIT nullumApparebit = createStationarySpell(caster, location);
+        Ollivanders2API.getStationarySpells().addStationarySpell(nullumApparebit);
+        mockServer.getScheduler().performTicks(20);
+
+        // entity outside spell area cannot teleport in
+        Rabbit rabbit = testWorld.spawn(outsideLocation, Rabbit.class);
+        assertFalse(nullumApparebit.isLocationInside(rabbit.getLocation()));
+        EntityTeleportEvent event = new EntityTeleportEvent(rabbit, outsideLocation, location);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(event.isCancelled(), "entity allowed to teleport in to spell area");
+
+        // entity inside spell area can teleport out
+        rabbit = testWorld.spawn(location, Rabbit.class);
+        assertTrue(nullumApparebit.isLocationInside(rabbit.getLocation()));
+        event = new EntityTeleportEvent(rabbit, location, outsideLocation);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(event.isCancelled(), "entity inside spell area prevented from teleporting out");
+    }
+
+    /**
+     * Tests player teleport event handling.
+     *
+     * <p>Verifies that players outside the spell area are prevented from teleporting in and receive
+     * feedback when their entry attempts are blocked, while players inside the spell area can
+     * freely teleport out of the protected area.</p>
+     */
+    @Test
+    void doOnPlayerTeleportEventTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 300, 4, 100);
+        Location outsideLocation = new Location(location.getWorld(), location.getX(), location.getY(), location.getZ() + NULLUM_APPAREBIT.maxRadiusConfig + 1);
+        PlayerMock caster = mockServer.addPlayer();
+
+        NULLUM_APPAREBIT nullumApparebit = createStationarySpell(caster, location);
+        Ollivanders2API.getStationarySpells().addStationarySpell(nullumApparebit);
+        mockServer.getScheduler().performTicks(20);
+
+        // player outside the spell area cannot teleport in
+        caster.setLocation(outsideLocation);
+        assertFalse(nullumApparebit.isLocationInside(caster.getLocation()));
+        PlayerTeleportEvent event = new PlayerTeleportEvent(caster, outsideLocation, location);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(event.isCancelled(), "player allowed to teleport into spell area");
+
+        // check player got feedback message
+        mockServer.getScheduler().performTicks(200);
+        String message = caster.nextMessage();
+        assertNotNull(message, "Player did not get feedback message when trying to teleport in");
+        assertEquals(NULLUM_APPAREBIT.feedbackMessage, TestCommon.cleanChatMessage(message), "player did not get expected feedback message");
+
+        // player inside spell area can teleport out
+        caster.setLocation(location);
+        assertTrue(nullumApparebit.isLocationInside(caster.getLocation()));
+        event = new PlayerTeleportEvent(caster, location, outsideLocation);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(event.isCancelled(), "player not allowed to teleport out of spell area");
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/NullumEvanescuntTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/NullumEvanescuntTest.java
@@ -1,0 +1,203 @@
+package net.pottercraft.ollivanders2.test.stationaryspell;
+
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.spell.events.OllivandersApparateByCoordinatesEvent;
+import net.pottercraft.ollivanders2.spell.events.OllivandersApparateByNameEvent;
+import net.pottercraft.ollivanders2.stationaryspell.NULLUM_APPAREBIT;
+import net.pottercraft.ollivanders2.stationaryspell.NULLUM_EVANESCUNT;
+import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpellType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Rabbit;
+import org.bukkit.event.entity.EntityTeleportEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test suite for the NULLUM_EVANESCUNT stationary spell.
+ *
+ * <p>Tests spell-specific behavior for the anti-disapparition barrier that prevents entities
+ * from escaping the protected area through apparition or teleportation. Inherits common
+ * stationary spell tests from the base class and adds tests for event handling specific to
+ * this spell's escape-prevention mechanics.</p>
+ *
+ * @author Azami7
+ */
+public class NullumEvanescuntTest extends O2StationarySpellTest {
+    /**
+     * Gets the spell type being tested.
+     *
+     * @return {@link O2StationarySpellType#NULLUM_EVANESCUNT}
+     */
+    @Override
+    O2StationarySpellType getSpellType() {
+        return O2StationarySpellType.NULLUM_EVANESCUNT;
+    }
+
+    /**
+     * Creates a NULLUM_EVANESCUNT spell instance for testing.
+     *
+     * <p>Constructs a new spell at the specified location with the minimum radius and duration values.</p>
+     *
+     * @param caster   the player casting the spell (not null)
+     * @param location the center location of the spell (not null)
+     * @return a new NULLUM_EVANESCUNT spell instance (not null)
+     */
+    @Override
+    NULLUM_EVANESCUNT createStationarySpell(Player caster, Location location) {
+        return new NULLUM_EVANESCUNT(testPlugin, caster.getUniqueId(), location, NULLUM_APPAREBIT.minRadiusConfig, NULLUM_APPAREBIT.minDurationConfig); // nullum evanescunt uses the radius and duration constants rom nullum apparebit
+    }
+
+    /**
+     * Tests upkeep behavior (skipped - covered by base class tests).
+     *
+     * <p>The upkeep method only performs aging, which is already tested comprehensively by the inherited
+     * ageAndKillTest() from the base test class.</p>
+     */
+    @Override
+    @Test
+    void upkeepTest() {
+        // upkeep just calls age(), which is tested by ageAndKillTest()
+    }
+
+    /**
+     * Tests apparate by name and coordinates event handling.
+     *
+     * <p>Verifies that players inside the spell area cannot apparate out by name or coordinates,
+     * while players outside the spell area can freely apparate in. Confirms that both blocked and
+     * allowed apparations are handled correctly, and that players receive feedback when their
+     * escape attempts are prevented.</p>
+     */
+    @Test
+    void doOnOllivandersApparateEventsTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 40, 100);
+        Location outsideLocation = new Location(location.getWorld(), location.getX(), location.getY(), location.getZ() + NULLUM_APPAREBIT.maxRadiusConfig + 1);
+        PlayerMock caster = mockServer.addPlayer();
+
+        NULLUM_EVANESCUNT nullumEvanescunt = createStationarySpell(caster, location);
+        Ollivanders2API.getStationarySpells().addStationarySpell(nullumEvanescunt);
+        mockServer.getScheduler().performTicks(20);
+
+        // player cannot apparate out of the spell area
+        caster.setLocation(location);
+        assertTrue(nullumEvanescunt.isLocationInside(caster.getLocation()));
+        OllivandersApparateByNameEvent event = new OllivandersApparateByNameEvent(caster, outsideLocation, "outside");
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(event.isCancelled(), "player allowed apparate out of spell area");
+
+        // check player got feedback message
+        mockServer.getScheduler().performTicks(200);
+        String message = caster.nextMessage();
+        assertNotNull(message, "Player did not get feedback message when trying to apparate out by name");
+        assertEquals(NULLUM_EVANESCUNT.feedbackMessage, TestCommon.cleanChatMessage(message), "player did not get expected feedback message");
+
+        OllivandersApparateByCoordinatesEvent event2 = new OllivandersApparateByCoordinatesEvent(caster, outsideLocation);
+        mockServer.getPluginManager().callEvent(event2);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(event2.isCancelled(), "player allowed apparate out of spell area");
+
+        // check player got feedback message
+        mockServer.getScheduler().performTicks(200);
+        message = caster.nextMessage();
+        assertNotNull(message, "Player did not get feedback message when trying to apparate out by coordinates");
+        assertEquals(NULLUM_EVANESCUNT.feedbackMessage, TestCommon.cleanChatMessage(message), "player did not get expected feedback message");
+
+        // player outside of area can apparate in
+        caster.setLocation(outsideLocation);
+        assertFalse(nullumEvanescunt.isLocationInside(caster.getLocation()));
+        event = new OllivandersApparateByNameEvent(caster, location, "inside");
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(event.isCancelled(), "player outside spell area prevented from apparating in");
+
+        event2 = new OllivandersApparateByCoordinatesEvent(caster, location);
+        mockServer.getPluginManager().callEvent(event2);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(event2.isCancelled(), "player outside spell area prevented from apparating in");
+    }
+
+    /**
+     * Tests entity teleport event handling.
+     *
+     * <p>Verifies that non-player entities inside the spell area are prevented from teleporting out,
+     * while entities outside the spell area can freely teleport into the protected area.</p>
+     */
+    @Test
+    void doOnEntityTeleportEventTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 200, 40, 100);
+        Location outsideLocation = new Location(location.getWorld(), location.getX(), location.getY(), location.getZ() + NULLUM_APPAREBIT.maxRadiusConfig + 1);
+        PlayerMock caster = mockServer.addPlayer();
+
+        NULLUM_EVANESCUNT nullumEvanescunt = createStationarySpell(caster, location);
+        Ollivanders2API.getStationarySpells().addStationarySpell(nullumEvanescunt);
+        mockServer.getScheduler().performTicks(20);
+
+        // entity inside spell area cannot teleport out
+        Rabbit rabbit = testWorld.spawn(location, Rabbit.class);
+        assertTrue(nullumEvanescunt.isLocationInside(rabbit.getLocation()));
+        EntityTeleportEvent event = new EntityTeleportEvent(rabbit, location, outsideLocation);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(event.isCancelled(), "entity allowed to teleport out of spell area");
+
+        // entity outside spell area can teleport in
+        Rabbit rabbit2 = testWorld.spawn(outsideLocation, Rabbit.class);
+        assertFalse(nullumEvanescunt.isLocationInside(rabbit2.getLocation()));
+        event = new EntityTeleportEvent(rabbit2, outsideLocation, location);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(event.isCancelled(), "entity outside spell area prevented from teleporting in");
+    }
+
+    /**
+     * Tests player teleport event handling.
+     *
+     * <p>Verifies that players inside the spell area are prevented from teleporting out and receive
+     * feedback when their escape attempts are blocked, while players outside the spell area can
+     * freely teleport into the protected area.</p>
+     */
+    @Test
+    void doOnPlayerTeleportEventTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 300, 40, 100);
+        Location outsideLocation = new Location(location.getWorld(), location.getX(), location.getY(), location.getZ() + NULLUM_APPAREBIT.maxRadiusConfig + 1);
+        PlayerMock caster = mockServer.addPlayer();
+
+        NULLUM_EVANESCUNT nullumEvanescunt = createStationarySpell(caster, location);
+        Ollivanders2API.getStationarySpells().addStationarySpell(nullumEvanescunt);
+        mockServer.getScheduler().performTicks(20);
+
+        // player inside spell area cannot teleport out
+        caster.setLocation(location);
+        assertTrue(nullumEvanescunt.isLocationInside(caster.getLocation()));
+        PlayerTeleportEvent event = new PlayerTeleportEvent(caster, location, outsideLocation);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(event.isCancelled(), "player allowed to teleport out of spell area");
+
+        // check player got feedback message
+        mockServer.getScheduler().performTicks(200);
+        String message = caster.nextMessage();
+        assertNotNull(message, "Player did not get feedback message when trying to teleport out");
+        assertEquals(NULLUM_EVANESCUNT.feedbackMessage, TestCommon.cleanChatMessage(message), "player did not get expected feedback message");
+
+        // player outside spell area can teleport in
+        caster.setLocation(outsideLocation);
+        assertFalse(nullumEvanescunt.isLocationInside(caster.getLocation()));
+        event = new PlayerTeleportEvent(caster, outsideLocation, location);
+        mockServer.getPluginManager().callEvent(event);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(event.isCancelled(), "player not allowed to teleport in to spell area");
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/ProtegoHorribilisTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/stationaryspell/ProtegoHorribilisTest.java
@@ -64,8 +64,7 @@ public class ProtegoHorribilisTest extends O2StationarySpellTest {
      * <p>The upkeep method only performs aging, which is already tested comprehensively by the inherited
      * ageAndKillTest() from the base test class.</p>
      */
-    @Override
-    @Test
+    @Override @Test
     void upkeepTest() {
         // upkeep just calls age(), which is tested by ageAndKillTest()
     }

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/testcommon/TestCommon.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/testcommon/TestCommon.java
@@ -5,6 +5,9 @@ import net.pottercraft.ollivanders2.player.O2Player;
 import net.pottercraft.ollivanders2.potion.O2PotionType;
 import net.pottercraft.ollivanders2.spell.O2SpellType;
 import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
@@ -14,6 +17,7 @@ import org.jetbrains.annotations.Nullable;
 import org.mockbukkit.mockbukkit.ServerMock;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -287,4 +291,24 @@ public class TestCommon {
 
         return o2player.getSpellCount(spellType);
     }
+
+    /**
+     * Get all items in the world.
+     *
+     * @param world the world
+     * @return a list of all item entities found
+     */
+    @NotNull
+    public static List<Item> getAllItems(@NotNull World world) {
+        ArrayList<Item> items = new ArrayList<>();
+
+        for (Entity entity : world.getEntities()) {
+            if (entity instanceof Item)
+                items.add((Item)entity);
+        }
+
+        return items;
+    }
+
+
 }


### PR DESCRIPTION
* added tests for Harmonia, Herbicide, Nullum Apparebit, Nullum Evanescunt, and Horcrux stationary spells
* added getItemAtLocation to EntityCommon
* fixed bug in Herbicide where it was not removing the block changed to an item
* reworked how horcrux items respawn to be more robust