### PR TITLE
Legilimens and Harmonia Nectere Passus tests

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/Ollivanders2.java
@@ -20,6 +20,7 @@ import net.pottercraft.ollivanders2.listeners.OllivandersListener;
 import net.pottercraft.ollivanders2.player.O2PlayerCommon;
 import net.pottercraft.ollivanders2.player.O2Players;
 import net.pottercraft.ollivanders2.spell.APPARATE;
+import net.pottercraft.ollivanders2.spell.O2Spell;
 import net.pottercraft.ollivanders2.spell.O2Spells;
 import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpells;
 import org.bukkit.World;
@@ -1425,19 +1426,7 @@ public class Ollivanders2 extends JavaPlugin {
      * @param player the player that attempted to cast the spell
      */
     public void spellCannotBeCastMessage(@NotNull Player player) {
-        player.sendMessage(chatColor + "A powerful protective magic prevents you from casting this spell here.");
-    }
-
-    /**
-     * Send a message when a spell's effect is blocked by protective magic (e.g., WorldGuard).
-     *
-     * <p>This is used when a spell is cast but its effects are blocked at the target location,
-     * not when the initial casting is prevented. This is not the message to use for bookLearning enforcement.</p>
-     *
-     * @param player the player whose spell effect was blocked
-     */
-    public void spellFailedMessage(@NotNull Player player) {
-        player.sendMessage(chatColor + "A powerful protective magic blocks your spell.");
+        player.sendMessage(chatColor + O2Spell.isAllowedFailureMessage);
     }
 
     /**
@@ -1449,7 +1438,7 @@ public class Ollivanders2 extends JavaPlugin {
      * @param player the player who attempted to cast while on cooldown
      */
     public void spellCoolDownMessage(@NotNull Player player) {
-        player.sendMessage(chatColor + "You are too tired to cast this spell right now.");
+        player.sendMessage(chatColor + O2Spell.cooldownMessage);
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Prophecy.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/divination/O2Prophecy.java
@@ -267,7 +267,7 @@ public class O2Prophecy {
         // Example: 50% accuracy needs to roll < 50 to succeed
         int rand = Math.abs(Ollivanders2Common.random.nextInt() % 100);
 
-        if (accuracy > rand) {
+        if (accuracy > rand || (Ollivanders2.testMode && Ollivanders2.maxSpellLevel)) { // make sure this always succeeds in test mode
             // Prophecy succeeds: apply the effect to the target
             O2Effect effect;
             Class<?> effectClass = effectType.getClassName();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effect.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effect.java
@@ -195,6 +195,24 @@ public abstract class O2Effect {
     }
 
     /**
+     * Get the legiliments text for this effect
+     *
+     * @return the legilimens text
+     */
+    public String getLegilimensText() {
+        return legilimensText;
+    }
+
+    /**
+     * Get the informous text for this effect
+     *
+     * @return the informous text
+     */
+    public String getInformousText() {
+        return informousText;
+    }
+
+    /**
      * Decrement the effect's duration by the specified amount.
      *
      * <p>Called by the player effects system each game tick to age the effect. Permanent effects

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effects.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2Effects.java
@@ -1373,12 +1373,14 @@ public class O2Effects implements Listener {
      */
     @Nullable
     public String detectEffectWithLegilimens(@NotNull UUID pid) {
+        common.printDebugMessage("O2Effects.detectEffectWithLegilimens", null, null, false);
         String infoText = null;
 
         Map<O2EffectType, O2Effect> activeEffects = effectsData.getPlayerActiveEffects(pid);
         Collection<O2Effect> effects = activeEffects.values();
 
         for (O2Effect effect : effects) {
+            common.printDebugMessage("O2Effects.detectEffectWithLegilimens: found " + effect.effectType.toString(), null, null, false);
             if (effect.legilimensText != null) {
                 infoText = effect.legilimensText;
                 break;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/listeners/OllivandersListener.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/listeners/OllivandersListener.java
@@ -68,7 +68,6 @@ import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.lang.reflect.Constructor;
 import java.util.Set;
 
 /**
@@ -278,42 +277,6 @@ public class OllivandersListener implements Listener {
     }
 
     /**
-     * This creates the spell projectile.
-     *
-     * @param player the player that cast the spell
-     * @param name   the name of the spell cast
-     * @param wandC  the wand check value for the held wand
-     */
-    @Nullable
-    private O2Spell createSpellProjectile(@NotNull Player player, @NotNull O2SpellType name, double wandC) {
-        common.printDebugMessage("OllivandersListener.createSpellProjectile: enter", null, null, false);
-
-        //spells go here, using any of the three types of magic
-        String spellClass = "net.pottercraft.ollivanders2.spell." + name;
-
-        Constructor<?> c;
-        try {
-            c = Class.forName(spellClass).getConstructor(Ollivanders2.class, Player.class, Double.class);
-        }
-        catch (Exception e) {
-            common.printDebugMessage("OllivandersListener.createSpellProjectile: exception creating spell constructor", e, null, true);
-            return null;
-        }
-
-        O2Spell spell;
-
-        try {
-            spell = (O2Spell) c.newInstance(p, player, wandC);
-        }
-        catch (Exception e) {
-            common.printDebugMessage("OllivandersListener.createSpellProjectile: exception creating spell", e, null, true);
-            return null;
-        }
-
-        return spell;
-    }
-
-    /**
      * Action by player to cast a spell
      *
      * @param player the player casting the spell
@@ -346,7 +309,7 @@ public class OllivandersListener implements Listener {
                 return;
             }
 
-            O2Spell castSpell = createSpellProjectile(player, spellType, wandCheck);
+            O2Spell castSpell = Ollivanders2API.getSpells().createSpell(player, spellType, wandCheck);
             if (castSpell == null) {
                 return;
             }
@@ -861,7 +824,7 @@ public class OllivandersListener implements Listener {
             return false;
         }
 
-        O2Spell spell = createSpellProjectile(sender, spellType, 1.0);
+        O2Spell spell = Ollivanders2API.getSpells().createSpell(sender, spellType, O2PlayerCommon.rightWand);
 
         if (!(spell instanceof Divination))
             return false;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/APPARATE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/APPARATE.java
@@ -119,7 +119,8 @@ public final class APPARATE extends O2Spell {
             destinationParsed = true;
         else {
             if (Ollivanders2.apparateLocations) {
-                player.sendMessage(Ollivanders2.chatColor + "That location does not exist.");
+                failureMessage = "That location does not exist.";
+                sendFailureMessage();
                 kill();
                 return;
             }
@@ -129,7 +130,8 @@ public final class APPARATE extends O2Spell {
 
         // are they allowed to apparate to that location?
         if (!canApparateTo(destination)) {
-            p.spellFailedMessage(player);
+            failureMessage = "A powerful protective magic blocks your spell.";
+            sendFailureMessage();
             kill();
             return;
         }
@@ -137,14 +139,16 @@ public final class APPARATE extends O2Spell {
         // are they allowed to apparate from this location?
         Location source = player.getLocation();
         if (!canApparateFrom(source)) {
-            p.spellFailedMessage(player);
+            failureMessage = "A powerful protective magic blocks your spell.";
+            sendFailureMessage();
             kill();
             return;
         }
 
         // does this exceed the max apparate distance?
         if (exceedsMaxDistance(source, destination)) {
-            player.sendMessage(Ollivanders2.chatColor + "Your magic is not powerful enough to apparate that far.");
+            failureMessage = "Your magic is not powerful enough to apparate that far.";
+            sendFailureMessage();
             kill();
             return;
         }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/LEGILIMENS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/LEGILIMENS.java
@@ -16,11 +16,38 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 
 /**
- * Reveal certain information about a player
+ * Mind-reading spell that reveals information about a target player.
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Legilimency_Spell">https://harrypotter.fandom.com/wiki/Legilimency_Spell</a>
+ * <p>When cast at a nearby player, the spell attempts to read their mind and reveal various information
+ * depending on the caster's experience level and the target's resistance. Success depends on comparing
+ * the caster's Legilimens skill against the target's skill.</p>
+ *
+ * <p><strong>Information Revealed (by Legilimens Level):</strong></p>
+ * <ul>
+ * <li><strong>Base (any level):</strong> Whether target is a muggle or witch/wizard, house and year (if sorted)</li>
+ * <li><strong>Level 2+:</strong> Target's wand type (50% chance)</li>
+ * <li><strong>Level 3+:</strong> Last spell cast by target (50% chance)</li>
+ * <li><strong>Level 4+:</strong> Target's mastered spell for non-verbal casting (33% chance, if enabled)</li>
+ * <li><strong>Level 6+:</strong> Active magical effects on target (40% chance)</li>
+ * <li><strong>Level 10+:</strong> Whether target is an animagus and their form (10% chance)</li>
+ * </ul>
+ *
+ * <p><strong>Success Rate by Skill Comparison:</strong></p>
+ * <ul>
+ * <li>80% success when caster's skill > target's skill</li>
+ * <li>66% success when skills are equal</li>
+ * <li>10% success when caster's skill < target's skill</li>
+ * </ul>
+ *
+ * <p><strong>Animagus Form:</strong> When target is in animagus form, only level 10+ casters can attempt
+ * mind reading, with a 10% success rate. Lower level casters cannot read an animagus's mind.</p>
+ *
+ * @see <a href="https://harrypotter.fandom.com/wiki/Legilimency_Spell">Legilimency Spell</a>
  */
 public final class LEGILIMENS extends O2Spell {
+    public static final int radius = 3;
+    public static final String mindReadFailureMessage = " resists your mind.";
+
     /**
      * Default constructor for use in generating spell text. Do not use to cast the spell.
      *
@@ -57,113 +84,153 @@ public final class LEGILIMENS extends O2Spell {
     }
 
     /**
-     * Attempt to reveal information about a target player
+     * Attempt to read nearby (within 3 blocks) players' minds when spell is active.
+     *
+     * <p>Finds nearby players (excluding the caster) and determines success based on skill comparison.
+     * If successful, reveals information about the target. If unsuccessful, the target resists.
+     * The spell kills itself after attempting to read one target.</p>
+     *
+     * <p>Special handling for animagus form: only level 10+ casters can attempt reading, with 10% success.</p>
      */
     @Override
-    protected void doCheckEffect() {
-        // projectile has stopped, kill the spell
-        if (hasHitTarget())
-            kill();
+    public void checkEffect() {
+        kill();
 
-        for (Player target : getNearbyPlayers(defaultRadius)) {
-            if (target.getUniqueId().equals(player.getUniqueId()))
+        if (!isSpellAllowed()) {
+            return;
+        }
+
+        for (Player target : getNearbyPlayers(radius)) {
+            common.printDebugMessage("LEGILIMENS.checkEffect: checking " + target.getName(), null, null, false);
+            if (target.getUniqueId().equals(player.getUniqueId())) {
                 continue;
+            }
 
-            int targetExperience = p.getO2Player(target).getSpellCount(O2SpellType.LEGILIMENS) / 10;
+            // only someone who has mastered legilimens can even attempt to read a mind when they are in animagus form
+            if (Ollivanders2API.getPlayers().playerEffects.hasEffect(target.getUniqueId(), O2EffectType.ANIMAGUS_EFFECT)) {
+                common.printDebugMessage("LEGILIMENS.checkEffect: target is in animagus form", null, null, false);
+                common.printDebugMessage("LEGILIMENS.checkEffect: Uses modifier = " + usesModifier, null, null, false);
 
-            int randLess = (Math.abs(Ollivanders2Common.random.nextInt()) % 10);
-            int randEqual = (Math.abs(Ollivanders2Common.random.nextInt()) % 3);
-            int randGreater = (Math.abs(Ollivanders2Common.random.nextInt()) % 5);
+                if (usesModifier < O2Spell.spellMasteryLevel) {
+                    return; // spell fails with no message, caster skill too low to read animagus
+                }
+
+                if (!Ollivanders2.testMode) { // always pass this in test mode so we can reliably test legilimens on animagus form
+                    // 10% chance to detect animagus if spell level is at or above mastery level
+                    int rand = (Math.abs(Ollivanders2Common.random.nextInt()) % 10);
+
+                    if (rand < 9) {
+                        return; // spell fails with no message, same as if they'd targeted a non-player entity
+                    }
+                }
+            }
 
             // Legilimens will be successful:
             // 80% of the time if the caster's legilimens level is greater than the target's
             // 33% of the time if the caster and target have the same legilimens level
             // 10% of the time if the caster's legilimens level is less than the target
-            if (((usesModifier > targetExperience) && (randGreater < 4)) // success on 3, 2, 1, 0
-                    || ((usesModifier == targetExperience) && (randEqual > 0)) // success on 1, 2
-                    || ((usesModifier < targetExperience) && (randLess < 1))) // success on 0
-            {
-                if (Ollivanders2API.getPlayers().playerEffects.hasEffect(target.getUniqueId(), O2EffectType.ANIMAGUS_EFFECT)) {
-                    common.printDebugMessage("Legilimens: target is in animagus form", null, null, false);
-                    common.printDebugMessage("Uses modifier = " + usesModifier, null, null, false);
+            int targetExperience = p.getO2Player(target).getSpellCount(O2SpellType.LEGILIMENS);
+            int randGreater = (Math.abs(Ollivanders2Common.random.nextInt()) % 5);
+            int randEqual = (Math.abs(Ollivanders2Common.random.nextInt()) % 3);
+            int randLess = (Math.abs(Ollivanders2Common.random.nextInt()) % 10);
 
-                    // when in animagus form, only someone who has mastered legilimens can mind read a person
-                    if (usesModifier >= 10) {
-                        int rand = (Math.abs(Ollivanders2Common.random.nextInt()) % 100);
-
-                        // 10% chance to detect animagus
-                        if (rand < 90) {
-                            kill();
-                            return;
-                        }
-                    }
-                    else {
-                        kill();
-                        return;
-                    }
-                }
+            boolean success;
+            if (Ollivanders2.testMode && !Ollivanders2.maxSpellLevel) { // always fail in testmode with maxSpellLevel off so we can reliably test failure
+                success = false;
+            }
+            else if (((usesModifier > targetExperience) && (randGreater < 4)) // success on 3, 2, 1, 0 of 0-4
+                    || ((usesModifier == targetExperience) && (randEqual < 1)) // success on 0 of 0-2
+                    || ((usesModifier < targetExperience) && (randLess < 1)) // success on 0 of 0-9
+                    || (Ollivanders2.testMode && Ollivanders2.maxSpellLevel)) {// in testmode with maxspelllevel on so we can reliably test success
+                success = true;
 
                 readMind(target);
             }
             else
-                player.sendMessage(Ollivanders2.chatColor + target.getName() + " resists your mind.");
+                success = false;
 
-            kill();
+            if (!success) {
+                failureMessage = target.getName() + mindReadFailureMessage;
+                sendFailureMessage();
+            }
+
             return;
         }
     }
 
     /**
-     * Read a target player's mind
+     * Reveal information about a target player based on caster's Legilimens skill.
      *
-     * @param target the player to mind read
+     * <p>Progressively reveals more information as the caster's Legilimens level increases:
+     * <ul>
+     * <li>Always reveals: muggle status, house and year</li>
+     * <li>Level 2+: wand type (50% chance)</li>
+     * <li>Level 3+: last spell cast (50% chance)</li>
+     * <li>Level 4+: mastered spell if non-verbal casting enabled (33% chance)</li>
+     * <li>Level 6+: active effects on target (40% chance)</li>
+     * <li>Level 10+: animagus status and form (10% chance)</li>
+     * </ul>
+     *
+     * @param target the player whose mind is being read
      */
     private void readMind(Player target) {
         O2Player o2p = p.getO2Player(target);
 
+        common.printDebugMessage("LEGILIMENS.readMind: usesModifier = " + usesModifier, null, null, false);
         player.sendMessage(Ollivanders2.chatColor + "You search in to " + o2p.getPlayerName() + "'s mind ...");
 
-        // detect if they are a muggle
-        if (o2p.isMuggle())
-            player.sendMessage(Ollivanders2.chatColor + " is a muggle.");
-        else
-            player.sendMessage(Ollivanders2.chatColor + " is a witch/wizard.");
-
-        // detect house and year
-        if (O2Houses.useHouses) {
-            StringBuilder message = new StringBuilder();
-            message.append(Ollivanders2.chatColor);
-
-            if (Ollivanders2API.getHouses().isSorted(target)) {
-                message.append(" is a ");
-
-                if (Ollivanders2.useYears)
-                    message.append(o2p.getYear().getDisplayText()).append(" year ");
-
-                O2HouseType house = Ollivanders2API.getHouses().getHouse(target);
-                if (house != null)
-                    message.append(house.getName()).append(".");
-                else
-                    common.printDebugMessage("Null house in LEGILIMENS.readMind()", null, null, false);
-            }
-            else
-                message.append(" has not started school yet.");
-
-            player.sendMessage(message.toString());
-        }
-
+        // this will dictate all the information the caster can detect
         int rand = (Math.abs(Ollivanders2Common.random.nextInt()) % 100);
 
-        // 50% chance detect destined wand
-        if (rand >= 50) {
-            if (o2p.foundWand())
-                player.sendMessage(Ollivanders2.chatColor + " uses a " + o2p.getDestinedWandWood() + " and " + o2p.getDestinedWandCore() + " wand.");
-            else
-                player.sendMessage(Ollivanders2.chatColor + " has not gotten a wand.");
+        // always succeed chance rolls in testmode with maxspelllevel on so we can reliably test all functionality
+        if (Ollivanders2.testMode && Ollivanders2.maxSpellLevel)
+            rand = 100;
+
+        //
+        // muggle
+        //
+        if (o2p.isMuggle())
+            player.sendMessage(Ollivanders2.chatColor + target.getName() + " is a muggle.");
+        //
+        // basic wizard information
+        //
+        else {
+            player.sendMessage(Ollivanders2.chatColor + target.getName() + " is a witch/wizard.");
+
+            // detect house and year
+            if (O2Houses.useHouses) {
+                StringBuilder message = new StringBuilder();
+                message.append(Ollivanders2.chatColor);
+
+                if (Ollivanders2API.getHouses().isSorted(target)) {
+                    message.append(" is a ");
+
+                    if (Ollivanders2.useYears)
+                        message.append(o2p.getYear().getDisplayText()).append(" year ");
+
+                    O2HouseType house = Ollivanders2API.getHouses().getHouse(target);
+                    if (house != null)
+                        message.append(house.getName()).append(".");
+                    else
+                        common.printDebugMessage("Null house in LEGILIMENS.readMind()", null, null, false);
+                }
+                else
+                    message.append(" has not started school yet.");
+
+                player.sendMessage(message.toString());
+            }
+
+            // 50% chance detect destined wand
+            if (rand >= 50) {
+                if (o2p.foundWand())
+                    player.sendMessage(Ollivanders2.chatColor + " uses a " + o2p.getDestinedWandWood() + " and " + o2p.getDestinedWandCore() + " wand.");
+                else
+                    player.sendMessage(Ollivanders2.chatColor + " has not gotten a wand.");
+            }
         }
 
         // information beyond this depends on legilimens level
-        if (usesModifier > 2) {
+        if (usesModifier > (int)(O2Spell.spellMasteryLevel/5) ) { // 20% mastery level
             // 50% chance detect recent spell cast
             if (rand >= 50) {
                 O2SpellType lastSpell = o2p.getLastSpell();
@@ -171,7 +238,7 @@ public final class LEGILIMENS extends O2Spell {
                     player.sendMessage(Ollivanders2.chatColor + " last cast " + lastSpell.getSpellName() + ".");
             }
 
-            if (usesModifier > 3) {
+            if (usesModifier > (int)(O2Spell.spellMasteryLevel/3)) { // 33% mastery level
                 // 33% chance detect mastered spell
                 if (rand >= 66) {
                     if (Ollivanders2.enableNonVerbalSpellCasting) {
@@ -181,15 +248,15 @@ public final class LEGILIMENS extends O2Spell {
                     }
                 }
 
-                if (usesModifier > 5) {
+                if (usesModifier > (int)(O2Spell.spellMasteryLevel/2)) { // 50% mastery level
                     // 40% chance detect effects
                     if (rand >= 40) {
-                        String legilText = Ollivanders2API.getPlayers().playerEffects.detectEffectWithLegilimens(o2p.getID());
-                        if (legilText != null)
-                            player.sendMessage(Ollivanders2.chatColor + " " + legilText + ".");
+                        String affectedBy = Ollivanders2API.getPlayers().playerEffects.detectEffectWithLegilimens(o2p.getID());
+                        if (affectedBy != null)
+                            player.sendMessage(Ollivanders2.chatColor + " " + affectedBy + ".");
                     }
 
-                    if (usesModifier >= 10) {
+                    if (usesModifier >= O2Spell.spellMasteryLevel) { // mastery level
                         // 10% chance detect is animagus
                         if (rand >= 90) {
                             if (o2p.isAnimagus()) {
@@ -204,5 +271,12 @@ public final class LEGILIMENS extends O2Spell {
                 }
             }
         }
+    }
+
+    /**
+     * Does nothing in this class because this spell is not a projectile so we override checkEffect itself
+     */
+    @Override
+    protected void doCheckEffect() {
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spell.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spell.java
@@ -70,6 +70,21 @@ public abstract class O2Spell {
     public static final int maxProjectileDistance = 50;
 
     /**
+     * A spell is considered mastered at level 100
+     */
+    public static final int spellMasteryLevel = 100;
+
+    /**
+     * The message for an isAllowed failure
+     */
+    public static final String isAllowedFailureMessage = "A powerful protective magic prevents you from casting this spell here.";
+
+    /**
+     * The message for cooldown spell failures
+     */
+    public static final String cooldownMessage = "You are too tired to cast this spell right now.";
+
+    /**
      * The currently traveled distance for the projectile
      */
     int projectileDistance = 0;
@@ -437,8 +452,10 @@ public abstract class O2Spell {
             isAllowed = false;
         }
 
-        if (!isAllowed)
-            p.spellFailedMessage(player);
+        if (!isAllowed) {
+            failureMessage = isAllowedFailureMessage;
+            sendFailureMessage();
+        }
 
         return isAllowed;
     }
@@ -633,6 +650,8 @@ public abstract class O2Spell {
                 // half skill when 1 level below
                 usesModifier *= 0.5;
         }
+
+        common.printDebugMessage("O2Spell.setUsesModifier: usesModifier = " + usesModifier, null, null, false);
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spells.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spells.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.Constructor;
 import java.util.HashMap;
 import java.util.ArrayList;
 import java.util.List;
@@ -450,5 +451,41 @@ public class O2Spells {
     @NotNull
     public List<O2Spell> getActiveSpells() {
         return new ArrayList<>(activeSpells);
+    }
+
+    /**
+     * This creates the spell projectile.
+     *
+     * @param player the player that cast the spell
+     * @param name   the name of the spell cast
+     * @param wandC  the wand check value for the held wand
+     */
+    @Nullable
+    public O2Spell createSpell(@NotNull Player player, @NotNull O2SpellType name, double wandC) {
+        common.printDebugMessage("OllivandersListener.createSpellProjectile: enter", null, null, false);
+
+        //spells go here, using any of the three types of magic
+        String spellClass = "net.pottercraft.ollivanders2.spell." + name;
+
+        Constructor<?> c;
+        try {
+            c = Class.forName(spellClass).getConstructor(Ollivanders2.class, Player.class, Double.class);
+        }
+        catch (Exception e) {
+            common.printDebugMessage("OllivandersListener.createSpellProjectile: exception creating spell constructor", e, null, true);
+            return null;
+        }
+
+        O2Spell spell;
+
+        try {
+            spell = (O2Spell) c.newInstance(p, player, wandC);
+        }
+        catch (Exception e) {
+            common.printDebugMessage("OllivandersListener.createSpellProjectile: exception creating spell", e, null, true);
+            return null;
+        }
+
+        return spell;
     }
 }

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/divination/O2ProphecyTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/divination/O2ProphecyTest.java
@@ -222,6 +222,7 @@ public class O2ProphecyTest {
 
         // test fulfill
         // a prophecy with max accuracy - so should succeed
+        Ollivanders2.maxSpellLevel = true;
         prophecy = new O2Prophecy(testPlugin, prophecyEffect, prophecyMessage, target.getUniqueId(), prophet.getUniqueId(), 10, effectDuration, 99);
         prophecy.fulfill();
         mockServer.getScheduler().performTicks(5);
@@ -251,6 +252,7 @@ public class O2ProphecyTest {
         assertFalse(Ollivanders2API.getPlayers().playerEffects.hasEffect(target.getUniqueId(), prophecyEffect), "Target still has the prophecy effect after expected duration");
 
         // low accuracy prophecy sends failure message to prophet and nothing to target, no effect added to target
+        Ollivanders2.maxSpellLevel = false;
         prophecyMessage = "low accuracy prophecy";
         prophecy = new O2Prophecy(testPlugin, prophecyEffect, prophecyMessage, target.getUniqueId(), prophet.getUniqueId(), 10, 10, 0);
         prophecy.fulfill();

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/HarmoniaNecterePassusTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/HarmoniaNecterePassusTest.java
@@ -1,29 +1,69 @@
 package net.pottercraft.ollivanders2.test.spell;
 
 import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.spell.HARMONIA_NECTERE_PASSUS;
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpell;
 import net.pottercraft.ollivanders2.stationaryspell.O2StationarySpellType;
-import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * Unit tests for HARMONIA_NECTERE_PASSUS spell functionality.
+ *
+ * <p>Tests the vanishing cabinet creation spell including:
+ * <ul>
+ * <li>Successful creation of paired vanishing cabinets</li>
+ * <li>Prevention of duplicate cabinets at the same location</li>
+ * <li>Validation that target block is a sign</li>
+ * <li>Validation that sign contains valid destination coordinates</li>
+ * <li>Prevention of cabinets that point to themselves</li>
+ * </ul>
+ *
+ * <p>Each test validates that the spell either succeeds in creating stationary spells
+ * or correctly fails when requirements are not met.</p>
+ *
+ * @author Azami7
+ */
 public class HarmoniaNecterePassusTest extends O2SpellTestSuper {
     /**
-     * Test spell-specific set up such as anything in doInitSpell, pass through blocks, move effect data,
-     * target material allow and block lists, world guard flags, projectile radius, and any spell-specific settings
+     * Test spell-specific configuration and initialization.
+     *
+     * <p>Verifies spell-specific settings such as pass-through blocks, move effects,
+     * target material restrictions, and world guard flags. This spell sets WorldGuard
+     * BUILD flag but cannot be tested without a WorldGuard mock.</p>
      */
-    @Override @Test
+    @Override
+    @Test
     void spellConstructionTest() {
         // harmonia only sets world guard flags, which we do not have tests for because we do not have a WorldGuard mock
     }
 
     /**
-     * Test the specific spell functionality
+     * Test vanishing cabinet creation and failure conditions.
+     *
+     * <p>Verifies that:
+     * <ul>
+     * <li>Spell successfully creates paired vanishing cabinets when signs are properly configured</li>
+     * <li>Spell fails (no stationary spell created) when:
+     *   <ul>
+     *   <li>A vanishing cabinet already exists at the location</li>
+     *   <li>Target block is not a sign</li>
+     *   <li>Sign lacks valid destination coordinates</li>
+     *   <li>Sign points to the same location (from and to are identical)</li>
+     *   </ul>
+     * </li>
+     * </ul>
      */
-    @Override @Test
+    @Override
+    @Test
     void doCheckEffectTest() {
         World testWorld = mockServer.addSimpleWorld("world1");
         Location location1 = new Location(testWorld, 200, 40, 100);
@@ -33,17 +73,49 @@ public class HarmoniaNecterePassusTest extends O2SpellTestSuper {
         net.pottercraft.ollivanders2.test.stationaryspell.HarmoniaNecterePassusTest.createCabinet(location1, location2);
         net.pottercraft.ollivanders2.test.stationaryspell.HarmoniaNecterePassusTest.createCabinet(location2, location1);
 
+        // cast the spell
         Location castLocation = new Location(testWorld, 200, 39, 102);
+        caster.setLocation(castLocation);
 
-        // we need to set the player facing the cabinet
-        caster.setLocation(TestCommon.faceTarget(castLocation, location1));
-
-        // if the cabinets are constructed correctly, we can create the stationary spell
-        net.pottercraft.ollivanders2.spell.HARMONIA_NECTERE_PASSUS harmoniaSpell = new net.pottercraft.ollivanders2.spell.HARMONIA_NECTERE_PASSUS(testPlugin, caster, 1.0);
-        Ollivanders2API.getSpells().addSpell(caster, harmoniaSpell);
+        HARMONIA_NECTERE_PASSUS harmonia = (HARMONIA_NECTERE_PASSUS) castSpell(caster, location1, O2SpellType.HARMONIA_NECTERE_PASSUS);
         mockServer.getScheduler().performTicks(20);
+        assertTrue(harmonia.hasHitTarget(), "harmonia did not hit target");
 
+        // verify the stationary spells were successfully cast
         assertTrue(Ollivanders2API.getStationarySpells().checkLocationForStationarySpell(location1, O2StationarySpellType.HARMONIA_NECTERE_PASSUS), "harmonia spell killed");
         assertTrue(Ollivanders2API.getStationarySpells().checkLocationForStationarySpell(location2, O2StationarySpellType.HARMONIA_NECTERE_PASSUS), "twin spell killed");
+
+        // spell fails if there is already a harmonia stationary spell
+        harmonia = (HARMONIA_NECTERE_PASSUS) castSpell(caster, location1, O2SpellType.HARMONIA_NECTERE_PASSUS);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(harmonia.hasHitTarget());
+        assertEquals(1, Ollivanders2API.getStationarySpells().getStationarySpellsAtLocation(location1).size(), "harmonia created a stationary spell when there was already a spell present");
+
+        // clean spells for next tests
+        for (O2StationarySpell stationary : Ollivanders2API.getStationarySpells().getActiveStationarySpells()) {
+            stationary.kill();
+        }
+        mockServer.getScheduler().performTicks(5);
+
+        // spell fails if there is not a sign in the location
+        location1.getBlock().setType(Material.DANDELION);
+        harmonia = (HARMONIA_NECTERE_PASSUS) castSpell(caster, location1, O2SpellType.HARMONIA_NECTERE_PASSUS);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(harmonia.hasHitTarget());
+        assertFalse(Ollivanders2API.getStationarySpells().checkLocationForStationarySpell(location1, O2StationarySpellType.HARMONIA_NECTERE_PASSUS), "harmonia stationary spell was created when there was no sign");
+
+        // spell fails if there is a sign, but it does not have the to location
+        location1.getBlock().setType(Material.ACACIA_SIGN);
+        harmonia = (HARMONIA_NECTERE_PASSUS) castSpell(caster, location1, O2SpellType.HARMONIA_NECTERE_PASSUS);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(harmonia.hasHitTarget());
+        assertFalse(Ollivanders2API.getStationarySpells().checkLocationForStationarySpell(location1, O2StationarySpellType.HARMONIA_NECTERE_PASSUS), "harmonia stationary spell was created when the sign had no text");
+
+        // spell fails in the to and from location are the same
+        net.pottercraft.ollivanders2.test.stationaryspell.HarmoniaNecterePassusTest.createCabinet(location1, location1);
+        harmonia = (HARMONIA_NECTERE_PASSUS) castSpell(caster, location1, O2SpellType.HARMONIA_NECTERE_PASSUS);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(harmonia.hasHitTarget());
+        assertFalse(Ollivanders2API.getStationarySpells().checkLocationForStationarySpell(location1, O2StationarySpellType.HARMONIA_NECTERE_PASSUS), "harmonia stationary spell was created when to and from locations were the same");
     }
 }

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/LegilimensTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/LegilimensTest.java
@@ -1,0 +1,235 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.effect.ANIMAGUS_EFFECT;
+import net.pottercraft.ollivanders2.effect.AWAKE;
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.house.O2HouseType;
+import net.pottercraft.ollivanders2.house.O2Houses;
+import net.pottercraft.ollivanders2.player.O2Player;
+import net.pottercraft.ollivanders2.spell.LEGILIMENS;
+import net.pottercraft.ollivanders2.spell.O2Spell;
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.EntityType;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for LEGILIMENS spell functionality.
+ *
+ * <p>Tests the mind-reading spell including:</p>
+ * <ul>
+ * <li>Failure when caster has insufficient skill to detect targets</li>
+ * <li>Information revealed progressively by caster's Legilimens level (muggle status, wand, spells, effects, animagus form)</li>
+ * <li>Detection of animagus forms by level 10+ casters only</li>
+ * <li>Spell failure when target is in animagus form and caster skill is below mastery</li>
+ * <li>Spell failure when no targets are in range</li>
+ * <li>Zone-based spell blocking via isAllowed check</li>
+ * </ul>
+ *
+ * <p>All tests are combined into a single method because global state like maxSpellLevel and blocked spell
+ * zones interfere when tests run in parallel. The @Isolated annotation should be used to prevent parallel
+ * execution of this test class.</p>
+ *
+ * @author Azami7
+ */
+public class LegilimensTest extends O2SpellTestSuper {
+    @Override @Test
+    void spellConstructionTest() {
+        // legilimens has no spell-specific settings
+    }
+
+    /**
+     * Test LEGILIMENS spell behavior across all scenarios.
+     *
+     * <p>Validates spell functionality including failure detection, progressive information revelation,
+     * animagus detection, and spell blocking. Tests are ordered to progressively enable features and
+     * modify player state (house sorting, wand acquisition, effects, animagus transformation, skill level changes)
+     * to verify spell behavior at each stage. Tests confirm that readMind() revealscorrect information and that
+     * checkEffect() properly handles animagus forms and skill thresholds.</p>
+     */
+    @Override @Test
+    void doCheckEffectTest() {
+        World testWorld = mockServer.addSimpleWorld("world");
+        Location location = new Location(testWorld, 100, 40, 100);
+        PlayerMock caster = mockServer.addPlayer("Caster");
+        PlayerMock player = mockServer.addPlayer("Player1");
+
+        caster.setLocation(location);
+        player.setLocation(TestCommon.getRelativeLocation(caster.getLocation(), BlockFace.EAST));
+
+        O2Player casterO2P = Ollivanders2API.getPlayers().getPlayer(caster.getUniqueId());
+        assertNotNull(casterO2P);
+        O2Player playerO2P = Ollivanders2API.getPlayers().getPlayer(player.getUniqueId());
+        assertNotNull(playerO2P);
+
+        // when spell fail to read the player's mind, a failure message is sent
+        LEGILIMENS legilimens = (LEGILIMENS) castSpell(caster, location, O2SpellType.LEGILIMENS);
+        mockServer.getScheduler().performTicks(5);
+        assertTrue(legilimens.isKilled(), "Legilimens not immediately killed");
+        String message = getWholeMessage(caster);
+        assertNotNull(message, "caster did not receive a failure message when mind read failed on target");
+        assertTrue(message.contains(LEGILIMENS.mindReadFailureMessage), "caster did not receive expected failure message when mind read failed on target");
+
+        // when the player is a muggle, we should get the muggle message
+        Ollivanders2.maxSpellLevel = true;
+        caster.setLocation(location); // handle caster drift
+        castSpell(caster, location, O2SpellType.LEGILIMENS);
+        mockServer.getScheduler().performTicks(5);
+        message = getWholeMessage(caster);
+        assertNotNull(message);
+        assertTrue(message.contains(" is a muggle."), "not expected message when target is a muggle");
+
+        // when the player is not a muggle, we should get a wizard message
+        playerO2P.setMuggle(false);
+        O2Houses.useHouses = true;
+        caster.setLocation(location); // handle caster drift
+        castSpell(caster, location, O2SpellType.LEGILIMENS);
+        mockServer.getScheduler().performTicks(5);
+        message = getWholeMessage(caster);
+        assertNotNull(message);
+        assertTrue(message.contains(" is a witch/wizard."), "not expected message when target is a wizard");
+
+        // when the player has not been sorted yet
+        assertTrue(message.contains(" has not started school yet."), "not expected message when target has not been sorted");
+
+        // when the player has not found their destined wand
+        assertTrue(message.contains(" has not gotten a wand."), "not expected message when target has not found wand yet");
+
+        // when player has been sorted
+        Ollivanders2API.getHouses().sort(player, O2HouseType.HUFFLEPUFF);
+        playerO2P.setFoundWand(true);
+        Ollivanders2.useYears = true;
+        caster.setLocation(location); // handle caster drift
+        castSpell(caster, location, O2SpellType.LEGILIMENS);
+        mockServer.getScheduler().performTicks(5);
+        message = getWholeMessage(caster);
+        assertNotNull(message);
+
+        assertTrue(message.contains(O2HouseType.HUFFLEPUFF.getName()), "not expected message when target has been sorted");
+
+        // when years enabled and player has been sorted
+        assertTrue(message.contains(playerO2P.getYear().getDisplayText() + " year"), "not expected message when years enabled");
+
+        // when player has found destined wand
+        assertTrue(message.contains(" uses a " + playerO2P.getDestinedWandWood() + " and " + playerO2P.getDestinedWandCore() + " wand."));
+
+        Ollivanders2.useYears = false;
+        playerO2P.setSpellRecentCastTime(O2SpellType.ACCIO);
+        playerO2P.setMasterSpell(O2SpellType.LUMOS);
+        Ollivanders2.enableNonVerbalSpellCasting = true;
+        caster.setLocation(location); // handle caster drift
+        castSpell(caster, location, O2SpellType.LEGILIMENS);
+        mockServer.getScheduler().performTicks(5);
+        message = getWholeMessage(caster);
+        assertNotNull(message);
+
+        // the last spell a player cast
+        assertTrue(message.contains(" last cast "), "not expected message when player has cast a spell");
+
+        // when target has a mastered spell
+        assertTrue(message.contains(" can non-verbally cast the spell "), "not expected message when player has mastered spell");
+
+        // when the player has an effect
+        AWAKE awake = new AWAKE(testPlugin, 200, false, player.getUniqueId());
+        Ollivanders2API.getPlayers().playerEffects.addEffect(awake);
+        mockServer.getScheduler().performTicks(20);
+        caster.setLocation(location); // handle caster drift
+        castSpell(caster, location, O2SpellType.LEGILIMENS);
+        mockServer.getScheduler().performTicks(5);
+        message = getWholeMessage(caster);
+        assertNotNull(message);
+
+        assertNotNull(awake.getLegilimensText());
+        assertTrue(message.contains(awake.getLegilimensText()), "not expected message when target has an effect");
+        awake.kill();
+        mockServer.getScheduler().performTicks(5);
+
+        // when player is an animagus
+        playerO2P.setIsAnimagus();
+        playerO2P.setAnimagusForm(EntityType.RABBIT);
+        caster.setLocation(location); // handle caster drift
+        castSpell(caster, location, O2SpellType.LEGILIMENS);
+        mockServer.getScheduler().performTicks(5);
+        message = getWholeMessage(caster);
+        assertNotNull(message);
+        assertTrue(message.contains(" has the animagus form of a "), "not expected message when target is an animagus");
+
+        // when player is in animagus form and spell level not expert
+        Ollivanders2API.getPlayers().playerEffects.addEffect(new ANIMAGUS_EFFECT(testPlugin, 100, true, player.getUniqueId()));
+        mockServer.getScheduler().performTicks(5);
+        Ollivanders2.maxSpellLevel = false;
+        casterO2P.setSpellCount(O2SpellType.LEGILIMENS, O2Spell.spellMasteryLevel - 10);
+        caster.setLocation(location); // handle caster drift
+        castSpell(caster, location, O2SpellType.LEGILIMENS);
+        mockServer.getScheduler().performTicks(5);
+        assertNull(caster.nextMessage(), "caster unexpectedly got a failure message when target in animagus form and skill level below mastery");
+
+        // when player is in animagus form when spell level is expert
+        Ollivanders2.maxSpellLevel = true;
+
+        caster.setLocation(location); // handle caster drift
+        castSpell(caster, location, O2SpellType.LEGILIMENS);
+        mockServer.getScheduler().performTicks(5);
+        message = getWholeMessage(caster);
+        assertNotNull(message, "caster did not get a result message when target in animagus form and skill level above mastery"); // they'll either get a failure message or the legilmens data
+        Ollivanders2API.getPlayers().playerEffects.removeEffect(player.getUniqueId(), O2EffectType.ANIMAGUS_EFFECT);
+
+        // spell cannot target a player if none are in range
+        player.setLocation(new Location(location.getWorld(), location.getX() + LEGILIMENS.radius + 100, location.getY(), location.getZ()));
+        caster.setLocation(location); // handle caster drift
+        castSpell(caster, location, O2SpellType.LEGILIMENS);
+        mockServer.getScheduler().performTicks(5);
+        assertNull(caster.nextMessage(), "caster unexpectedly got a failure message when no players in range");
+
+        // make sure the overridden checkEffect is isAllowed check is working
+        testPlugin.getConfig().set("zones.test-world.type", "World");
+        testPlugin.getConfig().set("zones.test-world.world", testWorld.getName());
+        testPlugin.getConfig().set("zones.test-world.disallowed-spells", List.of("LEGILIMENS"));
+        Ollivanders2API.getSpells().loadZoneConfig();
+
+        caster.setLocation(location); // handle caster drift
+        castSpell(caster, location, O2SpellType.LEGILIMENS);
+        mockServer.getScheduler().performTicks(5);
+        message = caster.nextMessage();
+        assertNotNull(message, "caster did not get isAllowed failure message");
+        assertEquals(O2Spell.isAllowedFailureMessage, TestCommon.cleanChatMessage(message), "Player did not get expected failure message");
+    }
+
+    /**
+     * Collects all pending messages from a player's message queue into a single string.
+     *
+     * <p>Repeatedly calls nextMessage() to drain the queue, concatenating all messages with space
+     * separators. Used to gather multi-line readMind() output into a single string for assertion checking.</p>
+     *
+     * @param player the player to collect messages from
+     * @return concatenated message string with spaces between lines, or null if no messages are pending
+     */
+    @Nullable
+    String getWholeMessage(PlayerMock player) {
+        String message = player.nextMessage();
+        if (message == null)
+            return null;
+
+        StringBuilder wholeMessage = new StringBuilder();
+        while (message != null) {
+            wholeMessage.append(message).append(" ");
+            message = player.nextMessage();
+        }
+
+        return wholeMessage.toString();
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/testcommon/TestCommon.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/testcommon/TestCommon.java
@@ -7,6 +7,8 @@ import net.pottercraft.ollivanders2.spell.O2SpellType;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
@@ -333,5 +335,18 @@ public class TestCommon {
         }
 
         return items;
+    }
+
+    /**
+     * Get the location relative to a location.
+     *
+     * @param location the starting location
+     * @param relativeTo the relative position to get a location for
+     * @return the relative location
+     */
+    public static Location getRelativeLocation(Location location, BlockFace relativeTo) {
+        Block blockAt = location.getBlock();
+
+        return blockAt.getRelative(relativeTo).getLocation();
     }
 }


### PR DESCRIPTION
* added tests for Legilimens
* added tests for Harmonia Nectere Passus
* updated some spells to use sendFailureMessage instead of messaging directly
* refactored how legilimens success chance works
* fixed intermittent failures in O2Prophecy tests by removing failure chance in testmode
* moved createSpellProjectile to O2Spells