### PR TITLE
Ebublio and Anapneo

### DIFF
--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/CHADWICKS_CHARMS_VOLUME_1.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/CHADWICKS_CHARMS_VOLUME_1.java
@@ -8,7 +8,6 @@ import org.jetbrains.annotations.NotNull;
  * Chadwick's Charms - O.W.L level charms book
  * <p>
  * Contents:<br>
- * {@link net.pottercraft.ollivanders2.spell.ASCENDIO}<br>
  * {@link net.pottercraft.ollivanders2.spell.CRESCERE_PROTEGAT}<br>
  * {@link net.pottercraft.ollivanders2.spell.HORREAT_PROTEGAT}<br>
  * {@link net.pottercraft.ollivanders2.spell.MOV_FOTIA}<br>

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/CURSES_AND_COUNTERCURSES.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/CURSES_AND_COUNTERCURSES.java
@@ -1,6 +1,5 @@
 package net.pottercraft.ollivanders2.book;
 
-import net.pottercraft.ollivanders2.spell.GEMINO;
 import net.pottercraft.ollivanders2.spell.O2SpellType;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import org.jetbrains.annotations.NotNull;
@@ -10,8 +9,8 @@ import org.jetbrains.annotations.NotNull;
  * <p>
  * Contents:<br>
  * {@link net.pottercraft.ollivanders2.spell.PETRIFICUS_TOTALUS}<br>
- * {@link GEMINO}<br>
- * {@link net.pottercraft.ollivanders2.spell.LOQUELA_INEPTIAS}
+ * {@link net.pottercraft.ollivanders2.spell.GEMINO}<br>
+ * {@link net.pottercraft.ollivanders2.spell.LOQUELA_INEPTIAS}<br>
  * </p>
  *
  * @author Azami7
@@ -40,6 +39,6 @@ public class CURSES_AND_COUNTERCURSES extends O2Book {
         // todo confringo - https://harrypotter.fandom.com/wiki/Blasting_Curse
         // todo conjuntivitis curse - https://harrypotter.fandom.com/wiki/Conjunctivitis_Curse
         // todo expluso - https://harrypotter.fandom.com/wiki/Expulso_Curse
-        // slugus eructo - https://harrypotter.fandom.com/wiki/Slug-Vomiting_Charm
+        // todo slugus eructo - https://harrypotter.fandom.com/wiki/Slug-Vomiting_Charm
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/DEFENSE_AGAINST_THE_DARK_ARTS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/DEFENSE_AGAINST_THE_DARK_ARTS.java
@@ -8,7 +8,6 @@ import org.jetbrains.annotations.NotNull;
  * Defence Against the Dark Arts by Galatea Merrythought - 7th year Defense against the dark arts book
  * <p>
  * Contents:<br>
- * {@link net.pottercraft.ollivanders2.spell.ASCENDIO}<br>
  * {@link net.pottercraft.ollivanders2.spell.MORTUOS_SUSCITATE}<br>
  * {@link net.pottercraft.ollivanders2.spell.INCENDIO_TRIA}<br>
  * {@link net.pottercraft.ollivanders2.spell.NULLUM_APPAREBIT}<br>

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/ESSENTIAL_DARK_ARTS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/ESSENTIAL_DARK_ARTS.java
@@ -13,7 +13,6 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.IMMOBULUS}<br>
  * {@link net.pottercraft.ollivanders2.spell.ARANIA_EXUMAI}<br>
  * {@link net.pottercraft.ollivanders2.spell.ALARTE_ASCENDARE}<br>
- * {@link net.pottercraft.ollivanders2.spell.AQUA_ERUCTO}<br>
  * {@link net.pottercraft.ollivanders2.spell.FUMOS_DUO}
  * </p>
  *

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/EXTREME_INCANTATIONS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/EXTREME_INCANTATIONS.java
@@ -32,6 +32,6 @@ public class EXTREME_INCANTATIONS extends O2Book {
         spells.add(O2SpellType.BOMBARDA);
         spells.add(O2SpellType.BOMBARDA_MAXIMA);
         spells.add(O2SpellType.COLOVARIA);
-        //spells.add(O2SpellType.LUMOS_MAXIMA);
+        spells.add(O2SpellType.LUMOS_MAXIMA);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/MAGICAL_DRAFTS_AND_POTIONS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/MAGICAL_DRAFTS_AND_POTIONS.java
@@ -1,7 +1,6 @@
 package net.pottercraft.ollivanders2.book;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.potion.FORGETFULNESS_POTION;
 import net.pottercraft.ollivanders2.potion.O2PotionType;
 import org.jetbrains.annotations.NotNull;
 
@@ -9,15 +8,18 @@ import org.jetbrains.annotations.NotNull;
  * Magical Drafts and Potions - OWL potions book
  * <p>
  * {@link net.pottercraft.ollivanders2.potion.COMMON_ANTIDOTE_POTION}<br>
- * {@link FORGETFULNESS_POTION}<br>
+ * {@link net.pottercraft.ollivanders2.potion.FORGETFULNESS_POTION}<br>
  * {@link net.pottercraft.ollivanders2.potion.HERBICIDE_POTION}<br>
  * {@link net.pottercraft.ollivanders2.potion.CURE_FOR_BOILS}<br>
  * {@link net.pottercraft.ollivanders2.potion.OCULUS_FELIS}<br>
  * {@link net.pottercraft.ollivanders2.potion.WIGGENWELD_POTION}<br>
  * {@link net.pottercraft.ollivanders2.potion.ICE_POTION}<br>
  * {@link net.pottercraft.ollivanders2.potion.STRENGTHENING_SOLUTION}<br>
+ * {@link net.pottercraft.ollivanders2.potion.WEAKNESS_POTION}<br>
  * {@link net.pottercraft.ollivanders2.potion.HUNGER_POTION}<br>
  * {@link net.pottercraft.ollivanders2.potion.SATIATION_POTION}<br>
+ * {@link net.pottercraft.ollivanders2.potion.SWELLING_SOLUTION}<br>
+ * {@link net.pottercraft.ollivanders2.potion.SHRINKING_SOLUTION}<br>
  * {@link net.pottercraft.ollivanders2.potion.WIDEYE_POTION}<br>
  * {@link net.pottercraft.ollivanders2.potion.SLEEPING_DRAUGHT}<br>
  * {@link net.pottercraft.ollivanders2.potion.WIT_SHARPENING_POTION}

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/POTION_OPUSCULE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/POTION_OPUSCULE.java
@@ -1,7 +1,6 @@
 package net.pottercraft.ollivanders2.book;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
-import net.pottercraft.ollivanders2.potion.FORGETFULNESS_POTION;
 import net.pottercraft.ollivanders2.potion.O2PotionType;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
  * <p>
  * Contents:<br>
  * {@link net.pottercraft.ollivanders2.potion.BABBLING_BEVERAGE}<br>
- * {@link FORGETFULNESS_POTION}
+ * {@link net.pottercraft.ollivanders2.potion.FORGETFULNESS_POTION}
  * </p>
  *
  * @author Azami7

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/PRACTICAL_DEFENSIVE_MAGIC.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/PRACTICAL_DEFENSIVE_MAGIC.java
@@ -16,6 +16,7 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.REDUCTO}<br>
  * {@link net.pottercraft.ollivanders2.spell.IMPEDIMENTA}<br>
  * {@link net.pottercraft.ollivanders2.spell.LACARNUM_INFLAMARI}<br>
+ * {@link net.pottercraft.ollivanders2.spell.AQUA_ERUCTO_DUO}<br>
  * {@link net.pottercraft.ollivanders2.spell.MUFFLIATO}<br>
  * {@link net.pottercraft.ollivanders2.spell.VERMILLIOUS_TRIA}
  * </p>

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/QUINTESSENCE_A_QUEST.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/QUINTESSENCE_A_QUEST.java
@@ -10,8 +10,11 @@ import org.jetbrains.annotations.NotNull;
  * Contents:<br>
  * {@link net.pottercraft.ollivanders2.spell.CONFUNDUS_DUO}<br>
  * {@link net.pottercraft.ollivanders2.spell.APARECIUM}<br>
+ * {@link net.pottercraft.ollivanders2.spell.CELATUM}<br>
  * {@link net.pottercraft.ollivanders2.spell.GLACIUS_TRIA}<br>
  * {@link net.pottercraft.ollivanders2.spell.MOLLIARE}
+ * {@link net.pottercraft.ollivanders2.spell.AZURILLIOUS}<br>
+ * {@link net.pottercraft.ollivanders2.spell.ANAPNEO}<br>
  * </p>
  *
  * @author Azami7
@@ -34,5 +37,6 @@ public class QUINTESSENCE_A_QUEST extends O2Book {
         spells.add(O2SpellType.GLACIUS_TRIA);
         spells.add(O2SpellType.MOLLIARE);
         spells.add(O2SpellType.AZURILLIOUS);
+        spells.add(O2SpellType.ANAPNEO);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/STANDARD_BOOK_OF_SPELLS_GRADE_4.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/STANDARD_BOOK_OF_SPELLS_GRADE_4.java
@@ -38,7 +38,7 @@ public class STANDARD_BOOK_OF_SPELLS_GRADE_4 extends O2Book {
         spells.add(O2SpellType.MELOFORS);
         spells.add(O2SpellType.DIAMAS_REPARO);
         spells.add(O2SpellType.DIFFINDO);
-        // todo Lumos Maxima - https://github.com/Azami7/Ollivanders2/issues/503
+        spells.add(O2SpellType.LUMOS_MAXIMA);
         spells.add(O2SpellType.TERGEO);
         spells.add(O2SpellType.COLOVARIA);
         // todo Orchideous - https://github.com/Azami7/Ollivanders2/issues/56

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/STANDARD_BOOK_OF_SPELLS_GRADE_7.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/STANDARD_BOOK_OF_SPELLS_GRADE_7.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.LUMOS_SOLEM}<br>
  * {@link net.pottercraft.ollivanders2.spell.OBLIVIATE}<br>
  * {@link net.pottercraft.ollivanders2.spell.REPELLO_MUGGLETON}<br>
+ * {@link net.pottercraft.ollivanders2.spell.ASCENDIO}<br>
  * </p>
  *
  * @author Azami7

--- a/Ollivanders/src/net/pottercraft/ollivanders2/book/THE_HEALERS_HELPMATE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/book/THE_HEALERS_HELPMATE.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.NotNull;
  * {@link net.pottercraft.ollivanders2.spell.AGUAMENTI}<br>
  * {@link net.pottercraft.ollivanders2.spell.BRACKIUM_EMENDO}<br>
  * {@link net.pottercraft.ollivanders2.spell.EPISKEY}<br>
+ * {@link net.pottercraft.ollivanders2.spell.AQUA_ERUCTO}<br>
  * {@link net.pottercraft.ollivanders2.potion.COMMON_ANTIDOTE_POTION}<br>
  * {@link net.pottercraft.ollivanders2.potion.WIDEYE_POTION}<br>
  * </p>
@@ -33,8 +34,8 @@ public class THE_HEALERS_HELPMATE extends O2Book {
         spells.add(O2SpellType.AGUAMENTI);
         spells.add(O2SpellType.BRACKIUM_EMENDO);
         spells.add(O2SpellType.EPISKEY);
-        potions.add(O2PotionType.COMMON_ANTIDOTE_POTION);
         spells.add(O2SpellType.AQUA_ERUCTO);
+        potions.add(O2PotionType.COMMON_ANTIDOTE_POTION);
         // todo wound cleaning potion
         // todo pepperup potion
         potions.add(O2PotionType.WIDEYE_POTION);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2EffectType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/effect/O2EffectType.java
@@ -100,7 +100,7 @@ public enum O2EffectType {
     /**
      * {@link FUMOS_DUO}
      */
-    FUMOS_DUO(FUMOS.class, MagicLevel.OWL, 30 * Ollivanders2Common.ticksPerSecond, 10 * Ollivanders2Common.ticksPerMinute),
+    FUMOS_DUO(FUMOS_DUO.class, MagicLevel.OWL, 30 * Ollivanders2Common.ticksPerSecond, 10 * Ollivanders2Common.ticksPerMinute),
     /**
      * {@link HARM}
      */

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/ANAPNEO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/ANAPNEO.java
@@ -1,0 +1,59 @@
+package net.pottercraft.ollivanders2.spell;
+
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.O2MagicBranch;
+import net.pottercraft.ollivanders2.Ollivanders2;
+
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+
+/**
+ * Bubble head charm gives the player water breathing for a length of time depending on the player's spell level.
+ *
+ * @author Azami7
+ * @see <a href="https://harrypotter.fandom.com/wiki/Bubble-Head_Charm">Bubble-Head Charm</a>
+ */
+public final class ANAPNEO extends AddO2Effect {
+    /**
+     * Default constructor for use in generating spell text.  Do not use to cast the spell.
+     *
+     * @param plugin the Ollivanders2 plugin
+     */
+    public ANAPNEO(Ollivanders2 plugin) {
+        super(plugin);
+
+        spellType = O2SpellType.ANAPNEO;
+        branch = O2MagicBranch.CHARMS;
+
+        flavorText = new ArrayList<>() {{
+            add("The Bubble-Head Charm");
+            add("Fleur Delacour, though she demonstrated excellent use of the Bubble-Head Charm, was attacked by grindylows as she approached her goal, and failed to retrieve her hostage.");
+            add("Cedric Diggory, who also used the Bubble-Head Charm, was first to return with his hostage, though he returned one minute outside the time limit of an hour.");
+        }};
+
+        text = "Gives target player the ability to breathe underwater.";
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param plugin    a callback to the MC plugin
+     * @param player    the player who cast this spell
+     * @param rightWand which wand the player was using
+     */
+    public ANAPNEO(@NotNull Ollivanders2 plugin, @NotNull Player player, @NotNull Double rightWand) {
+        super(plugin, player, rightWand);
+        spellType = O2SpellType.ANAPNEO;
+        branch = O2MagicBranch.CHARMS;
+
+        effectsToAdd.add(O2EffectType.WATER_BREATHING);
+        strengthModifier = 1;
+        minDurationInSeconds = 30;
+        durationModifier = 0;
+        targetSelf = true;
+
+        initSpell();
+    }
+}

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/AddO2Effect.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/AddO2Effect.java
@@ -1,11 +1,11 @@
 package net.pottercraft.ollivanders2.spell;
 
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.effect.O2Effect;
 import net.pottercraft.ollivanders2.effect.O2EffectType;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
@@ -14,7 +14,24 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * Spell type that adds an O2Effect to a target.
+ * Abstract base class for spells that apply one or more {@link net.pottercraft.ollivanders2.effect.O2Effect}
+ * instances to a target player.
+ *
+ * <p>Spells extending this class fire a projectile toward a target and apply their configured effects
+ * when the projectile reaches a player. Self-targeting spells ({@link #targetSelf} = true) apply
+ * effects to the caster immediately; non-self-targeting spells apply effects to the first nearby
+ * player found within {@link #defaultRadius} of the projectile.</p>
+ *
+ * <p>Effect duration is calculated from the caster's experience level via
+ * {@link #calculateEffectDurationInSeconds()}, clamped to [{@link #minDurationInSeconds},
+ * {@link #maxDurationInSeconds}]. Subclasses configure behavior by setting fields in their
+ * constructors before calling {@link #initSpell()}.</p>
+ *
+ * <p><strong>Effect class contract:</strong> All {@link net.pottercraft.ollivanders2.effect.O2EffectType}
+ * entries in {@link #effectsToAdd} must have an associated class with a constructor of the form
+ * {@code (Ollivanders2, int, boolean, UUID)}.</p>
+ *
+ * @author Azami7
  */
 public abstract class AddO2Effect extends O2Spell {
     /**
@@ -70,7 +87,7 @@ public abstract class AddO2Effect extends O2Spell {
     /**
      * Blacklist of effects that cannot be added by a spell.
      */
-    List<O2EffectType> effectBlacklist = new ArrayList<>() {{
+    private static final List<O2EffectType> effectBlacklist = new ArrayList<>() {{
         add(O2EffectType.ANIMAGUS_EFFECT);
         add(O2EffectType.ANIMAGUS_INCANTATION);
         add(O2EffectType.LYCANTHROPY);
@@ -104,47 +121,55 @@ public abstract class AddO2Effect extends O2Spell {
     }
 
     /**
-     * If a target player is within the radius of the projectile, add the effect to the player.
+     * Checks for nearby targets and applies this spell's effects.
+     *
+     * <p>If the projectile has already hit a target (set by {@link #move()} hitting a solid block),
+     * {@link #kill()} is called to complete cleanup and the current location is still checked for
+     * nearby players. For self-targeting spells, effects are applied to the caster directly. For
+     * non-self-targeting spells, effects are applied to up to {@link #numberOfTargets} nearby players
+     * within {@link #defaultRadius}. The spell kills itself after successfully applying effects.</p>
      */
     @Override
     protected void doCheckEffect() {
-        if (targetSelf) {
-            addEffectsToTarget(caster);
+        if (hasHitTarget())
             kill();
-            return;
+
+        int targets = 0;
+
+        if (targetSelf) {
+            common.printDebugMessage("AddO2Effect.doCheckEffect: adding effect to caster", null, null, false);
+            addEffectsToTarget(caster);
+            targets = targets + 1;
         }
 
         for (Player target : getNearbyPlayers(defaultRadius)) {
             if ((target.getUniqueId().equals(caster.getUniqueId())))
                 continue;
 
-            addEffectsToTarget(target);
+            if (targets >= numberOfTargets)
+                break;
 
-            // if the spell can only target a limited number, stop when the limit is reached
-            if (numberOfTargets <= 0) {
-                kill();
-                return;
-            }
+            common.printDebugMessage("AddO2Effect.doCheckEffect: adding effect to " + target.getName(), null, null, false);
+            addEffectsToTarget(target);
+            targets = targets + 1;
         }
 
-        if (hasHitTarget())
+        if (targets > 0)
             kill();
     }
 
     /**
-     * Add the effects for this spell to a target player.
+     * Applies this spell's effects to a target player.
      *
-     * @param target the player to add spells to
+     * <p>Calculates the effect duration from the caster's experience level, then instantiates and
+     * registers each effect in {@link #effectsToAdd} via reflection. Effects on the
+     * {@link #effectBlacklist} are skipped. Each effect class must provide a constructor of the
+     * form {@code (Ollivanders2, int, boolean, UUID)}.</p>
+     *
+     * @param target the player to apply effects to
      */
     private void addEffectsToTarget(@NotNull Player target) {
-        // calculate the duration based on the experience with this spell
-        durationInSeconds = ((int)(usesModifier * durationMultiplier) + durationModifier);
-
-        if (durationInSeconds > maxDurationInSeconds)
-            durationInSeconds = maxDurationInSeconds;
-        else if (durationInSeconds < minDurationInSeconds)
-            durationInSeconds = minDurationInSeconds;
-
+        calculateEffectDurationInSeconds();
         int duration = durationInSeconds * Ollivanders2Common.ticksPerSecond;
 
         // add the effect
@@ -163,10 +188,82 @@ public abstract class AddO2Effect extends O2Spell {
                 continue;
             }
 
-            if (permanent)
-                effect.setPermanent(true);
-
             Ollivanders2API.getPlayers().playerEffects.addEffect(effect);
         }
+    }
+
+    /**
+     * Calculates and stores the effect duration in seconds based on the caster's experience level.
+     *
+     * <p>Duration is computed as {@code (int)(usesModifier * durationMultiplier) + durationModifier},
+     * then clamped to [{@link #minDurationInSeconds}, {@link #maxDurationInSeconds}]. The result is
+     * stored in {@link #durationInSeconds} and can be retrieved via {@link #getDurationInSeconds()}.</p>
+     */
+    public void calculateEffectDurationInSeconds() {
+        durationInSeconds = ((int) (usesModifier * durationMultiplier) + durationModifier);
+
+        if (durationInSeconds > maxDurationInSeconds)
+            durationInSeconds = maxDurationInSeconds;
+        else if (durationInSeconds < minDurationInSeconds)
+            durationInSeconds = minDurationInSeconds;
+    }
+
+    /**
+     * Returns a copy of the list of effect types this spell will apply to its target.
+     *
+     * @return a new list containing the effect types configured for this spell
+     */
+    public List<O2EffectType> getEffectsToAdd() {
+        return new ArrayList<>() {{
+            addAll(effectsToAdd);
+        }};
+    }
+
+    /**
+     * Returns whether this spell targets the caster rather than a nearby player.
+     *
+     * @return true if the spell applies its effects to the caster, false if it targets nearby players
+     */
+    public boolean targetsSelf() {
+        return targetSelf;
+    }
+
+    /**
+     * Returns the minimum effect duration in seconds.
+     *
+     * @return the minimum number of seconds the effect can last
+     */
+    public int getMinDurationInSeconds() {
+        return minDurationInSeconds;
+    }
+
+    /**
+     * Returns the maximum effect duration in seconds.
+     *
+     * @return the maximum number of seconds the effect can last
+     */
+    public int getMaxDurationInSeconds() {
+        return maxDurationInSeconds;
+    }
+
+    /**
+     * Returns whether this spell applies its effects permanently.
+     *
+     * @return true if the effects do not expire, false if they have a finite duration
+     */
+    public boolean isPermanent() {
+        return permanent;
+    }
+
+    /**
+     * Returns the most recently calculated effect duration in seconds.
+     *
+     * <p>This value is set by {@link #calculateEffectDurationInSeconds()} and reflects the duration
+     * that will be applied to the target based on the caster's current experience level.</p>
+     *
+     * @return the calculated effect duration in seconds
+     */
+    public int getDurationInSeconds() {
+        return durationInSeconds;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/CARCEREM_AQUATICUM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/CARCEREM_AQUATICUM.java
@@ -4,22 +4,15 @@ import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.block.BlockCommon;
 import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.effect.WATER_BREATHING;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
-import org.bukkit.block.Block;
-import org.bukkit.block.data.Levelled;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.util.BoundingBox;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Carcerem Aquaticum - The Water Orb Spell.
@@ -59,7 +52,7 @@ public class CARCEREM_AQUATICUM extends ImmobilizePlayer {
         super(plugin);
 
         spellType = O2SpellType.CARCEREM_AQUATICUM;
-        branch = O2MagicBranch.DEFENSE_AGAINST_THE_DARK_ARTS;
+        branch = O2MagicBranch.CHARMS;
 
         flavorText = new ArrayList<>() {{
             add("The Water Orb Spell");
@@ -82,10 +75,13 @@ public class CARCEREM_AQUATICUM extends ImmobilizePlayer {
         moveEffectData = Material.BLUE_ICE;
 
         spellType = O2SpellType.CARCEREM_AQUATICUM;
-        branch = O2MagicBranch.DEFENSE_AGAINST_THE_DARK_ARTS;
+        branch = O2MagicBranch.CHARMS;
 
         fullImmobilize = false;
         minEffectDuration = minEffectDurationConfig;
+        imprison = true;
+        imprisonMaterial = Material.WATER;
+        prisonIsShell = false;
 
         if (Ollivanders2.worldGuardEnabled)
             worldGuardFlags.add(Flags.BUILD);
@@ -116,97 +112,17 @@ public class CARCEREM_AQUATICUM extends ImmobilizePlayer {
     }
 
     /**
-     * Create water blocks and breathing effect to trap and protect the target.
+     * Apply a WATER_BREATHING effect to prevent the target from drowning inside the water orb.
      *
-     * <p>Creates non-flowing water blocks around the target player and applies a WATER_BREATHING effect to
-     * prevent drowning. The water breathing effect lasts 10 ticks longer than the immobilization effect to
-     * ensure it persists through cleanup. A scheduled task will automatically revert all water blocks after
-     * the effect duration expires.</p>
+     * <p>The water breathing effect lasts 10 ticks longer than the immobilization effect to ensure
+     * it persists through cleanup when the water blocks are reverted.</p>
      *
-     * @param target the immobilized player to surround with water
+     * @param target the immobilized player
      */
+    @Override
     void addAdditionalEffects(Player target) {
-        // create water blocks around the player
-        createWaterBlocks(target);
-
         // add water breathing with just over duration time to make sure it doesn't expire before we clean up the water blocks
         WATER_BREATHING waterBreathing = new WATER_BREATHING(p, effectDuration + 10, false, target.getUniqueId());
         Ollivanders2API.getPlayers().playerEffects.addEffect(waterBreathing);
-
-        // clean up the blocks
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                revertBlocks();
-            }
-        }.runTaskLater(p, effectDuration);
-    }
-
-    /**
-     * Create water blocks around the target player based on their bounding box.
-     *
-     * <p>Expands the target player's bounding box by 1 block in all directions, then converts
-     * all air blocks within that expanded region to non-flowing water. Only air blocks are changed,
-     * preserving any existing non-air blocks. All changed blocks are tracked as temporarily changed
-     * so they can be reverted when the effect expires.</p>
-     *
-     * @param target the player to surround with water blocks
-     */
-    void createWaterBlocks(Player target) {
-        Levelled waterData = (Levelled) Bukkit.createBlockData(Material.WATER);
-        waterData.setLevel(0);
-
-        List<Block> blocks = calculateBlocksToChange(target.getBoundingBox().expand(1.0));
-        for (Block block : blocks) {
-
-            if (BlockCommon.isAirBlock(block)) {
-                Ollivanders2API.getBlocks().addTemporarilyChangedBlock(block, this);
-                block.setType(Material.WATER);
-                block.setBlockData(waterData);
-            }
-        }
-    }
-
-    /**
-     * Calculate all blocks within the expanded bounding box region.
-     *
-     * <p>Iterates through all integer block coordinates within the given bounding box and collects
-     * the Block objects. These blocks will be filtered later to only change air blocks to water.</p>
-     *
-     * @param boundingBox the expanded bounding box region to collect blocks from
-     * @return a list of all Block objects within the bounding box coordinates
-     */
-    List<Block> calculateBlocksToChange(BoundingBox boundingBox) {
-        ArrayList<Block> blocks = new ArrayList<>();
-
-        int minX = (int) Math.floor(boundingBox.getMinX());
-        int minY = (int) Math.floor(boundingBox.getMinY());
-        int minZ = (int) Math.floor(boundingBox.getMinZ());
-        int maxX = (int) Math.floor(boundingBox.getMaxX());
-        int maxY = (int) Math.floor(boundingBox.getMaxY());
-        int maxZ = (int) Math.floor(boundingBox.getMaxZ());
-
-        for (int x = minX; x <= maxX; x++) {
-            for (int y = minY; y <= maxY; y++) {
-                for (int z = minZ; z <= maxZ; z++) {
-                    Block block = location.getWorld().getBlockAt(x, y, z);
-
-                    if (!blocks.contains(block))
-                        blocks.add(block);
-                }
-            }
-        }
-
-        return blocks;
-    }
-
-    /**
-     * Revert all water blocks created by this spell.
-     *
-     * <p>Reverts all temporarily changed blocks that were created as part of the water orb. This is
-     * automatically called after the effect duration expires via a scheduled task.</p>
-     */
-    void revertBlocks() {
-        Ollivanders2API.getBlocks().revertTemporarilyChangedBlocksBy(this);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/EBUBLIO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/EBUBLIO.java
@@ -1,63 +1,106 @@
 package net.pottercraft.ollivanders2.spell;
 
-import net.pottercraft.ollivanders2.effect.O2EffectType;
+import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
-
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
+import org.bukkit.Material;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 
 /**
- * Bubble head charm gives the player water breathing for a length of time depending on the player's spell level.
+ * The Bubble Jinx that traps a target player inside a shell of glass.
  *
- * @author lownes
+ * <p>EBUBLIO entraps the target in a shell of white stained glass that cannot be broken by the
+ * player inside. Only the outer shell is built — blocks the player occupies are left unchanged
+ * to prevent suffocation damage. The spell only affects players at normal or reduced size (scale ≤ 1.0).</p>
+ *
+ * <p>Spell Mechanics:</p>
+ * <ul>
+ * <li>Only targets players with scale attribute ≤ 1.0</li>
+ * <li>Builds a shell of WHITE_STAINED_GLASS around the player's expanded bounding box</li>
+ * <li>Blocks inside the player's own bounding box are not changed (shell only)</li>
+ * <li>Uses partial immobilization (allows rotation but prevents movement)</li>
+ * <li>Minimum effect duration: 2 minutes</li>
+ * </ul>
+ *
  * @author Azami7
- * @version Ollivanders2
- * @see <a href = "https://harrypotter.fandom.com/wiki/Ebublio_Jinx">https://harrypotter.fandom.com/wiki/Ebublio_Jinx</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Ebublio_Jinx">Harry Potter Wiki - Ebublio Jinx</a>
  */
-public final class EBUBLIO extends AddO2Effect {
-    // todo this spell is wrong, ebublio is not the bubble-head charm
+public class EBUBLIO extends ImmobilizePlayer {
+    /**
+     * Minimum effect duration set to 2 minutes to match CARCEREM_AQUATICUM behaviour.
+     */
+    private static final int minEffectDurationConfig = 2 * Ollivanders2Common.ticksPerMinute;
 
     /**
-     * Default constructor for use in generating spell text.  Do not use to cast the spell.
+     * Default constructor for use in generating spell text. Do not use to cast the spell.
      *
      * @param plugin the Ollivanders2 plugin
      */
-    public EBUBLIO(Ollivanders2 plugin) {
+    public EBUBLIO(@NotNull Ollivanders2 plugin) {
         super(plugin);
 
         spellType = O2SpellType.EBUBLIO;
         branch = O2MagicBranch.CHARMS;
 
         flavorText = new ArrayList<>() {{
-            add("The Bubble-Head Charm");
-            add("Fleur Delacour, though she demonstrated excellent use of the Bubble-Head Charm, was attacked by grindylows as she approached her goal, and failed to retrieve her hostage.");
-            add("Cedric Diggory, who also used the Bubble-Head Charm, was first to return with his hostage, though he returned one minute outside the time limit of an hour.");
+            add("The Bubble Jinx");
         }};
 
-        text = "Gives target player the ability to breathe underwater.";
+        text = "Creates a prison of glass that surrounds the target player and immobilizes them.";
     }
 
     /**
-     * Constructor.
+     * Constructor for casting the spell.
      *
      * @param plugin    a callback to the MC plugin
      * @param player    the player who cast this spell
-     * @param rightWand which wand the player was using
+     * @param rightWand which wand the player was using (correctness factor)
      */
     public EBUBLIO(@NotNull Ollivanders2 plugin, @NotNull Player player, @NotNull Double rightWand) {
         super(plugin, player, rightWand);
+
+        moveEffectData = Material.BLUE_ICE;
+
         spellType = O2SpellType.EBUBLIO;
         branch = O2MagicBranch.CHARMS;
 
-        effectsToAdd.add(O2EffectType.WATER_BREATHING);
-        strengthModifier = 1;
-        minDurationInSeconds = 30;
-        durationModifier = 0;
-        targetSelf = true;
+        fullImmobilize = false;
+        minEffectDuration = minEffectDurationConfig;
+        imprison = true;
+        imprisonMaterial = Material.WHITE_STAINED_GLASS;
+        prisonIsShell = true;
+
+        if (Ollivanders2.worldGuardEnabled)
+            worldGuardFlags.add(Flags.BUILD);
 
         initSpell();
+    }
+
+    /**
+     * Determine if a player can be targeted by this spell.
+     *
+     * <p>Only players with a scale attribute of 1.0 or lower can be targeted. Oversized players cannot
+     * be trapped in the glass bubble due to the expanded bounding box being too small to contain them.</p>
+     *
+     * @param target the player to validate as a potential target
+     * @return true if the player's scale is ≤ 1.0, false if oversized (or if scale attribute is null)
+     */
+    boolean canTarget(Player target) {
+        if (!Ollivanders2.testMode) {
+            AttributeInstance scaleAttribute = target.getAttribute(Attribute.SCALE);
+
+            if (scaleAttribute == null || scaleAttribute.getBaseValue() > 1.0) {
+                common.printDebugMessage("Ebublio.canTarget: player scale > 1.0", null, null, false);
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/FUMOS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/FUMOS.java
@@ -10,12 +10,11 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 
 /**
- * Causes blindness in a radius
+ * The Smoke-Screen Spell - applies the {@link net.pottercraft.ollivanders2.effect.O2EffectType#FUMOS} effect
+ * to the caster, creating a defensive smoke cloud that causes blindness to those outside it.
  *
- * @author lownes
  * @author Azami7
- * @version Ollivanders2
- * @see <a href = "https://harrypotter.fandom.com/wiki/Smokescreen_Spell">https://harrypotter.fandom.com/wiki/Smokescreen_Spell</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Smokescreen_Spell">Smoke-Screen Spell</a>
  */
 public final class FUMOS extends AddO2Effect {
     /**
@@ -58,18 +57,5 @@ public final class FUMOS extends AddO2Effect {
         targetSelf = true;
 
         initSpell();
-    }
-
-    /**
-     * Initialize the parts of the spell that are based on experience, the player, etc. and not on class
-     * constants.
-     */
-    @Override
-    void doInitSpell() {
-        durationInSeconds = (int) (usesModifier / 2);
-        if (durationInSeconds < minDurationInSeconds)
-            durationInSeconds = minDurationInSeconds;
-        else if (durationInSeconds > maxDurationInSeconds)
-            durationInSeconds = maxDurationInSeconds;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/FUMOS_DUO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/FUMOS_DUO.java
@@ -10,12 +10,11 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 
 /**
- * Causes blindness in a radius larger than fumos.
+ * The Stronger Smoke-Screen Spell - applies the {@link net.pottercraft.ollivanders2.effect.O2EffectType#FUMOS_DUO}
+ * effect to the caster, creating a larger defensive smoke cloud than {@link FUMOS} that lasts longer.
  *
- * @author lownes
  * @author Azami7
- * @version Ollivanders2
- * @see <a href = "https://harrypotter.fandom.com/wiki/Fumos_Duo">https://harrypotter.fandom.com/wiki/Fumos_Duo</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Fumos_Duo">Stronger Smoke-Screen Spell</a>
  */
 public final class FUMOS_DUO extends AddO2Effect {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/ImmobilizePlayer.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/ImmobilizePlayer.java
@@ -2,27 +2,38 @@ package net.pottercraft.ollivanders2.spell;
 
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.block.BlockCommon;
 import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import net.pottercraft.ollivanders2.effect.FULL_IMMOBILIZE;
 import net.pottercraft.ollivanders2.effect.IMMOBILIZE;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.util.BoundingBox;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Abstract base class for player immobilization spells.
  *
- * <p>ImmobilizePlayerSuper provides the common implementation for spells that immobilize a target player
- * by applying immobilization effects. This class handles target detection, effect duration calculation,
- * and immobilization effect application. Concrete subclasses must implement target validation (canTarget)
- * and any additional spell-specific effects (addAdditionalEffects).</p>
+ * <p>ImmobilizePlayer provides the common implementation for spells that immobilize a target player.
+ * This class handles target detection, effect duration calculation, immobilization effect application,
+ * and optional prison block creation. Concrete subclasses must implement target validation (canTarget)
+ * and may override addAdditionalEffects() for spell-specific extras.</p>
  *
  * <p>Spell Mechanics:</p>
  * <ul>
  * <li>Searches for nearby players within the spell's default radius</li>
  * <li>Validates each nearby player using canTarget() to determine if they can be affected</li>
  * <li>Calculates immobilization duration based on spell uses, clamped to min/max bounds</li>
- * <li>Applies either IMMOBILIZE (partial) or FULL_IMMOBILIZE (complete) based on spell type</li>
+ * <li>Applies either IMMOBILIZE (partial) or FULL_IMMOBILIZE (complete) based on fullImmobilize</li>
  * <li>Triggers spell-specific additional effects via addAdditionalEffects()</li>
+ * <li>Optionally surrounds the target with prison blocks if imprison is true</li>
  * <li>Kills the spell after successfully targeting a player</li>
  * </ul>
  *
@@ -52,6 +63,22 @@ abstract public class ImmobilizePlayer extends O2Spell {
      * will allow pitch and yaw changes.
      */
     boolean fullImmobilize = false;
+
+    /**
+     * If true, surrounds the target player with prison blocks when the spell hits.
+     */
+    boolean imprison = false;
+
+    /**
+     * The material used to create the prison blocks around the target player.
+     */
+    Material imprisonMaterial = Material.AIR;
+
+    /**
+     * If true, only the outer shell of the expanded bounding box is filled with prison blocks,
+     * leaving the blocks the player physically occupies unchanged to prevent suffocation damage.
+     */
+    boolean prisonIsShell = false;
 
     /**
      * Default constructor for use in generating spell text.  Do not use to cast the spell.
@@ -109,6 +136,9 @@ abstract public class ImmobilizePlayer extends O2Spell {
             addImmobilizationEffect(target);
             addAdditionalEffects(target);
 
+            if (imprison)
+                imprisonPlayer(target);
+
             kill();
             return;
         }
@@ -164,15 +194,105 @@ abstract public class ImmobilizePlayer extends O2Spell {
     }
 
     /**
+     * Surround the target player with prison blocks.
+     *
+     * <p>Expands the target player's bounding box by 1 block in all directions, then converts all air
+     * blocks within that expanded region to the spell's imprisonMaterial. Only air blocks are changed,
+     * preserving any existing non-air blocks. If prisonIsShell is true, blocks the player physically
+     * occupies are skipped to prevent suffocation. All changed blocks are tracked so they can be
+     * reverted when the effect expires.</p>
+     *
+     * @param target the player to surround with prison blocks
+     */
+    void imprisonPlayer(Player target) {
+        BlockData additionalBlockData = getAdditionalPrisonBlockData();
+        BoundingBox playerBoundingBox = prisonIsShell ? target.getBoundingBox() : null;
+        if (playerBoundingBox == null) {
+            common.printDebugMessage("ImmobilizePlayer.imprisonPlayer: playerBoundingBox is null", null, null, true);
+            return;
+        }
+
+        List<Block> blocks = calculateBlocksToChange(target.getBoundingBox().expand(1.0));
+        for (Block block : blocks) {
+            if (prisonIsShell) {
+                BoundingBox blockBox = new BoundingBox(block.getX(), block.getY(), block.getZ(), block.getX() + 1, block.getY() + 1, block.getZ() + 1);
+                if (playerBoundingBox.overlaps(blockBox))
+                    continue;
+            }
+
+            if (BlockCommon.isAirBlock(block)) {
+                Ollivanders2API.getBlocks().addTemporarilyChangedBlock(block, this);
+                block.setType(imprisonMaterial);
+                if (additionalBlockData != null)
+                    block.setBlockData(additionalBlockData);
+            }
+        }
+
+        // clean up the blocks
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                revertBlocks();
+            }
+        }.runTaskLater(p, effectDuration);
+    }
+
+    /**
+     * Get optional additional block data to apply to each prison block after setting its material.
+     *
+     * <p>Returns null by default. Subclasses may override this to apply extra block state (e.g., water
+     * level data) to each prison block immediately after the material is set.</p>
+     *
+     * @return block data to apply, or null if none
+     */
+    @Nullable
+    BlockData getAdditionalPrisonBlockData() {
+        return null;
+    }
+
+    /**
      * Apply any spell-specific additional effects to the immobilized target.
      *
-     * <p>Abstract method that concrete subclasses must implement to apply spell-specific effects beyond
-     * the base immobilization effect. Examples include potion effects, block modifications, or other
-     * environmental changes specific to the spell's mechanics.</p>
+     * <p>No-op by default. Subclasses may override to apply extra effects such as potion effects
+     * or other environmental changes beyond the base immobilization.</p>
      *
      * @param target the immobilized player
      */
-    abstract void addAdditionalEffects(Player target);
+    void addAdditionalEffects(Player target) {
+    }
+
+    /**
+     * Calculate all blocks within the given bounding box region.
+     *
+     * <p>Iterates through all integer block coordinates within the given bounding box and collects
+     * the Block objects. These blocks will be filtered in the caller to only change eligible blocks.</p>
+     *
+     * @param boundingBox the bounding box region to collect blocks from
+     * @return a list of all Block objects within the bounding box coordinates
+     */
+    List<Block> calculateBlocksToChange(BoundingBox boundingBox) {
+        ArrayList<Block> blocks = new ArrayList<>();
+
+        int minX = (int) Math.floor(boundingBox.getMinX());
+        int minY = (int) Math.floor(boundingBox.getMinY());
+        int minZ = (int) Math.floor(boundingBox.getMinZ());
+        int maxX = (int) Math.floor(boundingBox.getMaxX());
+        int maxY = (int) Math.floor(boundingBox.getMaxY());
+        int maxZ = (int) Math.floor(boundingBox.getMaxZ());
+
+        for (int x = minX; x <= maxX; x++) {
+            for (int y = minY; y <= maxY; y++) {
+                for (int z = minZ; z <= maxZ; z++) {
+                    Block block = location.getWorld().getBlockAt(x, y, z);
+
+                    if (!blocks.contains(block))
+                        blocks.add(block);
+                }
+            }
+        }
+
+        return blocks;
+    }
 
     /**
      * Get the calculated immobilization duration in game ticks.
@@ -199,5 +319,44 @@ abstract public class ImmobilizePlayer extends O2Spell {
      */
     public int getMaxEffectDuration() {
         return maxEffectDuration;
+    }
+
+    /**
+     * Whether this spell surrounds the target with prison blocks.
+     *
+     * @return true if the spell creates a prison around the target, false otherwise
+     */
+    public boolean doesImprison() {
+        return imprison;
+    }
+
+    /**
+     * Get the material used to build the prison around the target player.
+     *
+     * @return the prison block material
+     */
+    public Material getImprisonMaterial() {
+        return imprisonMaterial;
+    }
+
+    /**
+     * Whether this spell builds only the outer shell of the prison, leaving the player's
+     * occupied blocks unchanged to prevent suffocation damage.
+     *
+     * @return true if only the shell is built, false if the entire expanded region is filled
+     */
+    public boolean isPrisonShell() {
+        return prisonIsShell;
+    }
+
+    /**
+     * Revert all prison blocks created by this spell.
+     *
+     * <p>Reverts all temporarily changed blocks created by imprisonPlayer(). This is automatically
+     * called after the effect duration expires via a scheduled task.</p>
+     */
+    void revertBlocks() {
+        if (imprison)
+            Ollivanders2API.getBlocks().revertTemporarilyChangedBlocksBy(this);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/LEVICORPUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/LEVICORPUS.java
@@ -10,59 +10,55 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 
 /**
- * Puts a levicorpus effect on the player
+ * The Suspension Jinx - applies the {@link net.pottercraft.ollivanders2.effect.O2EffectType#SUSPENSION}
+ * O2Effect to a target player, hoisting them into the air for the duration of the effect.
  *
- * @author lownes
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/Levitation_Charm">https://harrypotter.fandom.com/wiki/Levitation_Charm</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Levicorpus">Levicorpus</a>
  */
-public final class LEVICORPUS extends AddO2Effect
-{
-   /**
-    * Default constructor for use in generating spell text.  Do not use to cast the spell.
-    *
-    * @param plugin the Ollivanders2 plugin
-    */
-   public LEVICORPUS(Ollivanders2 plugin)
-   {
-      super(plugin);
+public final class LEVICORPUS extends AddO2Effect {
+    /**
+     * Default constructor for use in generating spell text.  Do not use to cast the spell.
+     *
+     * @param plugin the Ollivanders2 plugin
+     */
+    public LEVICORPUS(Ollivanders2 plugin) {
+        super(plugin);
 
-      spellType = O2SpellType.LEVICORPUS;
-      branch = O2MagicBranch.DARK_ARTS;
+        spellType = O2SpellType.LEVICORPUS;
+        branch = O2MagicBranch.DARK_ARTS;
 
-      flavorText = new ArrayList<>()
-      {{
-         add("\"Oh, that one had a great vogue during my time at Hogwarts. There were a few months in my fifth year when you couldn't move for being hoisted into the air by your ankle.\" -Remus Lupin");
-         add("Pointing his wand at nothing in particular, he gave it an upward flick and said Levicorpus! inside his head... There was a flash of light... Ron was dangling upside down in midair as though an invisible hook had hoisted him up by the ankle.");
-         add("The Suspension Jinx");
-      }};
+        flavorText = new ArrayList<>() {{
+            add("\"Oh, that one had a great vogue during my time at Hogwarts. There were a few months in my fifth year when you couldn't move for being hoisted into the air by your ankle.\" -Remus Lupin");
+            add("Pointing his wand at nothing in particular, he gave it an upward flick and said Levicorpus! inside his head... There was a flash of light... Ron was dangling upside down in midair as though an invisible hook had hoisted him up by the ankle.");
+            add("The Suspension Jinx");
+        }};
 
-      text = "Hoist a player up into the air for a duration.";
-   }
+        text = "Hoist a player up into the air for a duration.";
+    }
 
-   /**
-    * Constructor.
-    *
-    * @param plugin    a callback to the MC plugin
-    * @param player    the player who cast this spell
-    * @param rightWand which wand the player was using
-    */
-   public LEVICORPUS(@NotNull Ollivanders2 plugin, @NotNull Player player, @NotNull Double rightWand)
-   {
-      super(plugin, player, rightWand);
+    /**
+     * Constructor.
+     *
+     * @param plugin    a callback to the MC plugin
+     * @param player    the player who cast this spell
+     * @param rightWand which wand the player was using
+     */
+    public LEVICORPUS(@NotNull Ollivanders2 plugin, @NotNull Player player, @NotNull Double rightWand) {
+        super(plugin, player, rightWand);
 
-      spellType = O2SpellType.LEVICORPUS;
-      branch = O2MagicBranch.DARK_ARTS;
+        spellType = O2SpellType.LEVICORPUS;
+        branch = O2MagicBranch.DARK_ARTS;
 
-      // world guard flags
-      if (Ollivanders2.worldGuardEnabled)
-         worldGuardFlags.add(Flags.PVP);
+        // world guard flags
+        if (Ollivanders2.worldGuardEnabled)
+            worldGuardFlags.add(Flags.PVP);
 
-      effectsToAdd.add(O2EffectType.SUSPENSION);
+        effectsToAdd.add(O2EffectType.SUSPENSION);
 
-      maxDurationInSeconds = 180; // 3 minutes
-      durationModifier = 30;
+        maxDurationInSeconds = 180; // 3 minutes
+        durationModifier = 30;
 
-      initSpell();
-   }
+        initSpell();
+    }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/LOQUELA_INEPTIAS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/LOQUELA_INEPTIAS.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
  * Babbling curse is a curse that causes uncontrollable babbling.
  *
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/Babbling_Curse">https://harrypotter.fandom.com/wiki/Babbling_Curse</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Babbling_Curse">Babbling Curse</a>
  * @since 2.2.7
  */
 public class LOQUELA_INEPTIAS extends AddO2Effect {
@@ -50,9 +50,6 @@ public class LOQUELA_INEPTIAS extends AddO2Effect {
         spellType = O2SpellType.LOQUELA_INEPTIAS;
 
         effectsToAdd.add(O2EffectType.BABBLING);
-
-        // duration
-        maxDurationInSeconds = 300;
 
         // pass-through materials
         projectilePassThrough.remove(Material.WATER);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/MUCUS_AD_NAUSEAM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/MUCUS_AD_NAUSEAM.java
@@ -11,11 +11,11 @@ import net.pottercraft.ollivanders2.Ollivanders2;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Adds a MUCUS_AD_NAUSEAM oeffect to the player
+ * The Curse of the Bogies - applies the {@link net.pottercraft.ollivanders2.effect.O2EffectType#MUCUS}
+ * O2Effect to a target player.
  *
- * @author lownes
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/Curse_of_the_Bogies">https://harrypotter.fandom.com/wiki/Curse_of_the_Bogies</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Curse_of_the_Bogies">Curse of the Bogies</a>
  */
 public final class MUCUS_AD_NAUSEAM extends AddO2Effect {
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2SpellType.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2SpellType.java
@@ -40,6 +40,10 @@ public enum O2SpellType {
      */
     AMATO_ANIMO_ANIMATO_ANIMAGUS(AMATO_ANIMO_ANIMATO_ANIMAGUS.class, MagicLevel.NEWT),
     /**
+     * {@link ANAPNEO}
+     */
+    ANAPNEO(ANAPNEO.class, MagicLevel.NEWT),
+    /**
      * {@link APARECIUM}
      */
     APARECIUM(APARECIUM.class, MagicLevel.BEGINNER),

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/PETRIFICUS_TOTALUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/PETRIFICUS_TOTALUS.java
@@ -24,7 +24,8 @@ import java.util.ArrayList;
  * <li>Complete immobilization leaves the victim helpless but unharmed</li>
  * </ul>
  *
- * <p>Reference: <a href="http://harrypotter.wikia.com/wiki/Full_Body-Bind_Curse">Harry Potter Wiki - Full Body-Bind Curse</a></p>
+ * @author Azami7
+ * @see <a href="http://harrypotter.wikia.com/wiki/Full_Body-Bind_Curse">Harry Potter Wiki - Full Body-Bind Curse</a></p>
  */
 public class PETRIFICUS_TOTALUS extends ImmobilizePlayer {
     /**
@@ -76,16 +77,5 @@ public class PETRIFICUS_TOTALUS extends ImmobilizePlayer {
      */
     boolean canTarget(Player target) {
         return true; // we can target any player
-    }
-
-    /**
-     * Apply any spell-specific additional effects to the immobilized target.
-     *
-     * <p>Petrificus Totalus has no additional effects beyond the FULL_IMMOBILIZE effect applied by the
-     * parent class. The target is simply frozen in place without any secondary effects or conditions.</p>
-     *
-     * @param target the immobilized player (unused)
-     */
-    void addAdditionalEffects(Player target) {
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/PROTEGO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/PROTEGO.java
@@ -10,13 +10,12 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 
 /**
- * The Shield Charm - Protego - was a charm that protected the caster with an invisible shield that deflects spells
- * and projectiles.
- * <p>
- * {@link net.pottercraft.ollivanders2.effect.PROTEGO}
+ * The Shield Charm - applies the {@link net.pottercraft.ollivanders2.effect.O2EffectType#PROTEGO} O2Effect
+ * to the caster, providing a shield that deflects spells and projectiles.
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Shield_Charm">https://harrypotter.fandom.com/wiki/Shield_Charm</a>
- * {@link net.pottercraft.ollivanders2.stationaryspell.ShieldSpell}
+ * @see <a href="https://harrypotter.fandom.com/wiki/Shield_Charm">Shield Charm</a>
+ * @see net.pottercraft.ollivanders2.effect.PROTEGO
+ * @see net.pottercraft.ollivanders2.stationaryspell.ShieldSpell
  */
 public final class PROTEGO extends AddO2Effect {
     /**
@@ -49,7 +48,7 @@ public final class PROTEGO extends AddO2Effect {
     public PROTEGO(@NotNull Ollivanders2 plugin, @NotNull Player player, @NotNull Double rightWand) {
         super(plugin, player, rightWand);
 
-        spellType = O2SpellType.FUMOS;
+        spellType = O2SpellType.PROTEGO;
         branch = O2MagicBranch.CHARMS;
 
         effectsToAdd.add(O2EffectType.PROTEGO);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/RICTUSEMPRA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/RICTUSEMPRA.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
  * The Tickling Charm, also known as the Tickle Charm - Rictusempra - is a charm that caused the target to buckle with laughter.
  *
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/Tickling_Charm">https://harrypotter.fandom.com/wiki/Tickling_Charm</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Tickling_Charm">Tickling Charm</a>
  * @since 2.21
  */
 public class RICTUSEMPRA extends AddO2Effect {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/TARANTALLEGRA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/TARANTALLEGRA.java
@@ -13,9 +13,9 @@ import java.util.ArrayList;
  * The Dancing Feet Spell - Tarantallegra - is a charm that makes a target's legs spasm wildly out of control, making it
  * appear as though they are dancing.
  *
- * @since 2.21
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/Dancing_Feet_Spell">https://harrypotter.fandom.com/wiki/Dancing_Feet_Spell</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Dancing_Feet_Spell">Dancing Feet Spell</a>
+ * @since 2.21
  */
 public class TARANTALLEGRA extends AddO2Effect {
     /**
@@ -48,7 +48,7 @@ public class TARANTALLEGRA extends AddO2Effect {
     public TARANTALLEGRA(@NotNull Ollivanders2 plugin, @NotNull Player player, @NotNull Double rightWand) {
         super(plugin, player, rightWand);
 
-        branch = O2MagicBranch.CHARMS;
+        branch = O2MagicBranch.DARK_ARTS;
         spellType = O2SpellType.TARANTALLEGRA;
 
         effectsToAdd.add(O2EffectType.DANCING_FEET);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/TITILLANDO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/TITILLANDO.java
@@ -10,12 +10,13 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 
 /**
- * The Tickling Hex - Titillando - also known as the Tickling Spell, is a hex that tickled and subsequently weakened the
- * target.
+ * The Tickling Hex - applies the {@link net.pottercraft.ollivanders2.effect.O2EffectType#LAUGHING},
+ * {@link net.pottercraft.ollivanders2.effect.O2EffectType#TICKLING}, and
+ * {@link net.pottercraft.ollivanders2.effect.O2EffectType#WEAKNESS} O2Effects to a target player,
+ * causing uncontrollable laughter, tickling, and weakness.
  *
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/Tickling_Hex">https://harrypotter.fandom.com/wiki/Tickling_Hex</a>
- * @since 2.21
+ * @see <a href="https://harrypotter.fandom.com/wiki/Tickling_Hex">Tickling Hex</a>
  */
 public class TITILLANDO extends AddO2Effect {
     /**

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/AddO2EffectTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/AddO2EffectTest.java
@@ -1,0 +1,167 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.common.Ollivanders2Common;
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.player.O2PlayerCommon;
+import net.pottercraft.ollivanders2.spell.AddO2Effect;
+import net.pottercraft.ollivanders2.spell.O2Spell;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffectType;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Abstract base test class for {@link net.pottercraft.ollivanders2.spell.AddO2Effect} spell implementations.
+ *
+ * <p>Provides shared test infrastructure for spells that apply an {@link net.pottercraft.ollivanders2.effect.O2Effect}
+ * or Bukkit potion effect to a target player. Tests verify that:
+ * <ul>
+ * <li>The spell applies its effect to the correct target after being cast</li>
+ * <li>The effect expires after the calculated duration</li>
+ * <li>Calculated duration stays within the spell's configured min/max bounds at all experience levels</li>
+ * </ul>
+ *
+ * <p>Subclasses must implement {@link #getSpellType()}, {@link #addsPotionEffect()}, and
+ * {@link #getPotionEffects()} to configure which spell and effect type are under test.</p>
+ *
+ * @author Azami7
+ */
+abstract public class AddO2EffectTest extends O2SpellTestSuper {
+    @Override
+    void spellConstructionTest() {
+    }
+
+    /**
+     * Whether this spell applies a Bukkit potion effect rather than a custom O2Effect.
+     *
+     * <p>When true, {@link #doCheckEffectTest()} verifies the effect via
+     * {@link org.bukkit.entity.Player#hasPotionEffect(PotionEffectType)}. When false, it uses
+     * {@link net.pottercraft.ollivanders2.effect.O2Effects#hasEffect(java.util.UUID, O2EffectType)}.</p>
+     *
+     * @return true if the spell adds a Bukkit potion effect, false if it adds an O2Effect
+     */
+    abstract boolean addsPotionEffect();
+
+    /**
+     * The Bukkit potion effect types applied by this spell, or null if the spell adds an O2Effect instead.
+     *
+     * <p>Only used when {@link #addsPotionEffect()} returns true. The first element is used for
+     * presence checks in {@link #doCheckEffectTest()}.</p>
+     *
+     * @return list of potion effect types, or null if the spell does not add potion effects
+     */
+    @Nullable
+    abstract List<PotionEffectType> getPotionEffects();
+
+    /**
+     * Tests that the spell applies its effect to the correct target and that the effect expires after the duration.
+     *
+     * <p>Casts the spell at a target 3 blocks away and verifies:
+     * <ul>
+     * <li>The spell kills itself after hitting a target</li>
+     * <li>The expected effect is present on the target immediately after the spell hits</li>
+     * <li>The effect expires after the maximum configured duration</li>
+     * </ul>
+     *
+     * <p>For self-targeting spells the caster is the target; for non-self-targeting spells the nearby
+     * player is the target. Effect presence is checked via
+     * {@link org.bukkit.entity.Player#hasPotionEffect(PotionEffectType)} for potion effects and
+     * {@link net.pottercraft.ollivanders2.effect.O2Effects#hasEffect(java.util.UUID, O2EffectType)}
+     * for O2Effects.</p>
+     */
+    @Test
+    void doCheckEffectTest() {
+        World testWorld = mockServer.addSimpleWorld(getSpellType().getSpellName());
+        Location location = getNextLocation(testWorld);
+        Location targetLocation = new Location(testWorld, location.getX() + 3, location.getY(), location.getZ());
+        PlayerMock caster = mockServer.addPlayer();
+
+        PlayerMock player = mockServer.addPlayer();
+        player.setLocation(targetLocation);
+
+        AddO2Effect addO2Effect = (AddO2Effect) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel);
+        List<O2EffectType> effects = addO2Effect.getEffectsToAdd();
+        List<PotionEffectType> potionEffects = getPotionEffects();
+
+        if (addsPotionEffect()) {
+            assertNotNull(potionEffects);
+            assertFalse(potionEffects.isEmpty());
+        }
+
+        assertFalse(effects.isEmpty(), "Spell has no effects to add");
+
+        Player target;
+        if (addO2Effect.targetsSelf())
+            target = caster;
+        else
+            target = player;
+
+        if (addsPotionEffect())
+            assertFalse(target.hasPotionEffect(potionEffects.getFirst()), "target already has potion effect");
+        else
+            assertFalse(Ollivanders2API.getPlayers().playerEffects.hasEffect(target.getUniqueId(), effects.getFirst()), "target already has o2effect");
+
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(addO2Effect.isKilled(), "spell did not hit target");
+
+        if (addsPotionEffect())
+            assertTrue(target.hasPotionEffect(potionEffects.getFirst()), "target does not have potion effect");
+        else
+            assertTrue(Ollivanders2API.getPlayers().playerEffects.hasEffect(target.getUniqueId(), effects.getFirst()), "target does not have  o2effect");
+
+        mockServer.getScheduler().performTicks((long) addO2Effect.getMaxDurationInSeconds() * Ollivanders2Common.ticksPerSecond);
+
+        if (addO2Effect.isPermanent()) {
+            assertFalse(addsPotionEffect(), "spell set to permanent but it adds a potion effect"); // potion effects cannot be permanent
+            assertTrue(Ollivanders2API.getPlayers().playerEffects.hasEffect(target.getUniqueId(), effects.getFirst()), "target no longer has o2effect when spell is permanent");
+        }
+        else {
+            if (addsPotionEffect())
+                assertFalse(target.hasPotionEffect(potionEffects.getFirst()), "target already still has potion effect after duration expired");
+            else
+                assertFalse(Ollivanders2API.getPlayers().playerEffects.hasEffect(target.getUniqueId(), effects.getFirst()), "target still has o2effect after duration expired");
+        }
+    }
+
+    /**
+     * Tests that the calculated effect duration stays within the spell's configured min/max bounds.
+     *
+     * <p>Verifies duration bounds at two experience levels:
+     * <ul>
+     * <li>Experience level 1 (minimum skill) — duration should be at least {@code minDurationInSeconds}</li>
+     * <li>Experience level {@code spellMasteryLevel * 2} (beyond mastery) — duration should be at most
+     * {@code maxDurationInSeconds}</li>
+     * </ul>
+     */
+    @Test
+    void durationTest() {
+        World testWorld = mockServer.addSimpleWorld(getSpellType().getSpellName());
+        Location location = getNextLocation(testWorld);
+        Location targetLocation = new Location(testWorld, location.getX() + 3, location.getY(), location.getZ());
+        PlayerMock caster = mockServer.addPlayer();
+
+        AddO2Effect addO2Effect = (AddO2Effect) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, 1);
+        assertTrue(addO2Effect.getDurationInSeconds() >= addO2Effect.getMinDurationInSeconds(), "duration < min duration at skill level 1");
+        assertTrue(addO2Effect.getDurationInSeconds() <= addO2Effect.getMaxDurationInSeconds(), "duration > max duration at skill level 1");
+
+        addO2Effect = (AddO2Effect) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel * 2);
+        assertTrue(addO2Effect.getDurationInSeconds() >= addO2Effect.getMinDurationInSeconds(), "duration < min duration at skill level mastery * 2");
+        assertTrue(addO2Effect.getDurationInSeconds() <= addO2Effect.getMaxDurationInSeconds(), "duration > max duration at skill level mastery * 2");
+    }
+
+    @Override
+    @Test
+    void revertTest() {
+        // o2effect spells don't have revert actions
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/AnapneoTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/AnapneoTest.java
@@ -1,0 +1,38 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests for the {@link net.pottercraft.ollivanders2.spell.ANAPNEO} spell (Bubble-Head Charm).
+ *
+ * <p>ANAPNEO is a self-targeting charm that grants the caster water breathing via a Bukkit potion
+ * effect. Effect presence is verified via {@link org.bukkit.entity.Player#hasPotionEffect}.</p>
+ *
+ * @author Azami7
+ */
+@Isolated
+public class AnapneoTest extends AddO2EffectTest {
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.ANAPNEO;
+    }
+
+    @Override
+    boolean addsPotionEffect() {
+        return true;
+    }
+
+    @Override
+    List<PotionEffectType> getPotionEffects() {
+        return new ArrayList<>() {{
+            add(PotionEffectType.WATER_BREATHING);
+        }};
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/CarceremAquaticumTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/CarceremAquaticumTest.java
@@ -1,6 +1,5 @@
 package net.pottercraft.ollivanders2.test.spell;
 
-import net.pottercraft.ollivanders2.Ollivanders2API;
 import net.pottercraft.ollivanders2.spell.CARCEREM_AQUATICUM;
 import net.pottercraft.ollivanders2.spell.O2SpellType;
 import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
@@ -14,7 +13,6 @@ import org.junit.jupiter.api.parallel.Isolated;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -27,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p>Test Coverage:</p>
  * <ul>
- * <li>Spell targeting and effect application (inherited from ImmobilizePlayerSuperTest)</li>
+ * <li>Spell targeting and effect application (inherited from ImmobilizePlayerTest)</li>
  * <li>Effect duration calculation (inherited)</li>
  * <li>Partial immobilization behavior (inherited)</li>
  * <li>Water breathing effect application</li>
@@ -54,29 +52,6 @@ public class CarceremAquaticumTest extends ImmobilizePlayerTest {
     }
 
     /**
-     * Test spell construction and initial configuration.
-     *
-     * <p>Overridden to do nothing as CARCEREM_AQUATICUM has no spell-specific construction
-     * requirements beyond those tested in the base class.</p>
-     */
-    @Override
-    @Test
-    void spellConstructionTest() {
-    }
-
-    /**
-     * Test spell targeting and effect application.
-     *
-     * <p>Overridden to do nothing as the inherited doCheckEffectTest() from ImmobilizePlayerSuperTest
-     * provides complete coverage for this spell's targeting behavior.</p>
-     */
-    @Override
-    @Test
-    void doCheckEffectTest() {
-
-    }
-
-    /**
      * Test that only normal-sized players can be targeted.
      *
      * <p>CARCEREM_AQUATICUM only targets players with scale ≤ 1.0. This test cannot be implemented
@@ -90,11 +65,11 @@ public class CarceremAquaticumTest extends ImmobilizePlayerTest {
     }
 
     /**
-     * Test that WATER_BREATHING effect and water blocks are applied correctly.
+     * Test that the WATER_BREATHING effect is applied to the target.
      *
-     * <p>Verifies that the spell applies the WATER_BREATHING effect to the target player
-     * and creates a complete 3x3 water block grid at three levels (above, at, and below the
-     * player's eye level). All water blocks must be tracked as temporarily changed blocks.</p>
+     * <p>Verifies that the spell applies the WATER_BREATHING effect to the target player to prevent
+     * drowning inside the water orb. Water block creation is tested via the inherited
+     * {@link ImmobilizePlayerTest#imprisonEffectTest()}.</p>
      */
     @Override
     @Test
@@ -114,37 +89,5 @@ public class CarceremAquaticumTest extends ImmobilizePlayerTest {
 
         assertTrue(carceremAquaticum.hasHitTarget());
         assertTrue(target.hasPotionEffect(PotionEffectType.WATER_BREATHING), "target does not have water breathing");
-
-        assertEquals(Material.WATER, target.getEyeLocation().getBlock().getType(), "block at eye location not changed to Water");
-        assertTrue(Ollivanders2API.getBlocks().isTemporarilyChangedBlock(target.getEyeLocation().getBlock()), "eye location block not added to tracking");
-    }
-
-    /**
-     * Test that water blocks are reverted after the effect duration expires.
-     *
-     * <p>Verifies that when the immobilization effect duration expires, all water blocks
-     * are automatically reverted to their original state (AIR) and are no longer tracked
-     * as temporarily changed blocks.</p>
-     */
-    @Override
-    @Test
-    void revertTest() {
-        World testWorld = mockServer.addSimpleWorld("Immobilize");
-        Location location = getNextLocation(testWorld);
-        Location targetLocation = new Location(testWorld, location.getX() + 10, location.getY(), location.getZ());
-        PlayerMock caster = mockServer.addPlayer();
-
-        PlayerMock target = mockServer.addPlayer();
-        TestCommon.createBlockBase(new Location(targetLocation.getWorld(), target.getX(), target.getY() - 1, target.getZ()), 3);
-        target.setLocation(targetLocation);
-
-        CARCEREM_AQUATICUM carceremAquaticum = (CARCEREM_AQUATICUM) castSpell(caster, location, targetLocation);
-        mockServer.getScheduler().performTicks(20);
-
-        assertTrue(Ollivanders2API.getBlocks().isTemporarilyChangedBlock(targetLocation.getBlock()));
-        mockServer.getScheduler().performTicks(carceremAquaticum.getEffectDuration());
-
-        assertFalse(Ollivanders2API.getBlocks().isTemporarilyChangedBlock(targetLocation.getBlock()), "water block still being tracked");
-        assertEquals(Material.AIR, targetLocation.getBlock().getType(), "water block not reverted");
     }
 }

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/EbublioTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/EbublioTest.java
@@ -1,0 +1,48 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the EBUBLIO spell.
+ *
+ * <p>Inherits all immobilization tests from {@link ImmobilizePlayerTest} as the glass-prison variant:</p>
+ * <ul>
+ * <li>Target detection and effect application</li>
+ * <li>Effect duration clamped to min/max bounds</li>
+ * <li>Partial immobilization (allows rotation, prevents movement)</li>
+ * <li>Shell of WHITE_STAINED_GLASS built around the target</li>
+ * <li>Prison blocks reverted after effect duration expires</li>
+ * <li>Scale attribute validation (not testable in MockBukkit)</li>
+ * </ul>
+ *
+ * @author Azami7
+ * @see net.pottercraft.ollivanders2.spell.EBUBLIO for the spell implementation
+ * @see ImmobilizePlayerTest for the inherited test framework
+ */
+public class EbublioTest extends ImmobilizePlayerTest {
+    /**
+     * Get the spell type being tested.
+     *
+     * @return O2SpellType.EBUBLIO
+     */
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.EBUBLIO;
+    }
+
+    /**
+     * Test that only normal-sized players can be targeted.
+     *
+     * <p>EBUBLIO only targets players with scale ≤ 1.0. This test cannot be implemented
+     * as MockBukkit does not support the SCALE attribute. The test is overridden to do nothing but
+     * would verify that oversized players (scale > 1.0) cannot be targeted.</p>
+     */
+    @Override
+    @Test
+    void invalidTargetTest() {
+        // cannot test until MockBukkit supports the SCALE attribute
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/FumosDuoTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/FumosDuoTest.java
@@ -1,0 +1,35 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.List;
+
+/**
+ * Tests for the {@link net.pottercraft.ollivanders2.spell.FUMOS_DUO} spell (Stronger Smoke-Screen Spell).
+ *
+ * <p>FUMOS_DUO is a self-targeting charm that applies the FUMOS_DUO O2Effect to the caster,
+ * creating a larger defensive smoke cloud than {@link net.pottercraft.ollivanders2.spell.FUMOS}.</p>
+ *
+ * @author Azami7
+ */
+@Isolated
+public class FumosDuoTest extends AddO2EffectTest {
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.FUMOS_DUO;
+    }
+
+    @Override
+    boolean addsPotionEffect() {
+        return false;
+    }
+
+    @Override
+    List<PotionEffectType> getPotionEffects() {
+        return null;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/FumosTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/FumosTest.java
@@ -1,0 +1,35 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.List;
+
+/**
+ * Tests for the {@link net.pottercraft.ollivanders2.spell.FUMOS} spell (Smoke-Screen Spell).
+ *
+ * <p>FUMOS is a self-targeting charm that applies the FUMOS O2Effect to the caster,
+ * creating a defensive smoke cloud.</p>
+ *
+ * @author Azami7
+ */
+@Isolated
+public class FumosTest extends AddO2EffectTest {
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.FUMOS;
+    }
+
+    @Override
+    boolean addsPotionEffect() {
+        return false;
+    }
+
+    @Override
+    List<PotionEffectType> getPotionEffects() {
+        return null;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/ImmobilizePlayerTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/ImmobilizePlayerTest.java
@@ -5,19 +5,22 @@ import net.pottercraft.ollivanders2.effect.O2EffectType;
 import net.pottercraft.ollivanders2.spell.ImmobilizePlayer;
 import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.BlockFace;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Abstract base class for testing ImmobilizePlayerSuper spell implementations.
+ * Abstract base class for testing ImmobilizePlayer spell implementations.
  *
- * <p>ImmobilizePlayerSuperTest provides a common testing framework for all spell subclasses that extend
- * ImmobilizePlayerSuper, which are spells that target and immobilize a nearby player. This test class
+ * <p>ImmobilizePlayerTest provides a common testing framework for all spell subclasses that extend
+ * ImmobilizePlayer, which are spells that target and immobilize a nearby player. This test class
  * validates that the spell correctly targets players, applies appropriate immobilization effects, and
  * respects duration and immobilization type (full vs. partial).</p>
  *
@@ -29,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <li>Movement restriction - verifies location changes are prevented while rotation may be allowed</li>
  * <li>Full immobilization - verifies FULL_IMMOBILIZE prevents all movement including rotation</li>
  * <li>Partial immobilization - verifies IMMOBILIZE allows rotation but prevents location changes</li>
+ * <li>Prison block creation and reversion (for spells with imprison = true)</li>
  * </ul>
  *
  * @author Azami7
@@ -36,6 +40,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @see O2SpellTestSuper for the base spell testing framework
  */
 abstract public class ImmobilizePlayerTest extends O2SpellTestSuper {
+    /**
+     * Overridden to do nothing. Immobilize spells have no construction requirements beyond
+     * those covered by inherited base class tests.
+     */
+    @Override
+    @Test
+    void spellConstructionTest() {
+    }
+
     /**
      * Test that the immobilize spell correctly targets and applies effects to nearby players.
      *
@@ -136,31 +149,89 @@ abstract public class ImmobilizePlayerTest extends O2SpellTestSuper {
     /**
      * Test that the spell correctly rejects invalid targets.
      *
-     * <p>Abstract method that concrete subclasses must implement to test spell-specific target validation
-     * logic. Examples of invalid targets may include players with certain attributes, effects, or conditions
-     * that prevent the spell from affecting them.</p>
+     * <p>No-op by default. Subclasses may override to test spell-specific target validation logic,
+     * such as verifying that players with certain attributes or conditions cannot be targeted.</p>
      */
     @Test
-    abstract void invalidTargetTest();
+    void invalidTargetTest() {
+    }
+
+    /**
+     * Test that prison blocks are created correctly when the spell imprisons the target.
+     *
+     * <p>For spells with imprison = true, verifies that the prison material is placed adjacent to the
+     * target's eye location and that the block is tracked as a temporarily changed block. For spells
+     * where prisonIsShell = false, also verifies that the block at the target's eye location itself
+     * is changed. For non-imprisoning spells, verifies that no blocks are changed.</p>
+     */
+    @Test
+    void imprisonEffectTest() {
+        World testWorld = mockServer.addSimpleWorld("Immobilize");
+        Location location = getNextLocation(testWorld);
+        Location targetLocation = new Location(testWorld, location.getX() + 10, location.getY(), location.getZ());
+        PlayerMock caster = mockServer.addPlayer();
+
+        PlayerMock target = mockServer.addPlayer();
+        TestCommon.createBlockBase(new Location(targetLocation.getWorld(), target.getX(), target.getY() - 1, target.getZ()), 3);
+        target.setLocation(targetLocation);
+        assertEquals(Material.AIR, target.getEyeLocation().getBlock().getType());
+
+        ImmobilizePlayer immobilizePlayer = (ImmobilizePlayer) castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(immobilizePlayer.hasHitTarget());
+
+        if (immobilizePlayer.doesImprison()) {
+            Material prisonMaterial = immobilizePlayer.getImprisonMaterial();
+
+            assertEquals(prisonMaterial, target.getEyeLocation().getBlock().getRelative(BlockFace.EAST).getType(), "block next to eye location was changed");
+            assertTrue(Ollivanders2API.getBlocks().isTemporarilyChangedBlock(target.getEyeLocation().getBlock().getRelative(BlockFace.EAST)), "block not added to tracking");
+            if (!immobilizePlayer.isPrisonShell()) {
+                assertEquals(prisonMaterial, target.getEyeLocation().getBlock().getType(), "block at eye location not changed to Water");
+            }
+        }
+        else
+            assertEquals(Material.AIR, target.getEyeLocation().getBlock().getRelative(BlockFace.EAST).getType(), "block next to eye location was changed");
+    }
 
     /**
      * Test that the spell applies any spell-specific additional effects to the target.
      *
-     * <p>Abstract method that concrete subclasses must implement to test additional effects beyond the
-     * base immobilization effect. Different immobilize spells may apply supplementary effects such as
-     * potion effects or environmental changes as part of their mechanics.</p>
+     * <p>No-op by default. Subclasses may override to verify supplementary effects such as
+     * potion effects or environmental changes applied beyond the base immobilization.</p>
      */
     @Test
-    abstract void additionalEffectsTest();
+    void additionalEffectsTest() {
+    }
 
     /**
-     * Test that the spell effects revert after expiration.
+     * Test that prison blocks are reverted after the effect duration expires.
      *
-     * <p>This test is left empty for immobilize spells as the revert behavior is handled by the standard
-     * effect expiration mechanism and is not spell-specific.</p>
+     * <p>Verifies that when the immobilization effect duration expires, all prison blocks
+     * are automatically reverted to their original state (AIR) and are no longer tracked
+     * as temporarily changed blocks.</p>
      */
     @Override
     @Test
     void revertTest() {
+        World testWorld = mockServer.addSimpleWorld("Immobilize");
+        Location location = getNextLocation(testWorld);
+        Location targetLocation = new Location(testWorld, location.getX() + 10, location.getY(), location.getZ());
+        PlayerMock caster = mockServer.addPlayer();
+
+        ImmobilizePlayer immobilizePlayer = (ImmobilizePlayer) castSpell(caster, location, targetLocation);
+
+        if (immobilizePlayer.doesImprison()) {
+            PlayerMock target = mockServer.addPlayer();
+            TestCommon.createBlockBase(new Location(targetLocation.getWorld(), target.getX(), target.getY() - 1, target.getZ()), 3);
+            target.setLocation(targetLocation);
+
+            mockServer.getScheduler().performTicks(20);
+
+            assertTrue(Ollivanders2API.getBlocks().isTemporarilyChangedBlock(targetLocation.getBlock().getRelative(BlockFace.EAST)));
+            mockServer.getScheduler().performTicks(immobilizePlayer.getEffectDuration());
+
+            assertFalse(Ollivanders2API.getBlocks().isTemporarilyChangedBlock(targetLocation.getBlock().getRelative(BlockFace.EAST)), "prison block still being tracked");
+            assertEquals(Material.AIR, targetLocation.getBlock().getType(), "prison block not reverted");
+        }
     }
 }

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/LevicorpusTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/LevicorpusTest.java
@@ -1,0 +1,35 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.List;
+
+/**
+ * Tests for the {@link net.pottercraft.ollivanders2.spell.LEVICORPUS} spell (Suspension Jinx).
+ *
+ * <p>LEVICORPUS is a dark arts spell that applies the SUSPENSION O2Effect to a target player,
+ * hoisting them into the air for the duration of the effect.</p>
+ *
+ * @author Azami7
+ */
+@Isolated
+public class LevicorpusTest extends AddO2EffectTest {
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.LEVICORPUS;
+    }
+
+    @Override
+    boolean addsPotionEffect() {
+        return false;
+    }
+
+    @Override
+    List<PotionEffectType> getPotionEffects() {
+        return null;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/LoquelaIneptiasTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/LoquelaIneptiasTest.java
@@ -1,0 +1,35 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.List;
+
+/**
+ * Tests for the {@link net.pottercraft.ollivanders2.spell.LOQUELA_INEPTIAS} spell (Babbling Curse).
+ *
+ * <p>LOQUELA_INEPTIAS is a dark arts spell that applies the BABBLING O2Effect to a target player,
+ * causing them to speak nonsense for the duration of the effect.</p>
+ *
+ * @author Azami7
+ */
+@Isolated
+public class LoquelaIneptiasTest extends AddO2EffectTest {
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.LOQUELA_INEPTIAS;
+    }
+
+    @Override
+    boolean addsPotionEffect() {
+        return false;
+    }
+
+    @Override
+    List<PotionEffectType> getPotionEffects() {
+        return null;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/MucusAdNauseumTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/MucusAdNauseumTest.java
@@ -1,0 +1,34 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.List;
+
+/**
+ * Tests for the {@link net.pottercraft.ollivanders2.spell.MUCUS_AD_NAUSEAM} spell (Curse of the Bogies).
+ *
+ * <p>MUCUS_AD_NAUSEAM is a dark arts spell that applies the MUCUS O2Effect to a target player.</p>
+ *
+ * @author Azami7
+ */
+@Isolated
+public class MucusAdNauseumTest extends AddO2EffectTest {
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.MUCUS_AD_NAUSEAM;
+    }
+
+    @Override
+    boolean addsPotionEffect() {
+        return false;
+    }
+
+    @Override
+    List<PotionEffectType> getPotionEffects() {
+        return null;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/PetrificusTotalusTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/PetrificusTotalusTest.java
@@ -2,7 +2,6 @@ package net.pottercraft.ollivanders2.test.spell;
 
 import net.pottercraft.ollivanders2.spell.O2SpellType;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 
 /**
@@ -35,38 +34,5 @@ public class PetrificusTotalusTest extends ImmobilizePlayerTest {
     @NotNull
     O2SpellType getSpellType() {
         return O2SpellType.PETRIFICUS_TOTALUS;
-    }
-
-    /**
-     * Test spell construction and initial configuration.
-     *
-     * <p>Overridden to do nothing as PETRIFICUS_TOTALUS has no spell-specific construction
-     * requirements beyond those tested in the base class.</p>
-     */
-    @Override
-    @Test
-    void spellConstructionTest() {
-    }
-
-    /**
-     * Test that no players are invalid targets for this spell.
-     *
-     * <p>PETRIFICUS_TOTALUS can target any player without restrictions. This test is overridden
-     * to do nothing as there are no invalid target conditions to test.</p>
-     */
-    @Override
-    @Test
-    void invalidTargetTest() {
-    }
-
-    /**
-     * Test that no additional effects are applied beyond immobilization.
-     *
-     * <p>PETRIFICUS_TOTALUS applies only the FULL_IMMOBILIZE effect with no additional effects.
-     * This test is overridden to do nothing as there are no additional effects to test.</p>
-     */
-    @Override
-    @Test
-    void additionalEffectsTest() {
     }
 }

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/ProtegoTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/ProtegoTest.java
@@ -1,0 +1,35 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.List;
+
+/**
+ * Tests for the {@link net.pottercraft.ollivanders2.spell.PROTEGO} spell (Shield Charm).
+ *
+ * <p>PROTEGO is a self-targeting charm that applies the PROTEGO O2Effect to the caster,
+ * providing a shield that deflects spells and projectiles.</p>
+ *
+ * @author Azami7
+ */
+@Isolated
+public class ProtegoTest extends AddO2EffectTest {
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.PROTEGO;
+    }
+
+    @Override
+    boolean addsPotionEffect() {
+        return false;
+    }
+
+    @Override
+    List<PotionEffectType> getPotionEffects() {
+        return null;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/RictusempraTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/RictusempraTest.java
@@ -1,0 +1,35 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.List;
+
+/**
+ * Tests for the {@link net.pottercraft.ollivanders2.spell.RICTUSEMPRA} spell (Tickling Charm).
+ *
+ * <p>RICTUSEMPRA applies both the LAUGHING and TICKLING O2Effects to a target player,
+ * causing uncontrollable laughter and tickling.</p>
+ *
+ * @author Azami7
+ */
+@Isolated
+public class RictusempraTest extends AddO2EffectTest {
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.RICTUSEMPRA;
+    }
+
+    @Override
+    boolean addsPotionEffect() {
+        return false;
+    }
+
+    @Override
+    List<PotionEffectType> getPotionEffects() {
+        return null;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/TarantallegraTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/TarantallegraTest.java
@@ -1,0 +1,35 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.List;
+
+/**
+ * Tests for the {@link net.pottercraft.ollivanders2.spell.TARANTALLEGRA} spell (Dancing Feet Spell).
+ *
+ * <p>TARANTALLEGRA applies the DANCING_FEET O2Effect to a target player, causing their legs
+ * to spasm uncontrollably.</p>
+ *
+ * @author Azami7
+ */
+@Isolated
+public class TarantallegraTest extends AddO2EffectTest {
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.TARANTALLEGRA;
+    }
+
+    @Override
+    boolean addsPotionEffect() {
+        return false;
+    }
+
+    @Override
+    List<PotionEffectType> getPotionEffects() {
+        return null;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/TitillandoTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/TitillandoTest.java
@@ -1,0 +1,35 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.List;
+
+/**
+ * Tests for the {@link net.pottercraft.ollivanders2.spell.TITILLANDO} spell (Tickling Hex).
+ *
+ * <p>TITILLANDO applies the LAUGHING, TICKLING, and WEAKNESS O2Effects to a target player,
+ * causing uncontrollable laughter, tickling, and weakness.</p>
+ *
+ * @author Azami7
+ */
+@Isolated
+public class TitillandoTest extends AddO2EffectTest {
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.TITILLANDO;
+    }
+
+    @Override
+    boolean addsPotionEffect() {
+        return false;
+    }
+
+    @Override
+    List<PotionEffectType> getPotionEffects() {
+        return null;
+    }
+}


### PR DESCRIPTION
* rewrote Ebublio to be the bubble jinx, per HP canon
* added new spell Anapneo to replace ebublio as the bubble-head charm
* added tests for all AddO2Effect spells
* refactored ImmobilizePlayer to pull Carcerem prison functionality in to the parent for reuse by Ebublio
* updated the javadoc for several books
* fixed bug in FUMOS_DUO effect where the effect type enum was referencing FUMOS
* refactored doCheckEffect for AddO2Effect

https://github.com/Azami7/Ollivanders2/issues/491