### PR TITLE
Pack, Reparifarge, and Cuboid updates

### DIFF
--- a/.claude/skills/javadoc-writer/SKILL.md
+++ b/.claude/skills/javadoc-writer/SKILL.md
@@ -57,3 +57,19 @@ When invoked:
 5. Ensure external URLs use the `@see <a href="url">Label</a>` format
 
 For divination classes, coordinate systems, enums, and other specialized patterns, refer to the JAVADOC_STANDARDS.md file for detailed examples.
+
+## If you find a bug while writing javadoc
+
+Documenting code requires reading and understanding it, and that often surfaces real bugs — wrong conditions, off-by-one errors, dead branches, parameters used in the wrong place, etc.
+
+**When you spot a bug, report it to the user. Do NOT:**
+- Write a `// NOTE: this looks like a bug` or `// TODO: appears wrong` comment in the code and move on.
+- Quietly document the buggy behavior as if it were intentional.
+- Fabricate javadoc that papers over the broken behavior to make it sound correct.
+
+**Instead:**
+- Stop and tell the user: file path, line number, what's wrong, and the suggested fix (one line if possible).
+- Wait for direction before either editing the bug or returning to javadoc work.
+- If the user confirms it's a bug and asks you to fix it, fix the code first, then write javadoc that describes the corrected behavior.
+
+A buried `// looks like a bug` comment is worse than no comment — it tells future readers "we knew about this and shipped it anyway", which is rarely the user's actual intent.

--- a/.claude/skills/review-code/SKILL.md
+++ b/.claude/skills/review-code/SKILL.md
@@ -86,6 +86,12 @@ When reviewing source code, also find and review the corresponding test class(es
 - Verify different world coordinates are used across tests when block/entity persistence could cause interference
 - Check for use of unimplemented MockBukkit methods (e.g., `EntityMock.isUnderWater()`)
 
+## API references
+
+When you need to verify Spigot or MockBukkit API behavior (method signatures, return types, class hierarchies, snapshot vs. live semantics, etc.), consult the official javadocs via WebFetch rather than guessing:
+- Spigot: https://hub.spigotmc.org/javadocs/spigot/index.html
+- MockBukkit (v1.21): https://javadoc.io/static/org.mockbukkit.mockbukkit/mockbukkit-v1.21/4.98.0/index.html
+
 ## Output format
 
 For each issue found, report:

--- a/.claude/skills/test-code-writer/SKILL.md
+++ b/.claude/skills/test-code-writer/SKILL.md
@@ -96,6 +96,33 @@ This sacrifices coverage of the wrapped line in exchange for letting the rest of
 ### Bukkit events must be fired manually
 MockBukkit does not synthesize Bukkit events the way real Paper does — gameplay actions in a test won't automatically generate the corresponding event. To exercise an event handler, construct the event yourself, call `mockServer.getPluginManager().callEvent(event)`, then `performTicks(...)` afterward to give the handler time to run.
 
+### Observing instant or transient effects via event listeners
+Some Bukkit effects are instant — they fire once on application and are never stored in the player's active effects list. `PotionEffectType.INSTANT_HEALTH` is the canonical example: `player.hasPotionEffect(INSTANT_HEALTH)` returns `false` even immediately after `addPotionEffect(...)`, because the effect is consumed on application. MockBukkit also doesn't simulate the gameplay side-effects of effects (e.g., health changes from healing, damage from harming), so you can't observe the result either.
+
+To verify that an instant or transient effect was actually applied, register a temporary `EntityPotionEffectEvent` listener before casting the spell:
+
+```java
+AtomicBoolean effectApplied = new AtomicBoolean(false);
+mockServer.getPluginManager().registerEvents(new Listener() {
+    @EventHandler
+    public void onEffect(EntityPotionEffectEvent event) {
+        if (event.getEntity().equals(target)
+                && event.getNewEffect() != null
+                && event.getNewEffect().getType().equals(PotionEffectType.INSTANT_HEALTH)) {
+            effectApplied.set(true);
+        }
+    }
+}, testPlugin);
+
+castSpell(caster, location, targetLocation);
+mockServer.getScheduler().performTicks(20);
+assertTrue(effectApplied.get(), "INSTANT_HEALTH was not applied to target");
+```
+
+This works because MockBukkit fires `EntityPotionEffectEvent` when `addPotionEffect` is called, even for instant effects. The listener catches the event in-flight before MockBukkit discards the effect. Use `AtomicBoolean` (not a plain boolean) because the listener runs in the event dispatch context.
+
+This same pattern works for any effect or event that is difficult to observe after the fact — register a listener, let the spell run, then assert against the captured state.
+
 ### Snapshot vs live state in MockBukkit
 MockBukkit's `BlockState` snapshots can diverge from production Paper semantics for some `Container` types (notably `Chest`). When a test reads inventory state that the production code has just written, prefer re-fetching the state via `block.getState()` immediately before the assertion rather than reusing a stale snapshot reference. If a test still fails despite a fresh snapshot, suspect a MockBukkit-vs-Paper API divergence and check the API references below.
 

--- a/.claude/skills/test-code-writer/SKILL.md
+++ b/.claude/skills/test-code-writer/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: test-code-writer
+description: Use when the user asks to write, add, or improve unit tests for the Ollivanders2 project. Covers project test conventions, MockBukkit constraints, the parallel-execution model, and coverage practices.
+---
+
+# Test Code Writer Skill
+
+Write JUnit Jupiter unit tests for the Ollivanders2 project. Read the production class under test before writing tests — understand what it does, what its public surface is, and how it integrates with the surrounding system. Read at least one existing sibling test in the same package to match the project's conventions before writing anything new.
+
+## Project conventions
+
+### Test class naming
+For most production classes, the test class is `<ClassName>Test.java`. **Exception:** classes that act as implementations of an enumerated type — spells, effects, stationary spells, potions, etc. — use PascalCase based on the SCREAMING_SNAKE_CASE production name, not the raw class name. Examples:
+- `PACK.java` → `PackTest.java`
+- `WINGARDIUM_LEVIOSA.java` → `WingardiumLeviosaTest.java`
+- `ItemToItemTransfiguration.java` → `ItemToItemTransfigurationTest.java` (already PascalCase, no transform)
+
+### Test method naming
+Test methods are named `<scenarioOrAspect>Test()` — e.g. `doCheckEffectTest()`, `radiusTest()`, `upkeepTest()`, `invalidTargetTest()`. Not `test<Thing>()` and not bare camelCase verbs. The base class typically declares an abstract `doCheckEffectTest()` (or equivalent) that subclasses must implement; additional scenario tests follow the same `<aspect>Test()` shape.
+
+### Package layout
+Test packages mirror the production code package layout exactly. A class at `Ollivanders/src/net/pottercraft/ollivanders2/spell/PACK.java` has its test at `Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/PackTest.java`. The `test` segment is inserted between `ollivanders2` and the leaf package; everything below that mirrors prod.
+
+### Javadoc
+Test classes and test methods get Javadoc, same as production code. Document what the test verifies and why — not just what it does mechanically. Follow `JAVADOC_STANDARDS.md`.
+
+### Magic numbers and constants
+Any literal whose meaning isn't obvious from context needs an inline comment explaining where it comes from. Examples: `1728 // 27 slots × 64 stack depth — https://minecraft.fandom.com/wiki/Chest`, `20 // ticks per second`. Prefer a named local variable when the number is reused.
+
+### World naming
+Worlds created via `mockServer.addSimpleWorld(...)` use a short, descriptive name — typically the spell or effect name, with a scenario suffix when one test class needs several worlds. The first/canonical test in a spell test class commonly passes `getSpellType().getSpellName()`; sibling methods append a scenario tag (e.g. `"PackEnderChest"`, `"PackShulkerBox"`).
+
+## Test design
+
+### Don't hard-code production values
+Never copy a constant from production code into a test. If the test needs a value that lives in production (e.g. a spell's `maxDuration`, a radius, a cooldown), add a **copy-returning getter** to the production class and call it from the test. The production code becomes the single source of truth, and the test stays correct when the value changes.
+
+Strict rules for these getters:
+- Read-only access only. **Never** add a setter purely to satisfy a test.
+- If the value is a mutable object (List, Map, ItemStack, Location, etc.), the getter MUST return a defensive copy or unmodifiable view. A getter that hands out the live internal collection lets the test mutate production state, which is worse than the duplication it was trying to avoid.
+
+### Plugin lifecycle: `@BeforeAll` vs `@BeforeEach`
+Spell tests load the plugin once via a static `@BeforeAll` and reuse it across all methods in the class (`O2SpellTestSuper.globalSetUp`). Effect tests load a fresh plugin per method via `@BeforeEach` (`EffectTestSuper.setUp`). The split exists because effects mutate plugin-scoped state during a method, while spell tests are read-only against the plugin. When writing a new test class, match whichever base class you extend — don't reinvent the lifecycle. When designing a new base class, choose `@BeforeEach` if your category mutates plugin state, `@BeforeAll` otherwise (it's much faster).
+
+### Inheritance over duplication
+When multiple test classes share setup or assertions, push the common code up into a base class. Look at existing bases like `O2SpellTestSuper` for the pattern: shared MockBukkit lifecycle, shared `castSpell` helpers, abstract methods that subclasses must implement. New test classes should extend the appropriate base when one exists, and you should propose a new base when you see a third copy of the same setup emerging.
+
+### TestCommon for cross-cutting helpers
+Helpers that are useful across many *unrelated* test classes belong in `TestCommon` (or another `*Common` test utility), not duplicated per test. Examples: `createBlockBase`, `faceTarget`, `setPlayerSpellExperience`. Helpers that are only useful to one test class or to one test family stay local to that class or its base.
+
+### Useful existing helpers
+Before writing new fixture or assertion code, check whether one of these already exists:
+
+**Test-side utilities:**
+- **Block fixtures (`TestCommon`):** `createBlockBase(location, size)`, `createNorthSouthBlockWall(location, size)`, `createEastWestBlockWall(location, size)`. Use these instead of hand-rolled nested loops.
+- **Inventory queries (`TestCommon`):** `getPlayerInventoryItem(player, material)`, `getPlayerInventoryItem(player, material, name)`, `amountInPlayerInventory(player, material, name)`. These handle null safety and book/display-name edge cases.
+- **Chat / message handling (`TestCommon`):** `cleanChatMessage(message)` to strip color codes before assertion, `clearMessageQueue(player)` to drain pending messages before re-checking output.
+- **Wand correctness (`O2PlayerCommon`):** `rightWand`, `wrongWand`, `elderWand` constants. Pass these to `castSpell(...)` overloads instead of magic doubles when testing wand-dependent behavior.
+
+**Production `*Common` utilities — also for tests:**
+Tests can and should call the production helper classes (`Ollivanders2Common`, `EntityCommon`, `BlockCommon`, `O2PlayerCommon`, etc.) directly when they need the same logic the production code uses. Don't reimplement entity radius scans, block adjacency checks, distance math, player metadata lookups, etc. — find the existing helper first. If a test needs to assert "the spell affected the right entities", the most accurate check is usually "compare against what `EntityCommon.getEntitiesInRadius(...)` returns at the same location and radius". Reimplementing the logic in the test risks the test agreeing with itself but disagreeing with prod.
+
+### Coverage targets
+Aim for high line coverage of meaningful behavior. Skip:
+- Trivial getters and setters that just read/write a field with no logic.
+- Generated code, enum boilerplate.
+
+Always cover:
+- Happy paths.
+- Branch boundaries (off-by-one, min/max clamps, empty collections, null inputs where allowed).
+- Failure paths the production code is expected to handle gracefully.
+
+## MockBukkit constraints
+
+### Parallel execution + shared game state
+JUnit Jupiter runs test methods in parallel by default. MockBukkit's `ServerMock` is a shared static instance across the methods of a test class (set up in `@BeforeAll`), and the world/entity/scheduler state inside it is **global**. If two parallel test methods both mutate that shared state — spawning entities, changing blocks, casting spells, advancing the scheduler — they will interfere with each other in nondeterministic ways.
+
+**Rule:** any sequence of operations that depends on a specific state evolution must live inside a **single** `@Test` method, not split across methods. Use sub-sections within one method (with comments delimiting them) when you need multiple scenarios that share state assumptions. Splitting only makes sense when the scenarios are genuinely independent (different worlds, different players, no overlap).
+
+When in doubt, keep related scenarios together. The `doCheckEffectTest` pattern in the existing spell tests is the canonical example.
+
+### Wrapping unimplemented MockBukkit methods
+Some Bukkit/Paper APIs are not implemented in MockBukkit and will throw `UnimplementedOperationException` (or similar) if called from a test. Examples seen so far: `World.createExplosion`, certain entity state queries.
+
+When production code needs to call one of these, wrap the call so it's skipped under test:
+
+```java
+if (!Ollivanders2.testMode)
+    world.createExplosion(location, power);
+```
+
+This sacrifices coverage of the wrapped line in exchange for letting the rest of the method be tested. Keep the wrapped block as small as possible — only the actually-unimplemented call goes inside the guard, not the surrounding logic.
+
+`Ollivanders2.testMode` is set to `true` in the `@BeforeAll` of `O2SpellTestSuper` (and equivalents). Production never sets it.
+
+### Bukkit events must be fired manually
+MockBukkit does not synthesize Bukkit events the way real Paper does — gameplay actions in a test won't automatically generate the corresponding event. To exercise an event handler, construct the event yourself, call `mockServer.getPluginManager().callEvent(event)`, then `performTicks(...)` afterward to give the handler time to run.
+
+### Snapshot vs live state in MockBukkit
+MockBukkit's `BlockState` snapshots can diverge from production Paper semantics for some `Container` types (notably `Chest`). When a test reads inventory state that the production code has just written, prefer re-fetching the state via `block.getState()` immediately before the assertion rather than reusing a stale snapshot reference. If a test still fails despite a fresh snapshot, suspect a MockBukkit-vs-Paper API divergence and check the API references below.
+
+## API references
+
+You are pre-authorized to read the local Spigot Javadoc for any read-only operation (Read, Glob, Grep, Bash with grep/cat/find — not modifications). It lives at:
+
+```
+/Users/kristin/minecraft/spigot javadoc/index.html
+```
+
+Class pages follow the standard javadoc layout: `org/bukkit/block/Chest.html`, `org/bukkit/inventory/Inventory.html`, etc. Use Read or Grep against these files when you need to verify a method signature, return type, class hierarchy, or snapshot/live semantics — do **not** guess at the API. Note that `WebFetch` does not accept `file://` URLs; use Read or Bash for local files.
+
+For MockBukkit-specific behavior, the published javadocs are at:
+- https://javadoc.io/static/org.mockbukkit.mockbukkit/mockbukkit-v1.21/4.98.0/index.html
+
+## Workflow
+
+1. Read the production class under test.
+2. Read the most-similar existing test class to match conventions.
+3. Identify the abstract base test class to extend (if any).
+4. Identify any existing `TestCommon` helpers you can reuse.
+5. Identify any production values you'll need — add copy-returning getters first if they don't exist.
+6. Write the test, grouping state-dependent scenarios into single methods.
+7. Run only the affected test class first (`./gradlew test --tests <FQCN>`) to get fast feedback.
+8. Run the full test suite once everything passes locally.

--- a/Ollivanders/src/net/pottercraft/ollivanders2/common/Cuboid.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/common/Cuboid.java
@@ -98,8 +98,7 @@ public class Cuboid {
 
         if ((x1 > x2 && x <= x1 && x >= x2) || (x1 < x2 && x >= x1 && x <= x2)) {
             if ((y1 > y2 && y <= y1 && y >= y2) || (y1 < y2 && y >= y1 && y <= y2)) {
-                // NOTE: The second condition uses 'x >= z1' which appears to be a bug - should be 'z >= z1'
-                if ((z1 > z2 && z <= z1 && z >= z2) || (z1 < z2 && x >= z1 && z <= z2)) {
+                if ((z1 > z2 && z <= z1 && z >= z2) || (z1 < z2 && z >= z1 && z <= z2)) {
                     return true;
                 }
                 else {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/common/Ollivanders2Common.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/common/Ollivanders2Common.java
@@ -20,6 +20,7 @@ import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
+import org.bukkit.Tag;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.LivingEntity;
@@ -239,34 +240,31 @@ public class Ollivanders2Common {
         if (chestBlocks.isEmpty()) {
             chestBlocks.add(Material.CHEST); // special case, we don't want to use the regex "CHEST" in case some future block could match that but not be a chest (like "richest")
             chestBlocks.addAll(getAllMaterialsThatEndWith("_CHEST"));
-            chestBlocks.addAll(getAllMaterialsThatEndWith("_SHULKER_BOX"));
+            chestBlocks.addAll(Tag.SHULKER_BOXES.getValues());
         }
 
         if (wallSigns.isEmpty()) {
-            wallSigns.addAll(getAllMaterialsThatEndWith("_WALL_SIGN"));
+            wallSigns.addAll(Tag.WALL_SIGNS.getValues());
         }
 
         if (hangingSigns.isEmpty()) {
-            hangingSigns.addAll(getAllMaterialsThatEndWith("_HANGING_SIGN"));
+            hangingSigns.addAll(Tag.ALL_HANGING_SIGNS.getValues());
         }
 
         if (standingSigns.isEmpty()) {
-            for (Material sign : getAllMaterialsThatEndWith("_SIGN")) {
-                if (!wallSigns.contains(sign) && !hangingSigns.contains(sign))
-                    standingSigns.add(sign);
-            }
+            standingSigns.addAll(Tag.STANDING_SIGNS.getValues());
         }
 
         if (trapdoors.isEmpty()) {
-            trapdoors.addAll(getAllMaterialsThatEndWith("_TRAPDOOR"));
+            trapdoors.addAll(Tag.TRAPDOORS.getValues());
         }
 
         if (gates.isEmpty()) {
-            gates.addAll(getAllMaterialsThatEndWith("_FENCE_GATE"));
+            gates.addAll(Tag.FENCE_GATES.getValues());
         }
 
         if (doors.isEmpty()) {
-            doors.addAll(getAllMaterialsThatEndWith("_DOOR"));
+            doors.addAll(Tag.DOORS.getValues());
         }
 
         if (naturalLogs.isEmpty()) {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/ABERTO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/ABERTO.java
@@ -80,7 +80,7 @@ public class ABERTO extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (!hasHitTarget())
+        if (!hasHitBlock())
             return;
 
         kill();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/AGUAMENTI.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/AGUAMENTI.java
@@ -196,7 +196,7 @@ public final class AGUAMENTI extends BlockTransfiguration {
     @Override
     @Nullable
     public Block getTargetBlock() {
-        if (hasHitTarget()) {
+        if (hasHitBlock()) {
             // we want to target block before this block
             return location.clone().subtract(super.vector).getBlock();
         }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/ALIQUAM_FLOO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/ALIQUAM_FLOO.java
@@ -85,7 +85,7 @@ public final class ALIQUAM_FLOO extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (!hasHitTarget())
+        if (!hasHitBlock())
             return;
 
         Block target = getTargetBlock();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/ALOHOMORA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/ALOHOMORA.java
@@ -74,7 +74,7 @@ public final class ALOHOMORA extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
         // check all the stationary spells in the location of the projectile for a Colloportus

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/APARECIUM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/APARECIUM.java
@@ -72,7 +72,7 @@ public final class APARECIUM extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (hasHitTarget()) {
+        if (hasHitBlock()) {
             kill();
             return;
         }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/AQUA_ERUCTO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/AQUA_ERUCTO.java
@@ -96,7 +96,7 @@ public class AQUA_ERUCTO extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (!hasHitTarget()) {
+        if (!hasHitBlock()) {
             for (Entity entity : getNearbyEntities(1.5)) {
                 if (entity.getUniqueId().equals(caster.getUniqueId())) // don't target the caster
                     continue;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/ARRESTO_MOMENTUM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/ARRESTO_MOMENTUM.java
@@ -81,7 +81,7 @@ public final class ARRESTO_MOMENTUM extends O2Spell {
     @Override
     protected void doCheckEffect() {
         // if the spell has hit a solid block, the projectile is dead and won't go further so kill the spell
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
         Entity target = null;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/AVADA_KEDAVRA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/AVADA_KEDAVRA.java
@@ -70,7 +70,7 @@ public final class AVADA_KEDAVRA extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
         List<Damageable> entities = getNearbyDamageableEntities(defaultRadius);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/AddO2Effect.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/AddO2Effect.java
@@ -125,7 +125,7 @@ public abstract class AddO2Effect extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
         int targets = 0;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/AddPotionEffect.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/AddPotionEffect.java
@@ -128,7 +128,7 @@ public abstract class AddPotionEffect extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (hasHitTarget() || noProjectile)
+        if (hasHitBlock() || noProjectile)
             kill();
 
         affectRadius();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/BRACKIUM_EMENDO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/BRACKIUM_EMENDO.java
@@ -118,7 +118,7 @@ public final class BRACKIUM_EMENDO extends O2Spell {
         }
 
         // projectile has stopped, kill the spell
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/BlockTransfiguration.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/BlockTransfiguration.java
@@ -172,7 +172,7 @@ public abstract class BlockTransfiguration extends Transfiguration {
      * <p>If no blocks are successfully transfigured, the spell fails and is killed.</p>
      */
     protected void transfigure() {
-        if (isTransfigured || isKilled() || !hasHitTarget() || getTargetBlock() == null)
+        if (isTransfigured || isKilled() || !hasHitBlock() || getTargetBlock() == null)
             return;
 
         // set the spell affect radius

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/BombardaBase.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/BombardaBase.java
@@ -113,7 +113,7 @@ public abstract class BombardaBase extends O2Spell {
      * <p>Only breaks blocks that pass the {@code canBreak()} validation.</p>
      */
     protected void doCheckEffect() {
-        if (hasHitTarget()) {
+        if (hasHitBlock()) {
             calculateEffectRadius();
 
             // play explosion particle and sound

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/CISTERN_APERIO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/CISTERN_APERIO.java
@@ -65,7 +65,7 @@ public class CISTERN_APERIO extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (!hasHitTarget())
+        if (!hasHitBlock())
             return;
 
         kill();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/CRESCERE_PROTEGAT.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/CRESCERE_PROTEGAT.java
@@ -84,7 +84,7 @@ public final class CRESCERE_PROTEGAT extends O2Spell {
     @Override
     protected void doCheckEffect() {
         // projectile has stopped, kill the spell
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
         O2StationarySpell targetSpell = null;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/ChangeColorable.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/ChangeColorable.java
@@ -81,7 +81,7 @@ public abstract class ChangeColorable extends O2Spell {
             if (!changed)
                 sendFailureMessage();
         }
-        else if (hasHitTarget()) {
+        else if (hasHitBlock()) {
             kill();
 
             Block target = getTargetBlock();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/ChangeEntitySize.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/ChangeEntitySize.java
@@ -99,7 +99,7 @@ public abstract class ChangeEntitySize extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (hasHitTarget()) {
+        if (hasHitBlock()) {
             kill();
             return;
         }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/DEFODIO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/DEFODIO.java
@@ -104,7 +104,7 @@ public final class DEFODIO extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (!hasHitTarget())
+        if (!hasHitBlock())
             return;
 
         // use cooldown to slow defodio to 4 blocks per second

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/DELETRIUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/DELETRIUS.java
@@ -81,7 +81,7 @@ public final class DELETRIUS extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
         // look for area effect clouds

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/DEPRIMO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/DEPRIMO.java
@@ -99,7 +99,7 @@ public final class DEPRIMO extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (!hasHitTarget())
+        if (!hasHitBlock())
             return;
 
         List<Block> nearbyBlocks = BlockCommon.getBlocksInRadius(location, radius);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/DIFFINDO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/DIFFINDO.java
@@ -74,7 +74,7 @@ public final class DIFFINDO extends O2Spell {
         splitBackpack();
 
         // next check for log
-        if (hasHitTarget() && !isKilled()) {
+        if (hasHitBlock() && !isKilled()) {
             splitLogs();
             kill();
         }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/DISSENDIUM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/DISSENDIUM.java
@@ -86,7 +86,7 @@ public final class DISSENDIUM extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (!hasHitTarget())
+        if (!hasHitBlock())
             return;
 
         // continue until the spell opens a trapdoor, hits another block type and is killed, or projectile expires

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/ET_INTERFICIAM_ANIMAM_LIGAVERIS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/ET_INTERFICIAM_ANIMAM_LIGAVERIS.java
@@ -70,7 +70,7 @@ public final class ET_INTERFICIAM_ANIMAM_LIGAVERIS extends O2Spell {
     @Override
     protected void doCheckEffect() {
         // if we hit a target but didn't find an item, then end this spell
-        if (hasHitTarget()) {
+        if (hasHitBlock()) {
             kill();
             return;
         }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/EXPELLIARMUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/EXPELLIARMUS.java
@@ -133,7 +133,7 @@ public final class EXPELLIARMUS extends O2Spell {
         }
 
         // projectile has stopped, kill the spell
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/FIENDFYRE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/FIENDFYRE.java
@@ -102,7 +102,7 @@ public final class FIENDFYRE extends O2Spell
         }
 
         // spawn magmacubes, blazes, and ghasts
-        if (!isKilled() && hasHitTarget())
+        if (!isKilled() && hasHitBlock())
         {
             location.subtract(vector);
             spawnCreatures();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/FINESTRA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/FINESTRA.java
@@ -84,7 +84,7 @@ public final class FINESTRA extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (!hasHitTarget())
+        if (!hasHitBlock())
             return;
 
         kill();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/FINITE_INCANTATEM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/FINITE_INCANTATEM.java
@@ -93,7 +93,7 @@ public final class FINITE_INCANTATEM extends O2Spell {
             finiteIncantatemItems();
 
         // projectile has stopped, kill the spell
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
     }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/FRANGE_LIGNEA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/FRANGE_LIGNEA.java
@@ -78,7 +78,7 @@ public final class FRANGE_LIGNEA extends O2Spell {
     @Override
     protected void doCheckEffect() {
         // projectile has stopped, kill the spell
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
         Block target = getTargetBlock();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/Galeati.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/Galeati.java
@@ -11,13 +11,28 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 /**
- * Sets a player's helmet to a specific block type.
+ * Abstract base class for spells that replace a player's helmet with a specific block type.
  * <p>
- * In HP, these would be Transfiguration spells but for code purposes they behave like charm projectiles, so we
- * extend Charms then override the spell type.
+ * Galeati spells use the entity-scanning projectile model: each tick the projectile scans for
+ * nearby players within {@link #defaultRadius}. The first non-caster player found has their
+ * current helmet dropped at their eye location (if non-AIR) and replaced with a new
+ * {@link ItemStack} of {@link #helmetType}. Subclasses set {@code helmetType} in their
+ * casting constructor to control what block the target wears.
+ * </p>
+ * <p>
+ * In Harry Potter lore these would be Transfiguration spells, but for code purposes they
+ * behave like charm projectiles and set {@code branch} to {@link net.pottercraft.ollivanders2.O2MagicBranch#CHARMS}.
+ * </p>
+ *
+ * @see MELOFORS
+ * @see HERBIFORS
  */
 public abstract class Galeati extends O2Spell {
-    Material materialType = Material.AIR;
+    /**
+     * The material placed on the target player's head. Defaults to {@link Material#AIR};
+     * subclasses override this in their casting constructor.
+     */
+    protected Material helmetType = Material.AIR;
 
     /**
      * Default constructor for use in generating spell text.  Do not use to cast the spell.
@@ -40,12 +55,22 @@ public abstract class Galeati extends O2Spell {
     }
 
     /**
-     * Targets a player in radius of the projectile and changes their helmet.
+     * Scan for a nearby player and replace their helmet with {@link #helmetType}.
+     * <p>
+     * Each tick, the method scans within {@link #defaultRadius} for players. The caster is
+     * skipped. The first non-caster player found has their current helmet (if any and non-AIR)
+     * dropped as an item at their eye location, then replaced with a new item of
+     * {@code helmetType}. The spell is then killed (single-target).
+     * </p>
+     * <p>
+     * If the projectile hits a block before finding a player, the spell is killed and returns
+     * silently.
+     * </p>
      */
     @Override
     protected void doCheckEffect() {
         // projectile has stopped, kill the spell
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
         List<Player> livingEntities = getNearbyPlayers(defaultRadius);
@@ -56,9 +81,7 @@ public abstract class Galeati extends O2Spell {
 
             EntityEquipment entityEquipment = target.getEquipment();
             if (entityEquipment == null) {
-                // they have no equipment
-                kill();
-                return;
+                continue;
             }
 
             ItemStack helmet = entityEquipment.getHelmet();
@@ -66,9 +89,19 @@ public abstract class Galeati extends O2Spell {
                 if (helmet.getType() != Material.AIR)
                     target.getWorld().dropItem(target.getEyeLocation(), helmet);
             }
-            entityEquipment.setHelmet(new ItemStack(materialType, 1));
+
+            entityEquipment.setHelmet(new ItemStack(helmetType, 1));
             kill();
             return;
         }
+    }
+
+    /**
+     * Get the material type that this spell places on the target's head.
+     *
+     * @return the helmet material
+     */
+    public Material getHelmetType() {
+        return helmetType;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/HARMONIA_NECTERE_PASSUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/HARMONIA_NECTERE_PASSUS.java
@@ -108,7 +108,7 @@ public final class HARMONIA_NECTERE_PASSUS extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (!hasHitTarget())
+        if (!hasHitBlock())
             return;
 
         kill();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/HERBIFORS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/HERBIFORS.java
@@ -1,6 +1,7 @@
 package net.pottercraft.ollivanders2.spell;
 
-import net.pottercraft.ollivanders2.*;
+import net.pottercraft.ollivanders2.O2MagicBranch;
+import net.pottercraft.ollivanders2.Ollivanders2;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -8,12 +9,12 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 
 /**
- * This spell places a flower on the target player's head.
+ * Places a flower ({@link org.bukkit.Material#DANDELION}) on the target player's head.
  *
  * @author lownes
  * @author Azami7
- * @version Ollivanders2
- * @see <a href = "https://harrypotter.fandom.com/wiki/Herbifors">https://harrypotter.fandom.com/wiki/Herbifors</a>
+ * @see Galeati
+ * @see <a href="https://harrypotter.fandom.com/wiki/Herbifors">Herbifors Spell</a>
  */
 public final class HERBIFORS extends Galeati {
     /**
@@ -47,7 +48,7 @@ public final class HERBIFORS extends Galeati {
         spellType = O2SpellType.HERBIFORS;
         branch = O2MagicBranch.CHARMS;
 
-        materialType = Material.DANDELION;
+        helmetType = Material.DANDELION;
 
         initSpell();
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/HERBIVICUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/HERBIVICUS.java
@@ -97,7 +97,7 @@ public final class HERBIVICUS extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (!hasHitTarget())
+        if (!hasHitBlock())
             return;
 
         for (Block block : BlockCommon.getBlocksInRadius(location, radius)) {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/HORREAT_PROTEGAT.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/HORREAT_PROTEGAT.java
@@ -75,7 +75,7 @@ public final class HORREAT_PROTEGAT extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (!hasHitTarget())
+        if (!hasHitBlock())
             return;
 
         List<O2StationarySpell> shieldSpells = new ArrayList<>();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/INFORMOUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/INFORMOUS.java
@@ -81,7 +81,7 @@ public final class INFORMOUS extends O2Spell {
             gaveInfo = true;
         }
 
-        if (!gaveInfo && hasHitTarget()) {
+        if (!gaveInfo && hasHitBlock()) {
             // check for stationary spells near the projectile hit location. We use our own search radius
             // rather than the stationary spell's radius because some spells (e.g., vanishing cabinets) have
             // a radius too small for a projectile to land inside from outside the structure.
@@ -115,7 +115,7 @@ public final class INFORMOUS extends O2Spell {
             }
         }
 
-        if (gaveInfo || hasHitTarget()) // stop the spell if we hit a target or gave info about an entity
+        if (gaveInfo || hasHitBlock()) // stop the spell if we hit a target or gave info about an entity
             kill();
     }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/ImmobilizePlayer.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/ImmobilizePlayer.java
@@ -121,7 +121,7 @@ abstract public class ImmobilizePlayer extends O2Spell {
     @Override
     protected void doCheckEffect() {
         // projectile has stopped, kill the spell
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
         for (Player target : getNearbyPlayers(defaultRadius)) {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/IncendioBase.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/IncendioBase.java
@@ -157,12 +157,12 @@ public abstract class IncendioBase extends O2Spell {
      * the calculated burn duration. If so, the spell is killed, allowing the {@link #revert()} method to
      * clean up any temporarily changed blocks.</p>
      *
-     * <p>The spell requires a valid target block ({@link #hasHitTarget()}) to function. If the projectile
+     * <p>The spell requires a valid target block ({@link #hasHitBlock()}) to function. If the projectile
      * has not hit a target or the target block is null, the spell is killed immediately.</p>
      */
     @Override
     protected void doCheckEffect() {
-        if (!hasHitTarget())
+        if (!hasHitBlock())
             return;
 
         if (burning) {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/ItemEnchant.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/ItemEnchant.java
@@ -151,7 +151,7 @@ public abstract class ItemEnchant extends O2Spell {
             return;
         }
 
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
         List<Item> items = getNearbyItems(defaultRadius);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/Knockback.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/Knockback.java
@@ -100,7 +100,7 @@ public abstract class Knockback extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (hasHitTarget() || targetsSelf) // projectile is stopped so we'll check this location then exit the spell
+        if (hasHitBlock() || targetsSelf) // projectile is stopped so we'll check this location then exit the spell
             kill();
 
         //

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/LIGATIS_COR.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/LIGATIS_COR.java
@@ -67,7 +67,7 @@ public final class LIGATIS_COR extends O2Spell {
     @Override
     protected void doCheckEffect() {
         // projectile has stopped, kill the spell
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
         Item corelessWand = null;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/LUMOS_DUO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/LUMOS_DUO.java
@@ -129,7 +129,7 @@ public final class LUMOS_DUO extends O2Spell {
         if (getAge() < 2)
             return;
 
-        if (!hasHitTarget()) {
+        if (!hasHitBlock()) {
             if (lineLength < maxLineLength) {
                 Block currentBlock = location.getBlock();
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/MELOFORS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/MELOFORS.java
@@ -10,13 +10,17 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 
 /**
- * Encases target's head in a melon
+ * Encases the target player's head in a randomly selected melon or pumpkin block.
  *
  * @author lownes
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/Pumpkin-Head_Jinx">https://harrypotter.fandom.com/wiki/Pumpkin-Head_Jinx</a>
+ * @see Galeati
+ * @see <a href="https://harrypotter.fandom.com/wiki/Pumpkin-Head_Jinx">Pumpkin-Head Jinx</a>
  */
 public final class MELOFORS extends Galeati {
+    /**
+     * The pool of melon/pumpkin materials that the spell randomly selects from when cast.
+     */
     static Material[] melons = {
             Material.MELON,
             Material.JACK_O_LANTERN,
@@ -55,7 +59,7 @@ public final class MELOFORS extends Galeati {
         spellType = O2SpellType.MELOFORS;
         branch = O2MagicBranch.CHARMS;
 
-        materialType = melons[Math.abs(Ollivanders2Common.random.nextInt() % melons.length)];
+        helmetType = melons[Math.abs(Ollivanders2Common.random.nextInt() % melons.length)];
 
         initSpell();
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/MULTICORFORS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/MULTICORFORS.java
@@ -1,6 +1,7 @@
 package net.pottercraft.ollivanders2.spell;
 
 import net.pottercraft.ollivanders2.O2MagicBranch;
+import net.pottercraft.ollivanders2.common.O2Color;
 import org.bukkit.Color;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -11,12 +12,27 @@ import org.bukkit.inventory.meta.LeatherArmorMeta;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
+
 /**
- * If an entity has leather armor on, then this changes its color.
+ * Multicorfors changes the color of leather armor worn by a nearby entity.
+ * <p>
+ * Unlike block-targeting spells, Multicorfors scans for living entities along the projectile's
+ * path each tick. The first non-caster entity with leather armor gets all its leather pieces
+ * recolored to the same random dyeable color (via {@link O2Color#getRandomDyeableColor()}).
+ * If the projectile reaches a non-caster entity that has no leather armor, or no equipment at
+ * all, the spell is killed and a failure message is sent to the caster.
+ * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Multicorfors_Spell">https://harrypotter.fandom.com/wiki/Multicorfors_Spell</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Multicorfors_Spell">Multicorfors Spell</a>
  */
 public final class MULTICORFORS extends O2Spell {
+    /**
+     * The color applied to the target's leather armor on the most recent successful cast.
+     * Defaults to {@link Color#WHITE} before any armor is colored.
+     */
+    private Color color = Color.WHITE;
+
     /**
      * Default constructor for use in generating spell text. Do not use to cast the spell.
      *
@@ -49,39 +65,77 @@ public final class MULTICORFORS extends O2Spell {
     }
 
     /**
-     * Look for entities with armor we can change the color of and change it.
+     * Scan for nearby living entities and recolor the first one's leather armor.
+     * <p>
+     * Each tick, the method scans within {@link #defaultRadius} of the projectile for living
+     * entities. The caster is always skipped. When a non-caster entity is found, the spell is
+     * killed and the entity's armor is inspected:
+     * </p>
+     * <ul>
+     * <li>If any piece is leather armor, all leather pieces are recolored to the same random
+     *     dyeable color, the modified armor array is written back via
+     *     {@link org.bukkit.inventory.EntityEquipment#setArmorContents(ItemStack[])}, and the
+     *     loop breaks (single-target).</li>
+     * <li>If no leather armor is found on any non-caster entity in the scan, a failure message
+     *     is sent to the caster.</li>
+     * </ul>
+     * <p>
+     * If the projectile hits a block before finding an entity, the spell is killed and returns
+     * silently (no failure message).
+     * </p>
      */
+    @Override
     protected void doCheckEffect() {
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
-        for (LivingEntity live : getNearbyLivingEntities(defaultRadius)) {
-            if (live.getUniqueId().equals(caster.getUniqueId()))
+        List<LivingEntity> nearbyLivingEntities = getNearbyLivingEntities(defaultRadius);
+
+        if (nearbyLivingEntities.isEmpty())
+            return;
+
+        boolean colored = false;
+        for (LivingEntity livingEntity : nearbyLivingEntities) {
+            if (livingEntity.getUniqueId().equals(caster.getUniqueId()))
                 continue;
 
-            EntityEquipment equipment = live.getEquipment();
-            if (equipment == null) {
-                // they have no equipment
-                kill();
-                return;
-            }
+            kill();
 
-            for (ItemStack armor : equipment.getArmorContents()) {
-                if (armor.getItemMeta() instanceof LeatherArmorMeta) {
-                    LeatherArmorMeta meta = (LeatherArmorMeta) armor.getItemMeta();
-                    Color curColor = meta.getColor();
-                    int modifier = (int) (Math.random() * usesModifier * 40);
-                    modifier = modifier - modifier / 2;
-                    int blue = (curColor.getBlue() + modifier) % 256;
-                    int green = (curColor.getGreen() + modifier) % 256;
-                    int red = (curColor.getRed() + modifier) % 256;
-                    Color newColor = Color.fromRGB(red, green, blue);
-                    meta.setColor(newColor);
-                    armor.setItemMeta(meta);
+            EntityEquipment equipment = livingEntity.getEquipment();
+            if (equipment == null)
+                continue;
 
-                    kill();
+            color = O2Color.getRandomDyeableColor().getBukkitColor();
+
+            // getArmorContents() returns a copy — modify in place then write back
+            ItemStack[] armorContents = equipment.getArmorContents();
+
+            for (ItemStack armor : armorContents) {
+                if (armor != null && armor.getItemMeta() instanceof LeatherArmorMeta leatherArmorMeta) {
+                    leatherArmorMeta.setColor(color);
+                    armor.setItemMeta(leatherArmorMeta);
+
+                    colored = true;
                 }
             }
+
+            if (colored) {
+                equipment.setArmorContents(armorContents);
+                break;
+            }
         }
+
+        if (!colored && isKilled())
+            sendFailureMessage();
+    }
+
+    /**
+     * Get the color applied to the target's leather armor on the most recent successful cast.
+     * Returns {@link Color#WHITE} if the spell has not yet colored any armor.
+     *
+     * @return the color applied, or WHITE if no armor was colored
+     */
+    public Color getColor() {
+       return color;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spell.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/O2Spell.java
@@ -157,7 +157,7 @@ public abstract class O2Spell {
     /**
      * Whether the projectile has hit a target
      */
-    private boolean hitTarget = false;
+    private boolean hasHitBlock = false;
 
     /**
      * Does this spell do a spell projectile or not. Generally spells will send a projectile but any spell that targets
@@ -397,7 +397,7 @@ public abstract class O2Spell {
      */
     public void move() {
         // if this is somehow called when the spell is set to killed, or we've already hit a target, do nothing
-        if (isKilled() || hasHitTarget())
+        if (isKilled() || hasHitBlock())
             return;
 
         // if this spell should not do a projectile, stop the projectile and return from move
@@ -456,7 +456,7 @@ public abstract class O2Spell {
      */
     private void checkTargetBlock() {
         // if this is somehow called before we've hit a target, do nothing
-        if (!hasHitTarget())
+        if (!hasHitBlock())
             return;
 
         Block target = location.getBlock();
@@ -688,7 +688,7 @@ public abstract class O2Spell {
      */
     @Nullable
     public Block getTargetBlock() {
-        if (hitTarget)
+        if (hasHitBlock)
             return location.getBlock();
         else
             return null;
@@ -737,24 +737,24 @@ public abstract class O2Spell {
     }
 
     /**
-     * Stops the spell projectile from moving further and marks it as having hit a target.
+     * Stops the spell projectile from moving further and marks it as having hit a non pass-through block.
      *
-     * <p>Sets {@link #hitTarget} to true only if the projectile has not already exceeded max distance.
+     * <p>Sets {@link #hasHitBlock} to true only if the projectile has not already exceeded max distance.
      * This prevents marking as "hit target" when the spell is killed due to reaching max distance.</p>
      */
     void stopProjectile() {
         if (!isAtMaxDistance()) {
-            hitTarget = true;
+            hasHitBlock = true;
         }
     }
 
     /**
-     * Whether this spell has hit a target
+     * Whether this spell has hit a non pass-though block and the projectile is stopped
      *
-     * @return true if the spell has hit a target, false otherwise
+     * @return true if the spell has hit a non pass-though block and the projectile is stopped, false otherwise
      */
-    public boolean hasHitTarget() {
-        return hitTarget;
+    public boolean hasHitBlock() {
+        return hasHitBlock;
     }
 
     /**

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/OBLIVIATE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/OBLIVIATE.java
@@ -68,7 +68,7 @@ public final class OBLIVIATE extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
         for (Player target : getNearbyPlayers(defaultRadius)) {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/OPPUGNO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/OPPUGNO.java
@@ -100,7 +100,7 @@ public final class OPPUGNO extends O2Spell {
         }
 
         if (target != null) {
-            if (hasHitTarget())
+            if (hasHitBlock())
                 kill();
 
             // get an entity to attack the target

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/PACK.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/PACK.java
@@ -119,7 +119,7 @@ public final class PACK extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (!hasHitTarget())
+        if (!hasHitBlock())
             return;
 
         kill();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/PACK.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/PACK.java
@@ -4,7 +4,9 @@ import com.sk89q.worldguard.protection.flags.Flags;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.common.EntityCommon;
 import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.bukkit.block.Block;
+import org.bukkit.block.Chest;
 import org.bukkit.block.ShulkerBox;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
@@ -18,9 +20,16 @@ import java.util.HashMap;
 import java.util.List;
 
 /**
- * Pack is the incantation of a spell used to make items pack themselves into a trunk.
+ * Packing Charm — when cast at a chest, ender chest, or shulker box, sucks any nearby items into it.
+ * <p>
+ * The radius of items collected scales with caster experience (see {@link #doInitSpell()}). Items that
+ * fit are added to the target container's inventory and removed from the world; items that overflow
+ * have their stack reduced to the leftover amount and remain dropped in the world. For ender chest
+ * targets, items are routed into the caster's personal ender chest inventory rather than into the
+ * targeted block.
+ * </p>
  *
- * @see <a href = "https://harrypotter.fandom.com/wiki/Pack_Charm">https://harrypotter.fandom.com/wiki/Pack_Charm</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Pack_Charm">Pack Charm</a>
  */
 public final class PACK extends O2Spell {
     /**
@@ -47,7 +56,7 @@ public final class PACK extends O2Spell {
             add("The Packing Charm");
         }};
 
-        text = "When cast at an ender chest or shulker box, it will suck any items nearby into it.";
+        text = "When cast at a chest or shulker box, it will suck any items nearby into it.";
     }
 
     /**
@@ -67,33 +76,20 @@ public final class PACK extends O2Spell {
         if (Ollivanders2.worldGuardEnabled)
             worldGuardFlags.add(Flags.CHEST_ACCESS);
 
-        // only allow targeting ender chests and shulker boxes - aka "magic" chests
+        // only allow targeting chests and shulker boxes
+        materialAllowList.add(Material.CHEST);
+        materialAllowList.add(Material.TRAPPED_CHEST);
         materialAllowList.add(Material.ENDER_CHEST);
-        materialAllowList.add(Material.WHITE_SHULKER_BOX);
-        materialAllowList.add(Material.BLACK_SHULKER_BOX);
-        materialAllowList.add(Material.BLUE_SHULKER_BOX);
-        materialAllowList.add(Material.SHULKER_BOX);
-        materialAllowList.add(Material.BROWN_SHULKER_BOX);
-        materialAllowList.add(Material.CYAN_SHULKER_BOX);
-        materialAllowList.add(Material.GRAY_SHULKER_BOX);
-        materialAllowList.add(Material.GREEN_SHULKER_BOX);
-        materialAllowList.add(Material.LIGHT_BLUE_SHULKER_BOX);
-        materialAllowList.add(Material.LIGHT_GRAY_SHULKER_BOX);
-        materialAllowList.add(Material.LIME_SHULKER_BOX);
-        materialAllowList.add(Material.MAGENTA_SHULKER_BOX);
-        materialAllowList.add(Material.ORANGE_SHULKER_BOX);
-        materialAllowList.add(Material.PINK_SHULKER_BOX);
-        materialAllowList.add(Material.PURPLE_SHULKER_BOX);
-        materialAllowList.add(Material.RED_SHULKER_BOX);
-        materialAllowList.add(Material.YELLOW_SHULKER_BOX);
+        materialAllowList.addAll(Tag.SHULKER_BOXES.getValues());
 
-        materialBlockedList.removeAll(materialAllowList); // remove these unbreakables for this spell only
+        // chests and shulker boxes are normally on the projectile blocked-target list — allow them for this spell
+        materialBlockedList.removeAll(materialAllowList);
 
         initSpell();
     }
 
     /**
-     * Set the radius based on the caster's skill
+     * Set the radius based on the caster's skill, clamped to the {@link #minRadius}–{@link #maxRadius} range.
      */
     @Override
     void doInitSpell() {
@@ -106,7 +102,20 @@ public final class PACK extends O2Spell {
     }
 
     /**
-     * Find a nearby shulker box or ender chest and put any nearby items in to it
+     * On projectile impact with a valid container, scoop nearby items into that container.
+     * <p>
+     * Iterates over all item entities within {@link #radius} of the projectile's impact point and adds
+     * each to the target container's inventory. The destination depends on the target block type:
+     * </p>
+     * <ul>
+     * <li>{@code ENDER_CHEST} — items go into the caster's personal ender chest inventory, not the block.</li>
+     * <li>Any shulker box variant — items go into that shulker box's block inventory.</li>
+     * <li>{@code CHEST} / {@code TRAPPED_CHEST} — items go into that chest's block inventory.</li>
+     * </ul>
+     * <p>
+     * Items that fit completely are removed from the world. Items that don't fully fit have their stack
+     * size reduced to the leftover amount and remain dropped in the world.
+     * </p>
      */
     @Override
     protected void doCheckEffect() {
@@ -119,19 +128,34 @@ public final class PACK extends O2Spell {
         // get nearby items
         List<Item> nearbyItems = EntityCommon.getItemsInRadius(location, radius);
 
+        Block targetBlock = getTargetBlock();
+        if (targetBlock == null) {
+            common.printDebugMessage("PACK.doCheckEffect: target block is null", null, null, false);
+            return;
+        }
+
         for (Item item : nearbyItems) {
-            common.printDebugMessage("Adding " + item.getName() + " to chest", null, null, false);
+            common.printDebugMessage("Adding " + item.getItemStack().getType().name() + " to chest", null, null, false);
 
             HashMap<Integer, ItemStack> overflow;
 
-            Block targetBlock = getTargetBlock();
-
-            if (targetBlock != null && targetBlock.getType() == Material.ENDER_CHEST)
+            if (targetBlock.getType() == Material.ENDER_CHEST)
                 overflow = caster.getEnderChest().addItem(item.getItemStack());
-            else if (targetBlock != null && targetBlock.getState() instanceof ShulkerBox)
-                overflow = ((ShulkerBox) targetBlock.getState()).getInventory().addItem(item.getItemStack());
+            else if (targetBlock.getState() instanceof ShulkerBox state)
+                overflow = state.getInventory().addItem(item.getItemStack());
+            else if (targetBlock.getState() instanceof Chest chestState) { // it's a normal chest
+                // MockBukkit's Chest.getInventory() returns a fresh snapshot inventory on each
+                // getState() call, so spell-side writes don't surface to test-side reads.
+                // getBlockInventory() returns the persistent backing snapshot, which both sides
+                // share. In real Paper, getInventory() is the live tile-entity inventory and is
+                // the correct call.
+                if (Ollivanders2.testMode)
+                    overflow = chestState.getBlockInventory().addItem(item.getItemStack());
+                else
+                    overflow = chestState.getInventory().addItem(item.getItemStack());
+            }
             else {
-                common.printDebugMessage("Target chest is not an ender chest or shulker box", null, null, true);
+                common.printDebugMessage("PACK.doCheckEffect: block is not a chest or shulker box - material allowList flaw", null, null, true);
                 return;
             }
 
@@ -139,13 +163,7 @@ public final class PACK extends O2Spell {
             if (overflow.isEmpty())
                 item.remove();
             else {
-                // how many did it stash
-                for (ItemStack itemStack : overflow.values()) {
-                    if (itemStack.getType() == item.getItemStack().getType()) {
-                        int diff = item.getItemStack().getAmount() - itemStack.getAmount();
-                        item.getItemStack().setAmount(diff);
-                    }
-                }
+                item.setItemStack(overflow.values().iterator().next());
             }
         }
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/PARTIS_TEMPORUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/PARTIS_TEMPORUS.java
@@ -94,7 +94,7 @@ public final class PARTIS_TEMPORUS extends O2Spell {
             }
         }
 
-        if (hasHitTarget()) {
+        if (hasHitBlock()) {
             duration = duration - 1;
 
             if (duration <= 0)

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/PRIOR_INCANTATO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/PRIOR_INCANTATO.java
@@ -64,7 +64,7 @@ public class PRIOR_INCANTATO extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
         for (Player target : getNearbyPlayers(defaultRadius)) {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/PROPHETEIA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/PROPHETEIA.java
@@ -56,7 +56,7 @@ public class PROPHETEIA extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
         for (Player target : getNearbyPlayers(defaultRadius)) {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/REDUCTO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/REDUCTO.java
@@ -90,7 +90,7 @@ public final class REDUCTO extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (!hasHitTarget())
+        if (!hasHitBlock())
             return;
 
         Location backLoc = location.clone().subtract(vector);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/REPARIFARGE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/REPARIFARGE.java
@@ -99,7 +99,7 @@ public final class REPARIFARGE extends O2Spell {
      */
     @Override
     public void doCheckEffect() {
-        if (hasHitTarget()) {
+        if (hasHitBlock()) {
             if (getTargetBlock() == null) {
                 common.printDebugMessage("Target block null in " + spellType.toString(), null, null, false);
                 return;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/REPARIFARGE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/REPARIFARGE.java
@@ -1,11 +1,13 @@
 package net.pottercraft.ollivanders2.spell;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
 import net.pottercraft.ollivanders2.common.Ollivanders2Common;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.EnderDragonPart;
 import org.bukkit.entity.Entity;
@@ -13,28 +15,38 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * The Reparifarge spell - an untransfiguration counter-spell.
- *
- * <p>Reparifarge reverses active transfigurations cast by other spells, returning transfigured blocks
- * and entities back to their original state. This spell is primarily useful for countering incomplete
- * or unwanted transfigurations. It does not work on permanent transfigurations or Animagus transformations.</p>
- *
- * <p><strong>Success Mechanics:</strong> The spell has a variable success rate based on the caster's
- * skill level with Reparifarge (number of uses). The success rate ranges from {@link #minSuccessRate}%
- * to {@link #maxSuccessRate}%. Block transfigurations can always be reverted with a successful cast,
- * but entity transfigurations can only be reverted if the source transfiguration spell has an equal or
- * lower level than Reparifarge.</p>
- *
- * <p><strong>Target Detection:</strong> The spell projectile searches for both blocks and entities
- * at the impact location. Ender Dragon parts are automatically converted to their parent dragon entity
- * for targeting consistency.</p>
+ * Untransfiguration counter-spell that reverses active transfigurations on blocks and entities.
+ * <p>
+ * Reparifarge can target both block transfigurations (via block-hit) and entity transfigurations
+ * (via entity scanning along the projectile path). A transfiguration can be reverted if the source
+ * spell's {@link net.pottercraft.ollivanders2.common.MagicLevel} is at most one level above
+ * Reparifarge's own level. If the level check passes, the revert is subject to a random success
+ * check that scales from {@link #minSuccessRate}% to {@link #maxSuccessRate}% based on caster
+ * experience.
+ * </p>
+ * <p>
+ * Water is removed from the projectile pass-through list so the spell can stop on water blocks
+ * created by transfigurations like {@link TERGEO} → {@link AGUAMENTI}.
+ * </p>
  *
  * @author Azami7
- * @see <a href="https://harrypotter.fandom.com/wiki/Reparifarge">Reparifarge on Harry Potter Wiki</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Reparifarge">Reparifarge</a>
  */
 public final class REPARIFARGE extends O2Spell {
-    static final int maxSuccessRate = 100;
-    static final int minSuccessRate = 10;
+    /**
+     * Upper bound for the success rate percentage (100 = always succeeds at mastery).
+     */
+    public static final int maxSuccessRate = 100;
+
+    /**
+     * Lower bound for the success rate percentage (10 = 10% chance even at minimum skill).
+     */
+    public static final int minSuccessRate = 10;
+
+    /**
+     * The current success rate for this cast, clamped to [{@link #minSuccessRate}, {@link #maxSuccessRate}].
+     * Set in {@link #doInitSpell()} based on caster experience.
+     */
     int successRate = minSuccessRate;
 
     /**
@@ -69,8 +81,9 @@ public final class REPARIFARGE extends O2Spell {
         spellType = O2SpellType.REPARIFARGE;
         branch = O2MagicBranch.TRANSFIGURATION;
 
+        projectilePassThrough.remove(Material.WATER);
+
         successMessage = "Successfully untransfigured your target.";
-        failureMessage = "Nothing seems to happen";
 
         initSpell();
     }
@@ -88,26 +101,24 @@ public final class REPARIFARGE extends O2Spell {
     }
 
     /**
-     * Executes the Reparifarge spell effect.
-     *
-     * <p>When the projectile hits a target block, attempts to revert any active transfiguration on that block.
-     * When the projectile is in flight near entities, searches nearby entities and attempts to revert
-     * transfigurations on the first valid target found. Ender Dragon parts are automatically converted to
-     * their parent dragon entity before checking for transfigurations.</p>
-     *
-     * <p>Sends success or failure message to the caster and terminates the spell after attempting reversion.</p>
+     * Attempt to revert a transfiguration on the target block or a nearby entity.
+     * <p>
+     * When the projectile hits a block, the block is checked for an active transfiguration via
+     * {@link #reparifargeBlock(Block)}. When the projectile is in flight, nearby entities are
+     * scanned via {@link #reparifargeEntity(Entity)} (caster excluded, {@link EnderDragonPart}
+     * resolved to parent). In both cases, a success or failure message is sent to the caster
+     * and the spell is killed after the first attempt.
+     * </p>
      */
     @Override
     public void doCheckEffect() {
         if (hasHitBlock()) {
-            if (getTargetBlock() == null) {
+            if (getTargetBlock() == null)
                 common.printDebugMessage("Target block null in " + spellType.toString(), null, null, false);
-                return;
-            }
-            if (reparifargeBlock(getTargetBlock()))
-                caster.sendMessage(Ollivanders2.chatColor + successMessage);
+            else if (reparifargeBlock(getTargetBlock()))
+                sendSuccessMessage();
             else
-                caster.sendMessage(Ollivanders2.chatColor + failureMessage);
+                sendFailureMessage();
 
             kill();
         }
@@ -121,7 +132,7 @@ public final class REPARIFARGE extends O2Spell {
                     entity = ((EnderDragonPart) entity).getParent();
 
                 if (reparifargeEntity(entity)) {
-                    caster.sendMessage(Ollivanders2.chatColor + successMessage);
+                    sendSuccessMessage();
                     kill();
                     return;
                 }
@@ -132,21 +143,13 @@ public final class REPARIFARGE extends O2Spell {
     /**
      * Attempts to revert any active entity transfiguration affecting the target entity.
      *
-     * <p>Searches for active transfiguration spells that have transfigured the target entity.
-     * If a matching transfiguration is found, checks if Reparifarge's level is equal to or greater than
-     * the source transfiguration spell's level. If so, performs a success check and kills the source spell
-     * if successful, reverting the transfiguration.</p>
-     *
-     * <p>Returns true if a transfiguration was found (regardless of whether it was reverted), false otherwise.
-     * This distinguishes between "no transfiguration found" and "transfiguration found but revert failed".</p>
-     *
      * @param target the target entity to check for transfiguration
      * @return true if any transfiguration was found affecting this entity, false otherwise
      */
     public boolean reparifargeEntity(@NotNull Entity target) {
         for (O2Spell spell : Ollivanders2API.getSpells().getActiveSpells()) {
             if (spell instanceof Transfiguration && ((Transfiguration) spell).isTransfigured(target)) {
-                if ((spell.getLevel().ordinal() > this.spellType.getLevel().ordinal()) && checkSuccess())
+                if ((spell.getLevel().ordinal() <= this.spellType.getLevel().ordinal() + 1) && checkSuccess())
                     spell.kill();
 
                 return true;
@@ -159,21 +162,13 @@ public final class REPARIFARGE extends O2Spell {
     /**
      * Attempts to revert any active block transfiguration affecting the target block.
      *
-     * <p>Searches for active transfiguration spells that have transfigured the target block.
-     * If a matching transfiguration is found, performs a success check and kills the source spell
-     * if successful, reverting the transfiguration. Unlike entity transfigurations, block transfigurations
-     * have no level requirement - they can always be reverted if the success check passes.</p>
-     *
-     * <p>Returns true if a transfiguration was found (regardless of whether it was reverted), false otherwise.
-     * This distinguishes between "no transfiguration found" and "transfiguration found but revert failed".</p>
-     *
      * @param target the target block to check for transfiguration
      * @return true if any transfiguration was found affecting this block, false otherwise
      */
     public boolean reparifargeBlock(@NotNull Block target) {
         for (O2Spell spell : Ollivanders2API.getSpells().getActiveSpells()) {
             if (spell instanceof Transfiguration && ((Transfiguration) spell).isTransfigured(target)) {
-                if ((spell.getLevel().ordinal() > this.spellType.getLevel().ordinal()) && checkSuccess())
+                if ((spell.getLevel().ordinal() <= this.spellType.getLevel().ordinal() + 1) && checkSuccess())
                     spell.kill();
 
                 return true;
@@ -189,8 +184,18 @@ public final class REPARIFARGE extends O2Spell {
      * @return true if succeeded, false otherwise
      */
     boolean checkSuccess() {
-        int success = Math.abs(Ollivanders2Common.random.nextInt()) % 100;
+        int success = Math.abs(Ollivanders2Common.random.nextInt(100));
 
         return (success < successRate);
+    }
+
+    /**
+     * Get the success rate for this cast, as a percentage clamped to
+     * [{@link #minSuccessRate}, {@link #maxSuccessRate}].
+     *
+     * @return the success rate percentage (10–100)
+     */
+    public int getSuccessRate() {
+        return successRate;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/REPARIFORS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/REPARIFORS.java
@@ -4,16 +4,29 @@ import net.pottercraft.ollivanders2.effect.O2EffectType;
 import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import net.pottercraft.ollivanders2.Ollivanders2API;
-import net.pottercraft.ollivanders2.common.Ollivanders2Common;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Reparifors is a healing spell that reverts minor magically-induced ailments, such as paralysis and poisoning.
+ * Healing spell that reverts minor magically-induced ailments on a nearby player.
+ * <p>
+ * Reparifors uses the entity-scanning projectile model: each tick it scans for players near
+ * the projectile and treats the first non-caster it finds. Only one ailment is treated per
+ * cast, checked in priority order:
+ * </p>
+ * <ol>
+ * <li><strong>Immobilize</strong> (if not also suspended) — ages the
+ *     {@link net.pottercraft.ollivanders2.effect.O2EffectType#IMMOBILIZE} effect by a percentage
+ *     that scales with caster experience.</li>
+ * <li><strong>Poison</strong> — halves the remaining duration of the Minecraft
+ *     {@link PotionEffectType#POISON} effect, preserving the original amplifier.</li>
+ * <li><strong>Minor heal</strong> — applies a one-time {@link PotionEffectType#INSTANT_HEALTH}
+ *     effect if no specific ailment was found.</li>
+ * </ol>
  *
- * @see <a href = "http://harrypotter.wikia.com/wiki/Reparifors">http://harrypotter.wikia.com/wiki/Reparifors</a>
+ * @see <a href="https://harrypotter.fandom.com/wiki/Reparifors">Reparifors</a>
  */
 public class REPARIFORS extends O2Spell {
     /**
@@ -47,7 +60,23 @@ public class REPARIFORS extends O2Spell {
     }
 
     /**
-     * Find a target entity to heal.
+     * Scan for a nearby player and treat their highest-priority ailment.
+     * <p>
+     * Each tick, the method scans within {@link #defaultRadius} for players. The caster is
+     * skipped. The first non-caster player found is treated using a priority cascade:
+     * </p>
+     * <ol>
+     * <li>If the target has {@link O2EffectType#IMMOBILIZE} but not {@link O2EffectType#SUSPENSION},
+     *     the immobilize effect is aged by a caster-experience-scaled percentage. Suspension blocks
+     *     this treatment because freeing a suspended player could cause them to fall.</li>
+     * <li>Otherwise, if the target has {@link PotionEffectType#POISON}, the poison duration is
+     *     halved (preserving the original amplifier).</li>
+     * <li>Otherwise, a one-time {@link PotionEffectType#INSTANT_HEALTH} is applied as a minor heal.</li>
+     * </ol>
+     * <p>
+     * Only one ailment is treated per cast (single-target, single-ailment). If the projectile
+     * hits a block before finding a player, the spell is killed silently.
+     * </p>
      */
     @Override
     protected void doCheckEffect() {
@@ -58,13 +87,13 @@ public class REPARIFORS extends O2Spell {
             if (target.getUniqueId().equals(caster.getUniqueId()))
                 continue;
 
-            // if they are affected by immobilized, reduce the duration of the effect
+            kill();
+            // if they are affected by immobilize but not suspension, reduce the duration of the effect
+            // we cannot remove immobilize when a player is suspended, or they would be able to move, potentially fall, in suspension
             if (Ollivanders2API.getPlayers().playerEffects.hasEffect(target.getUniqueId(), O2EffectType.IMMOBILIZE) && !(Ollivanders2API.getPlayers().playerEffects.hasEffect(target.getUniqueId(), O2EffectType.SUSPENSION))) {
-                int decrease = ((int) usesModifier / 20) + 5; // age by at least 5 percent
+                int decrease = ((int) usesModifier / 2) + 5; // age by at least 5 percent
 
                 Ollivanders2API.getPlayers().playerEffects.ageEffectByPercent(target.getUniqueId(), O2EffectType.IMMOBILIZE, decrease);
-
-                kill();
                 return;
             }
 
@@ -72,20 +101,16 @@ public class REPARIFORS extends O2Spell {
             if (target.hasPotionEffect(PotionEffectType.POISON)) {
                 PotionEffect potionEffect = target.getPotionEffect(PotionEffectType.POISON);
                 if (potionEffect != null) {
-                    int duration = potionEffect.getDuration();
+                    int reducedDuration = potionEffect.getDuration() / 2;
                     target.removePotionEffect(PotionEffectType.POISON);
-                    target.addPotionEffect(new PotionEffect(PotionEffectType.POISON, (duration / 2), 1));
+                    target.addPotionEffect(new PotionEffect(PotionEffectType.POISON, reducedDuration, potionEffect.getAmplifier()));
                 }
 
-                kill();
                 return;
             }
 
             // do a minor heal
-            int duration = (((int) usesModifier / 10) * Ollivanders2Common.ticksPerSecond) + (15 * Ollivanders2Common.ticksPerSecond);
-            target.addPotionEffect(new PotionEffect(PotionEffectType.INSTANT_HEALTH, duration, 1));
-
-            kill();
+            target.addPotionEffect(new PotionEffect(PotionEffectType.INSTANT_HEALTH, 5, 1)); // duration not used for this instant effect
             return;
         }
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/REPARIFORS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/REPARIFORS.java
@@ -51,7 +51,7 @@ public class REPARIFORS extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
         for (Player target : getNearbyPlayers(defaultRadius)) {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/REPARO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/REPARO.java
@@ -100,7 +100,7 @@ public class REPARO extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
         List<Item> items = getNearbyItems(defaultRadius);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/RemoveO2Effect.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/RemoveO2Effect.java
@@ -77,7 +77,7 @@ abstract public class RemoveO2Effect extends O2Spell {
     protected void doCheckEffect() {
         affectRadius(defaultRadius, false);
 
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
     }
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/RemovePotionEffect.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/RemovePotionEffect.java
@@ -64,7 +64,7 @@ public abstract class RemovePotionEffect extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
         affectRadius(defaultRadius, false);

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/SCUTO_CONTERAM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/SCUTO_CONTERAM.java
@@ -76,7 +76,7 @@ public final class SCUTO_CONTERAM extends O2Spell {
         }
 
         // kill the spell if the projectile has stopped or when we have hit the max number of targets
-        if (hasHitTarget() || targetsRemaining <= 0)
+        if (hasHitBlock() || targetsRemaining <= 0)
             kill();
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/SILENCIO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/SILENCIO.java
@@ -84,7 +84,7 @@ public final class SILENCIO extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
         for (Player target : getNearbyPlayers(defaultRadius)) {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/SKURGE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/SKURGE.java
@@ -83,7 +83,7 @@ public class SKURGE extends O2Spell {
 
     @Override
     protected void doCheckEffect() {
-        if (!hasHitTarget())
+        if (!hasHitBlock())
             return;
 
         for (Block block : BlockCommon.getBlocksInRadius(location, radius)) {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/Sparks.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/Sparks.java
@@ -115,7 +115,7 @@ public abstract class Sparks extends O2Spell {
      */
     @Override
     public void doCheckEffect() {
-        if (hasHitTarget())
+        if (hasHitBlock())
             kill();
 
         // play the firework launch sound on the first tick, tick is incremented before doCheckEffect() is called so it starts at 1

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/SpellZone.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/SpellZone.java
@@ -4,59 +4,127 @@ import net.pottercraft.ollivanders2.common.Cuboid;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
- * Allow/disallow spells in an area
+ * Configuration for restricting spells in a particular area of the world.
+ * <p>
+ * A spell zone defines an area — a cuboid, an entire Minecraft world, or a WorldGuard region —
+ * along with the spells that are explicitly allowed or disallowed there. The zone itself is a
+ * passive value object: actual enforcement of the allow/disallow rules lives in
+ * {@link O2Spells#isSpellTypeAllowed(org.bukkit.Location, O2SpellType)}, which iterates the
+ * configured zones and applies the allow list (which takes precedence) or disallow list to a
+ * candidate spell cast.
+ * </p>
+ * <p>
+ * Zones are loaded from the plugin's zones config at startup by {@link O2Spells}; see the
+ * referenced wiki page for the config schema.
+ * </p>
  *
- * @see <a href = "https://github.com/Azami7/Ollivanders2/wiki/Configuration#zones">https://github.com/Azami7/Ollivanders2/wiki/Configuration#zones</a>
+ * @see <a href="https://github.com/Azami7/Ollivanders2/wiki/Configuration#zones">Ollivanders2 Wiki - Zone Configuration</a>
  */
 public class SpellZone {
     /**
-     * Type of spell zones that can be defined
+     * The kind of area a {@link SpellZone} covers.
      */
     public enum SpellZoneType {
         /**
-         * bounding box
+         * A 3D bounding box defined by two opposite corner coordinates within a single world.
          */
         CUBOID,
         /**
-         * entire world
+         * An entire Minecraft world, identified by world name.
          */
         WORLD,
         /**
-         * world guard region
+         * A WorldGuard region, identified by region name within a world.
          */
-        WORLD_GUARD;
+        WORLD_GUARD
     }
 
     /**
-     * String keys for zone config
+     * Config sub-key for the per-zone allowed-spells list.
      */
     final static String allowedList = "allowed-spells";
-    final static String disallowList = "disallowed-spells";
-    final static String globalZoneName = "global";
-    final static String none = "NONE";
-    final static String all = "ALL";
-
-    String zoneName;
-    SpellZoneType zoneType;
-    final Cuboid cuboid;
-    String zoneWorldName;
-
-    ArrayList<O2SpellType> disallowedSpells;
-    ArrayList<O2SpellType> allowedSpells;
 
     /**
-     * Constructor
-     *
-     * @param name       the name of this zone
-     * @param world      the name of the world this zone is in
-     * @param type       the type of zone
-     * @param area       the area bounds for this zone if a cuboid, this should be opposite corners
-     * @param allowed    a list of allowed spells, if set, this will take precedence over a disallow list
-     * @param disallowed a list of disallowed spells
+     * Config sub-key for the per-zone disallowed-spells list.
      */
-    SpellZone(@NotNull String name, @NotNull String world, @NotNull SpellZoneType type, int[] area, @NotNull ArrayList<O2SpellType> allowed, @NotNull ArrayList<O2SpellType> disallowed) {
+    final static String disallowList = "disallowed-spells";
+
+    /**
+     * Reserved zone name for the global allow/disallow lists that apply across all worlds.
+     */
+    final static String globalZoneName = "global";
+
+    /**
+     * Sentinel value indicating an empty spell list in the zones config.
+     */
+    final static String none = "NONE";
+
+    /**
+     * Sentinel value indicating that the spell list should match every loaded spell type.
+     */
+    final static String all = "ALL";
+
+    /**
+     * The name of this zone, used as the lookup key in the zones config.
+     */
+    final String zoneName;
+
+    /**
+     * The kind of area this zone covers. See {@link SpellZoneType}.
+     */
+    final SpellZoneType zoneType;
+
+    /**
+     * The cuboid backing this zone. Only meaningful when {@link #zoneType} is
+     * {@link SpellZoneType#CUBOID}; for other zone types this is a stub at (0,0,0,0,0,0)
+     * and must not be queried for containment.
+     */
+    final Cuboid cuboid;
+
+    /**
+     * The name of the Minecraft world this zone is in.
+     */
+    final String zoneWorldName;
+
+    /**
+     * Spells that are explicitly disallowed in this zone. Stored as a defensive copy of the
+     * caller-supplied list.
+     */
+    final List<O2SpellType> disallowedSpells;
+
+    /**
+     * Spells that are explicitly allowed in this zone. When non-empty, the consumer
+     * ({@link O2Spells#isSpellTypeAllowed(org.bukkit.Location, O2SpellType)}) treats this as
+     * the only allowed set in the zone — taking precedence over {@link #disallowedSpells}.
+     * Stored as a defensive copy of the caller-supplied list.
+     */
+    final List<O2SpellType> allowedSpells;
+
+    /**
+     * Constructs a spell zone from values supplied by the zones config loader.
+     * <p>
+     * The {@code area} array is consumed only when {@code type} is {@link SpellZoneType#CUBOID};
+     * for {@link SpellZoneType#WORLD} and {@link SpellZoneType#WORLD_GUARD} zones the cuboid
+     * field is constructed as a stub and must not be queried. Both spell lists are stored as
+     * defensive copies, so mutating the caller's lists after construction does not affect the
+     * resulting zone.
+     * </p>
+     *
+     * @param name       the name of this zone, used as the config-lookup key
+     * @param world      the name of the Minecraft world this zone is in
+     * @param type       the kind of area this zone covers
+     * @param area       opposite-corner coordinates {@code [x1,y1,z1,x2,y2,z2]} for CUBOID
+     *                   zones; ignored for WORLD and WORLD_GUARD zones
+     * @param allowed    spells explicitly allowed in this zone; when non-empty, the consumer
+     *                   ({@link O2Spells#isSpellTypeAllowed(org.bukkit.Location, O2SpellType)})
+     *                   treats this as the only allowed set, taking precedence over
+     *                   {@code disallowed}
+     * @param disallowed spells explicitly disallowed in this zone
+     */
+    public SpellZone(@NotNull String name, @NotNull String world, @NotNull SpellZoneType type, int[] area, @NotNull ArrayList<O2SpellType> allowed, @NotNull ArrayList<O2SpellType> disallowed) {
         zoneName = name;
         zoneType = type;
         zoneWorldName = world;
@@ -68,7 +136,73 @@ public class SpellZone {
             cuboid = new Cuboid(zoneWorldName, emptyArea);
         }
 
-        disallowedSpells = disallowed;
-        allowedSpells = allowed;
+        // defensive copies — caller-supplied lists must not be aliased
+        disallowedSpells = new ArrayList<>(disallowed);
+        allowedSpells = new ArrayList<>(allowed);
+    }
+
+    /**
+     * Get the name of this zone.
+     *
+     * @return the zone name
+     */
+    @NotNull
+    public String getZoneName() {
+        return zoneName;
+    }
+
+    /**
+     * Get the type of this zone.
+     *
+     * @return the zone type (CUBOID, WORLD, or WORLD_GUARD)
+     */
+    @NotNull
+    public SpellZoneType getZoneType() {
+        return zoneType;
+    }
+
+    /**
+     * Get the name of the world this zone is in.
+     *
+     * @return the world name
+     */
+    @NotNull
+    public String getZoneWorldName() {
+        return zoneWorldName;
+    }
+
+    /**
+     * Get the cuboid backing this zone. Only meaningful when {@link #getZoneType()} is CUBOID;
+     * non-CUBOID zones return a stub cuboid that should not be queried for containment.
+     *
+     * @return the cuboid for this zone
+     */
+    @NotNull
+    public Cuboid getCuboid() {
+        return cuboid;
+    }
+
+    /**
+     * Get a fresh defensive copy of the spells allowed in this zone. Mutating the returned
+     * list does not affect the zone's stored state, and successive calls return distinct
+     * list instances.
+     *
+     * @return a defensive copy of the allowed spells list
+     */
+    @NotNull
+    public List<O2SpellType> getAllowedSpells() {
+        return new ArrayList<>(allowedSpells);
+    }
+
+    /**
+     * Get a fresh defensive copy of the spells disallowed in this zone. Mutating the returned
+     * list does not affect the zone's stored state, and successive calls return distinct
+     * list instances.
+     *
+     * @return a defensive copy of the disallowed spells list
+     */
+    @NotNull
+    public List<O2SpellType> getDisallowedSpells() {
+        return new ArrayList<>(disallowedSpells);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/StationarySpell.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/StationarySpell.java
@@ -132,7 +132,7 @@ public abstract class StationarySpell extends O2Spell {
      */
     @Override
     protected void doCheckEffect() {
-        if (!noProjectile && !hasHitTarget()) // if we have not hit a target, continue
+        if (!noProjectile && !hasHitBlock()) // if we have not hit a target, continue
             return;
 
         setDuration();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/Transfiguration.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/Transfiguration.java
@@ -229,7 +229,7 @@ public abstract class Transfiguration extends O2Spell {
                 kill();
         }
 
-        if (hasHitTarget() && !isTransfigured) {
+        if (hasHitBlock() && !isTransfigured) {
             // we've hit a block and the projectile is stopped, but we didn't find anything to transfigure
             common.printDebugMessage("Failed to transfigure an entity before projectile stopped", null, null, false);
             sendFailureMessage();

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/WINGARDIUM_LEVIOSA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/WINGARDIUM_LEVIOSA.java
@@ -123,7 +123,7 @@ public final class WINGARDIUM_LEVIOSA extends O2Spell {
             List<Item> nearbyItems = getNearbyItems(defaultRadius);
 
             if (nearbyItems.isEmpty()) {
-                if (hasHitTarget()) // we failed to find a target and the projectile has stopped
+                if (hasHitBlock()) // we failed to find a target and the projectile has stopped
                     kill();
             }
             else {

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/common/CuboidTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/common/CuboidTest.java
@@ -65,6 +65,71 @@ public class CuboidTest {
     }
 
     /**
+     * Test that a point inside the x and y range but with z below the cuboid's z range
+     * is correctly identified as outside.
+     *
+     * <p>This case exercises the z-axis check independently from the x-axis check.
+     * A previous bug in {@link net.pottercraft.ollivanders2.common.Cuboid#isInside(String, int, int, int)}
+     * used the x coordinate where the z coordinate should have been used in the z-range
+     * comparison, so any test point that disagreed between x-inside and z-inside would
+     * have surfaced it. Points where x and z move together (e.g. (5,5,5) or (200,200,200))
+     * could not distinguish the bug from correct behavior.
+     */
+    @Test
+    void isInsideZBelowRangeTest() {
+        // x and y are inside [0,100] but z = -50 is below z1 = 0
+        assertFalse(testCuboid.isInside(new Location(testWorld, 50, 50, -50)),
+                "testCuboid.isInside(50, 50, -50) returned true; expected false because z is below the cuboid's z range");
+    }
+
+    /**
+     * Test that a point inside the x and y range but with z above the cuboid's z range
+     * is correctly identified as outside. Companion to {@link #isInsideZBelowRangeTest()}.
+     */
+    @Test
+    void isInsideZAboveRangeTest() {
+        // x and y are inside [0,100] but z = 200 is above z2 = 100
+        assertFalse(testCuboid.isInside(new Location(testWorld, 50, 50, 200)),
+                "testCuboid.isInside(50, 50, 200) returned true; expected false because z is above the cuboid's z range");
+    }
+
+    /**
+     * Test that a cuboid defined with reversed corners (corner1 coordinates greater than
+     * corner2 coordinates on every axis) still classifies points correctly.
+     *
+     * <p>The {@code isInside} implementation has separate branches for {@code n1 > n2}
+     * and {@code n1 < n2} on each axis; this test exercises the reversed-corner branches
+     * that the canonical {@code testCuboid} (with corner1 = origin, corner2 = (100,100,100))
+     * does not cover.
+     */
+    @Test
+    void isInsideReversedCornersTest() {
+        // same physical region as testCuboid but with the corner order swapped on every axis
+        Cuboid reversedCuboid = new Cuboid(worldName, new int[]{100, 100, 100, 0, 0, 0});
+
+        assertTrue(reversedCuboid.isInside(new Location(testWorld, 50, 50, 50)),
+                "reversedCuboid should contain (50,50,50)");
+        assertFalse(reversedCuboid.isInside(new Location(testWorld, 50, 50, -50)),
+                "reversedCuboid should not contain (50,50,-50) — z below range");
+        assertFalse(reversedCuboid.isInside(new Location(testWorld, 200, 200, 200)),
+                "reversedCuboid should not contain (200,200,200) — outside on all axes");
+    }
+
+    /**
+     * Test that points exactly on the cuboid's corner coordinates are considered inside.
+     *
+     * <p>The cuboid bounds are documented as inclusive, so both corners and any point
+     * coinciding with a face must report as inside.
+     */
+    @Test
+    void isInsideBoundaryTest() {
+        assertTrue(testCuboid.isInside(new Location(testWorld, 0, 0, 0)),
+                "corner (0,0,0) should be inside the cuboid");
+        assertTrue(testCuboid.isInside(new Location(testWorld, 100, 100, 100)),
+                "corner (100,100,100) should be inside the cuboid");
+    }
+
+    /**
      * Test that parseArea correctly converts a space-delimited string of coordinates
      * into an integer array representing a cuboid area.
      * Expected format: "x1 y1 z1 x2 y2 z2"

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/common/Ollivanders2CommonTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/common/Ollivanders2CommonTest.java
@@ -796,6 +796,9 @@ public class Ollivanders2CommonTest {
         Ollivanders2Common.initMaterials();
 
         for (Material material : Material.values()) {
+            // skip legacy materials — Ollivanders2 does not support LEGACY_* entries
+            if (material.toString().startsWith("LEGACY_"))
+                continue;
             if (material.toString().endsWith("_CHEST") || material.toString().endsWith("_SHULKER_BOX")) {
                 assertTrue(Ollivanders2Common.isChest(material), "Missing chest material " + material);
             }

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/AbertoTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/AbertoTest.java
@@ -96,6 +96,6 @@ public class AbertoTest extends O2SpellTestSuper {
     @Override
     @Test
     void revertTest() {
-        // aberto has no revert actions
+        // no revert actions
     }
 }

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/AguamentiTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/AguamentiTest.java
@@ -103,7 +103,7 @@ public class AguamentiTest extends BlockTransfigurationTest {
 
         mockServer.getScheduler().performTicks(20);
         Block target = aguamenti.getTargetBlock();
-        assertTrue(aguamenti.hasHitTarget());
+        assertTrue(aguamenti.hasHitBlock());
         assertFalse(aguamenti.isKilled());
         assertNotNull(target, "target block is null");
         assertEquals(Material.WATER, target.getType(), "block not changed to expected type");

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/ApareciumTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/ApareciumTest.java
@@ -120,7 +120,7 @@ public class ApareciumTest extends O2SpellTestSuper {
 
         APARECIUM aparecium = (APARECIUM) castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(aparecium.hasHitTarget());
+        assertTrue(aparecium.hasHitBlock());
         assertFalse(writtenBook.isDead()); // if aparecium tried to remove an enchantment, it would have removed the original book and dropped a new one
 
         // test on enchanted item that is not a book
@@ -129,7 +129,7 @@ public class ApareciumTest extends O2SpellTestSuper {
         Item broomstick = testWorld.dropItem(targetLocation, broomstickStack);
         aparecium = (APARECIUM) castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(aparecium.hasHitTarget());
+        assertTrue(aparecium.hasHitBlock());
         assertFalse(broomstick.isDead(), "aparecium removed enchanted item that is not a book"); // if aparecium tried to remove an enchantment, it would have removed the original book and dropped a new one
         assertTrue(Ollivanders2API.getItems().enchantedItems.isEnchanted(broomstick), "aparecium removed enchantment from item that is not a book");
     }

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/AquaEructoBaseTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/AquaEructoBaseTest.java
@@ -88,10 +88,10 @@ abstract public class AquaEructoBaseTest extends O2SpellTestSuper {
 
         AQUA_ERUCTO aquaEructo = (AQUA_ERUCTO) castSpell(caster, location, entity.getLocation());
         mockServer.getScheduler().performTicks(2);
-        assertFalse(aquaEructo.hasHitTarget(), "hit target too soon, potentially targeted the caster");
+        assertFalse(aquaEructo.hasHitBlock(), "hit target too soon, potentially targeted the caster");
 
         mockServer.getScheduler().performTicks(20);
-        assertTrue(aquaEructo.hasHitTarget(), "projectile not stopped when entity on fire found");
+        assertTrue(aquaEructo.hasHitBlock(), "projectile not stopped when entity on fire found");
         assertTrue(aquaEructo.isExtinguished(), "target not extinguished");
         checkEffect(entity);
     }
@@ -126,7 +126,7 @@ abstract public class AquaEructoBaseTest extends O2SpellTestSuper {
 
         AQUA_ERUCTO aquaEructo = (AQUA_ERUCTO) castSpell(caster, location, entity.getLocation());
         mockServer.getScheduler().performTicks(20);
-        assertTrue(aquaEructo.hasHitTarget());
+        assertTrue(aquaEructo.hasHitBlock());
         assertTrue(aquaEructo.isExtinguished(), "target not extinguished");
 
         Block waterBlock;
@@ -166,7 +166,7 @@ abstract public class AquaEructoBaseTest extends O2SpellTestSuper {
 
         assertFalse(aquaEructo.isExtinguished(), "target extinguished when they were not on fire");
         assertTrue(Ollivanders2API.getBlocks().getBlocksChangedBySpell(aquaEructo).isEmpty(), "water block effect turned on when target was not on fire");
-        assertTrue(aquaEructo.hasHitTarget());
+        assertTrue(aquaEructo.hasHitBlock());
         assertTrue(aquaEructo.isKilled(), "spell not killed when failed to find a target");
     }
 
@@ -193,7 +193,7 @@ abstract public class AquaEructoBaseTest extends O2SpellTestSuper {
         AQUA_ERUCTO aquaEructo = (AQUA_ERUCTO) castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
 
-        assertTrue(aquaEructo.hasHitTarget());
+        assertTrue(aquaEructo.hasHitBlock());
         assertTrue(caster.getFireTicks() > 0, "caster no longer on fire");
         assertFalse(aquaEructo.isExtinguished(), "spell targeted caster");
     }

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/AquaEructoDuoTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/AquaEructoDuoTest.java
@@ -113,7 +113,7 @@ public class AquaEructoDuoTest extends AquaEructoBaseTest {
         AQUA_ERUCTO aquaEructo = (AQUA_ERUCTO) castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
 
-        assertTrue(aquaEructo.hasHitTarget());
+        assertTrue(aquaEructo.hasHitBlock());
         AttributeInstance healthAttribute = caster.getAttribute(Attribute.MAX_HEALTH);
         assertNotNull(healthAttribute);
         assertEquals(healthAttribute.getValue(), caster.getHealth(), "caster was damaged");

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/AquaEructoTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/AquaEructoTest.java
@@ -105,7 +105,7 @@ public class AquaEructoTest extends AquaEructoBaseTest {
 
         AQUA_ERUCTO aquaEructo = (AQUA_ERUCTO) castSpell(caster, location, item.getLocation());
         mockServer.getScheduler().performTicks(20);
-        assertTrue(aquaEructo.hasHitTarget());
+        assertTrue(aquaEructo.hasHitBlock());
         assertTrue(aquaEructo.isExtinguished(), "target not extinguished");
     }
 }

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/ArrestoMomentumTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/ArrestoMomentumTest.java
@@ -74,7 +74,7 @@ public class ArrestoMomentumTest extends O2SpellTestSuper {
         ARRESTO_MOMENTUM arrestoMomentum = (ARRESTO_MOMENTUM) castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
 
-        assertTrue(arrestoMomentum.hasHitTarget());
+        assertTrue(arrestoMomentum.hasHitBlock());
         assertTrue(item.getVelocity().getY() < yVelocity, "item velocity did not decrease, y-velocity was " + yVelocity + ", now " + item.getVelocity().getY());
     }
 
@@ -107,7 +107,7 @@ public class ArrestoMomentumTest extends O2SpellTestSuper {
         mockServer.getScheduler().performTicks(20);
 
         // spell should fail because the caster year is not >= 5th
-        assertTrue(arrestoMomentum.hasHitTarget());
+        assertTrue(arrestoMomentum.hasHitBlock());
         assertEquals(5, target.getVelocity().getY(), "target velocity decreased, y-velocity was " + yVelocity + ", now " + target.getVelocity().getY());
 
         o2p.setYear(Year.YEAR_5);
@@ -115,7 +115,7 @@ public class ArrestoMomentumTest extends O2SpellTestSuper {
         mockServer.getScheduler().performTicks(20);
 
         // spell should pass because the caster year is 5th
-        assertTrue(arrestoMomentum.hasHitTarget());
+        assertTrue(arrestoMomentum.hasHitBlock());
         assertTrue(target.getVelocity().getY() < yVelocity, "target velocity did not decrease, y-velocity was " + yVelocity + ", now " + target.getVelocity().getY());
     }
 
@@ -144,7 +144,7 @@ public class ArrestoMomentumTest extends O2SpellTestSuper {
         ARRESTO_MOMENTUM arrestoMomentum = (ARRESTO_MOMENTUM) castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
 
-        assertTrue(arrestoMomentum.hasHitTarget());
+        assertTrue(arrestoMomentum.hasHitBlock());
         assertEquals(5, ironGolem.getVelocity().getY(), "Iron golem velocity changed");
     }
 
@@ -169,31 +169,31 @@ public class ArrestoMomentumTest extends O2SpellTestSuper {
 
         ARRESTO_MOMENTUM arrestoMomentum = (ARRESTO_MOMENTUM) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, 10);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(arrestoMomentum.hasHitTarget());
+        assertTrue(arrestoMomentum.hasHitBlock());
         assertEquals(6, item.getVelocity().getY(), "Velocity not changed to expected value for 10 experience");
 
         item.setVelocity(new Vector(0, yVelocity, 0));
         arrestoMomentum = (ARRESTO_MOMENTUM) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, 30);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(arrestoMomentum.hasHitTarget());
+        assertTrue(arrestoMomentum.hasHitBlock());
         assertEquals(5, item.getVelocity().getY(), "Velocity not changed to expected value for 30 experience");
 
         item.setVelocity(new Vector(0, yVelocity, 0));
         arrestoMomentum = (ARRESTO_MOMENTUM) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, 60);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(arrestoMomentum.hasHitTarget());
+        assertTrue(arrestoMomentum.hasHitBlock());
         assertEquals(4, item.getVelocity().getY(), "Velocity not changed to expected value for 60 experience");
 
         item.setVelocity(new Vector(0, yVelocity, 0));
         arrestoMomentum = (ARRESTO_MOMENTUM) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, 80);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(arrestoMomentum.hasHitTarget());
+        assertTrue(arrestoMomentum.hasHitBlock());
         assertEquals(3, item.getVelocity().getY(), "Velocity not changed to expected value for 80 experience");
 
         item.setVelocity(new Vector(0, yVelocity, 0));
         arrestoMomentum = (ARRESTO_MOMENTUM) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, 101);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(arrestoMomentum.hasHitTarget());
+        assertTrue(arrestoMomentum.hasHitBlock());
         assertEquals(2, item.getVelocity().getY(), "Velocity not changed to expected value for 101 experience");
     }
 

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/BlockToEntityTransfigurationTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/BlockToEntityTransfigurationTest.java
@@ -94,7 +94,7 @@ abstract public class BlockToEntityTransfigurationTest extends O2SpellTestSuper 
         assertNotNull(expectedType);
 
         mockServer.getScheduler().performTicks(20);
-        assertTrue(blockToEntityTransfiguration.hasHitTarget(), "spell did not hit the target");
+        assertTrue(blockToEntityTransfiguration.hasHitBlock(), "spell did not hit the target");
         assertEquals(Material.AIR, target.getType(), "target block not changed to air");
 
         LivingEntity entity = EntityCommon.getLivingEntityAtLocation(target.getLocation());
@@ -126,7 +126,7 @@ abstract public class BlockToEntityTransfigurationTest extends O2SpellTestSuper 
         BlockToEntityTransfiguration blockToEntityTransfiguration = (BlockToEntityTransfiguration) castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
 
-        assertTrue(blockToEntityTransfiguration.hasHitTarget());
+        assertTrue(blockToEntityTransfiguration.hasHitBlock());
         assertFalse(blockToEntityTransfiguration.isTransfigured(target), "block was transfigured when it is not a transfigurable block");
         assertEquals(originalMaterial, target.getType(), "block type changed when it is not a transfigurable block");
     }
@@ -165,7 +165,7 @@ abstract public class BlockToEntityTransfigurationTest extends O2SpellTestSuper 
         BlockToEntityTransfiguration blockToEntityTransfiguration = (BlockToEntityTransfiguration) castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
 
-        assertTrue(blockToEntityTransfiguration.hasHitTarget());
+        assertTrue(blockToEntityTransfiguration.hasHitBlock());
         LivingEntity entity = EntityCommon.getLivingEntityAtLocation(target.getLocation());
         assertNotNull(entity);
 

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/BlockTransfigurationTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/BlockTransfigurationTest.java
@@ -89,7 +89,7 @@ abstract public class BlockTransfigurationTest extends O2SpellTestSuper {
 
         mockServer.getScheduler().performTicks(20);
 
-        assertTrue(blockTransfiguration.hasHitTarget(), "hitTarget not set when spell hit invalid target " + blockTransfiguration.getLocation().getBlock().getType());
+        assertTrue(blockTransfiguration.hasHitBlock(), "hitTarget not set when spell hit invalid target " + blockTransfiguration.getLocation().getBlock().getType());
         assertFalse(blockTransfiguration.isTransfigured(target), "invalid block was transfigured");
         assertEquals(invalidType, target.getType(), "material for invalid block was changed");
     }
@@ -230,7 +230,7 @@ abstract public class BlockTransfigurationTest extends O2SpellTestSuper {
 
         if (!blockTransfiguration.isPermanent()) {
             mockServer.getScheduler().performTicks(20);
-            assertTrue(blockTransfiguration.hasHitTarget());
+            assertTrue(blockTransfiguration.hasHitBlock());
             assertTrue(blockTransfiguration.isTransfigured(), "block was not transfigured");
             assertFalse(blockTransfiguration.isKilled(), "transfiguration killed unexpectedly");
 
@@ -321,7 +321,7 @@ abstract public class BlockTransfigurationTest extends O2SpellTestSuper {
         assertTrue(blockTransfiguration.getEffectRadius() <= blockTransfiguration.getMaxRadius(), "radius not <= maxRadius");
 
         if (blockTransfiguration.getMaxRadius() > 1) {
-            assertTrue(blockTransfiguration.hasHitTarget());
+            assertTrue(blockTransfiguration.hasHitBlock());
 
             assertNotEquals(getValidTargetType(), testWorld.getBlockAt(targetLocation).getType(), "block at target location not changed");
 

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/BombaraBaseTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/BombaraBaseTest.java
@@ -76,7 +76,7 @@ abstract public class BombaraBaseTest extends O2SpellTestSuper {
         block.setType(getValidMaterial());
         BombardaBase bombarda = (BombardaBase) castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(bombarda.hasHitTarget(), "spell did not hit target");
+        assertTrue(bombarda.hasHitBlock(), "spell did not hit target");
         assertEquals(Material.AIR, block.getType(), "block was not broken");
 
         // test unbreakable
@@ -84,7 +84,7 @@ abstract public class BombaraBaseTest extends O2SpellTestSuper {
         block.setType(unbreakable);
         bombarda = (BombardaBase) castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(bombarda.hasHitTarget());
+        assertTrue(bombarda.hasHitBlock());
         assertEquals(unbreakable, block.getType(), "unbreakable material broken");
 
         // test doors
@@ -92,7 +92,7 @@ abstract public class BombaraBaseTest extends O2SpellTestSuper {
         block.setType(door);
         bombarda = (BombardaBase) castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(bombarda.hasHitTarget());
+        assertTrue(bombarda.hasHitBlock());
         if (bombarda.doesBreakDoors()) {
             assertEquals(Material.AIR, block.getType(), "spell did not break door");
         }
@@ -105,7 +105,7 @@ abstract public class BombaraBaseTest extends O2SpellTestSuper {
         block.setType(blastResistant);
         bombarda = (BombardaBase) castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(bombarda.hasHitTarget());
+        assertTrue(bombarda.hasHitBlock());
         assertEquals(blastResistant, block.getType(), "block with higher blast resistance broken");
 
         // test hardness
@@ -113,7 +113,7 @@ abstract public class BombaraBaseTest extends O2SpellTestSuper {
         block.setType(hard);
         bombarda = (BombardaBase) castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(bombarda.hasHitTarget());
+        assertTrue(bombarda.hasHitBlock());
         assertEquals(hard, block.getType(), "block with higher hardness was broken");
 
         // test radius
@@ -126,7 +126,7 @@ abstract public class BombaraBaseTest extends O2SpellTestSuper {
         outside.setType(getValidMaterial());
         bombarda = (BombardaBase) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(bombarda.hasHitTarget());
+        assertTrue(bombarda.hasHitBlock());
         assertEquals(Material.AIR, block.getType(), "block not broken");
         assertEquals(Material.AIR, east.getType(), "east block not broken");
         assertEquals(Material.AIR, west.getType(), "west block not broken");

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/CarceremAquaticumTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/CarceremAquaticumTest.java
@@ -85,7 +85,7 @@ public class CarceremAquaticumTest extends ImmobilizePlayerTest {
         CARCEREM_AQUATICUM carceremAquaticum = (CARCEREM_AQUATICUM) castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
 
-        assertTrue(carceremAquaticum.hasHitTarget());
+        assertTrue(carceremAquaticum.hasHitBlock());
         assertTrue(target.hasPotionEffect(PotionEffectType.WATER_BREATHING), "target does not have water breathing");
     }
 }

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/ColloportusTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/ColloportusTest.java
@@ -95,7 +95,7 @@ public class ColloportusTest extends StationarySpellTest {
 
         colloportus = (COLLOPORTUS) castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(colloportus.hasHitTarget());
+        assertTrue(colloportus.hasHitBlock());
         assertTrue(colloportus.isKilled());
 
         blockData = testWorld.getBlockAt(targetLocation).getBlockData();

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/EntityTransfigurationTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/EntityTransfigurationTest.java
@@ -127,7 +127,7 @@ abstract public class EntityTransfigurationTest extends O2SpellTestSuper {
 
         mockServer.getScheduler().performTicks(20);
 
-        assertTrue(entityTransfiguration.hasHitTarget(), "hitTarget not set when spell hit valid target");
+        assertTrue(entityTransfiguration.hasHitBlock(), "hitTarget not set when spell hit valid target");
         assertTrue(entityTransfiguration.isTransfigured(), "target was not transfigured");
     }
 
@@ -221,7 +221,7 @@ abstract public class EntityTransfigurationTest extends O2SpellTestSuper {
         // already transfigured entity cannot be targeted
         EntityTransfiguration entityTransfiguration = (EntityTransfiguration) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel * 2);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(entityTransfiguration.hasHitTarget(), "spell did not hit target");
+        assertTrue(entityTransfiguration.hasHitBlock(), "spell did not hit target");
         assertTrue(entityTransfiguration.isTransfigured(), "target was not transfigured");
 
         EntityTransfiguration entityTransfiguration2 = (EntityTransfiguration) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel * 2);
@@ -280,7 +280,7 @@ abstract public class EntityTransfigurationTest extends O2SpellTestSuper {
 
         if (!entityTransfiguration.isPermanent()) {
             mockServer.getScheduler().performTicks(20);
-            assertTrue(entityTransfiguration.hasHitTarget());
+            assertTrue(entityTransfiguration.hasHitBlock());
             assertTrue(entityTransfiguration.isTransfigured(), "entity was not transfigured");
             assertFalse(entityTransfiguration.isKilled(), "transfiguration killed unexpectedly");
 

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/EvanescoMaximaTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/EvanescoMaximaTest.java
@@ -112,7 +112,7 @@ public class EvanescoMaximaTest extends EntityTransfigurationTest {
         // already transfigured entity cannot be targeted
         EVANESCO evanesco = (EVANESCO) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel * 2, O2SpellType.EVANESCO);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(evanesco.hasHitTarget(), "spell did not hit target");
+        assertTrue(evanesco.hasHitBlock(), "spell did not hit target");
         assertTrue(evanesco.isTransfigured(), "target was not transfigured");
 
         EVANESCO_MAXIMA evanescoMaxima = (EVANESCO_MAXIMA) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel * 2);
@@ -138,7 +138,7 @@ public class EvanescoMaximaTest extends EntityTransfigurationTest {
 
         EVANESCO_MAXIMA evanescoMaxima = (EVANESCO_MAXIMA) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel * 2);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(evanescoMaxima.hasHitTarget());
+        assertTrue(evanescoMaxima.hasHitBlock());
         assertTrue(evanescoMaxima.isTransfigured());
 
         // target entity was removed

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/EvanescoTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/EvanescoTest.java
@@ -78,7 +78,7 @@ public class EvanescoTest extends EntityTransfigurationTest {
 
         EVANESCO evanesco = (EVANESCO) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel * 2);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(evanesco.hasHitTarget());
+        assertTrue(evanesco.hasHitBlock());
         assertTrue(evanesco.isTransfigured());
 
         // target entity was removed

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/GaleatiTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/GaleatiTest.java
@@ -1,0 +1,99 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.common.EntityCommon;
+import net.pottercraft.ollivanders2.spell.Galeati;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.Item;
+import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Abstract base test for {@link Galeati} helmet-replacement spells.
+ *
+ * <p>Provides shared test coverage for the helmet-placement mechanics that all Galeati
+ * subclasses ({@link net.pottercraft.ollivanders2.spell.HERBIFORS},
+ * {@link net.pottercraft.ollivanders2.spell.MELOFORS}) inherit. Subclasses override
+ * {@link #getSpellType()} to specify which spell to test; the same test logic validates
+ * both spell variants.
+ *
+ * <p>Tests cover:
+ * <ul>
+ * <li><strong>No target:</strong> Spell hits a block with no nearby players and is killed</li>
+ * <li><strong>Bare-headed player:</strong> Spell places the correct helmet type on a player with no helmet</li>
+ * <li><strong>Helmeted player:</strong> Spell drops the existing helmet as an item and replaces it</li>
+ * </ul>
+ *
+ * @author Azami7
+ */
+abstract public class GaleatiTest extends O2SpellTestSuper {
+    /**
+     * Tests the full progression of Galeati helmet-replacement scenarios.
+     *
+     * <p>Sub-tests run in order against the same world and target player:
+     * <ul>
+     * <li>Spell cast with no nearby player — killed on block hit, no side effects</li>
+     * <li>Spell cast at a bare-headed player — helmet of {@link Galeati#getHelmetType()} placed</li>
+     * <li>Spell cast at a player wearing an iron helmet — existing helmet dropped at eye location,
+     *     new helmet of {@link Galeati#getHelmetType()} placed</li>
+     * </ul>
+     */
+    @Override
+    @Test
+    void doCheckEffectTest() {
+        World testWorld = mockServer.addSimpleWorld(getSpellType().getSpellName());
+        Location location = getNextLocation(testWorld);
+        Location targetLocation = new Location(testWorld, location.getX() + 3, location.getY(), location.getZ());
+        PlayerMock caster = mockServer.addPlayer();
+
+        TestCommon.createBlockBase(new Location(targetLocation.getWorld(), targetLocation.getX(), targetLocation.getY() - 1, targetLocation.getZ()), 5);
+
+        Galeati galeati = (Galeati) castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(galeati.isKilled(), "spell not killed when it hit a block");
+
+        PlayerMock targetPlayer = mockServer.addPlayer();
+        targetPlayer.setLocation(targetLocation);
+        EntityEquipment playerEquipment = targetPlayer.getEquipment();
+        assertNotNull(playerEquipment, "target player has no equipment");
+        assertNull(playerEquipment.getHelmet(), "Player should start with no helmet");
+        galeati = (Galeati) castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(galeati.isKilled(), "spell not killed when it hit an entity");
+        playerEquipment = targetPlayer.getEquipment();
+        assertNotNull(playerEquipment, "target player has no equipment");
+        ItemStack helmet = playerEquipment.getHelmet();
+        assertNotNull(helmet, "target player is not wearing a helmet");
+        assertEquals(galeati.getHelmetType(), helmet.getType(), "helmet is not expected type");
+
+        playerEquipment.setHelmet(new ItemStack(Material.IRON_HELMET));
+        galeati = (Galeati) castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        playerEquipment = targetPlayer.getEquipment();
+        assertNotNull(playerEquipment, "target player has no equipment");
+        helmet = playerEquipment.getHelmet();
+        assertNotNull(helmet, "target player is not wearing a helmet");
+        assertEquals(galeati.getHelmetType(), helmet.getType(), "helmet is not expected type");
+        Item droppedHelmet = EntityCommon.getItemAtLocation(targetPlayer.getEyeLocation());
+        assertNotNull(droppedHelmet, "player's original helmet was not dropped at the player location");
+        assertEquals(Material.IRON_HELMET, droppedHelmet.getItemStack().getType(), "dropped original helmet not expected type");
+    }
+
+    /**
+     * No-op revert test — Galeati spells have no revert actions to undo.
+     */
+    @Override
+    @Test
+    void revertTest() {
+        // no revert actions
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/HarmoniaNecterePassusTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/HarmoniaNecterePassusTest.java
@@ -70,7 +70,7 @@ public class HarmoniaNecterePassusTest extends O2SpellTestSuper {
         // cast the spell
         HARMONIA_NECTERE_PASSUS harmonia = (HARMONIA_NECTERE_PASSUS) castSpell(caster, castLocation, location1);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(harmonia.hasHitTarget(), "harmonia did not hit target");
+        assertTrue(harmonia.hasHitBlock(), "harmonia did not hit target");
 
         // verify the stationary spells were successfully cast
         assertTrue(Ollivanders2API.getStationarySpells().checkLocationForStationarySpell(location1, O2StationarySpellType.HARMONIA_NECTERE_PASSUS), "harmonia spell killed");
@@ -79,7 +79,7 @@ public class HarmoniaNecterePassusTest extends O2SpellTestSuper {
         // spell fails if there is already a harmonia stationary spell
         harmonia = (HARMONIA_NECTERE_PASSUS) castSpell(caster, castLocation, location1);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(harmonia.hasHitTarget());
+        assertTrue(harmonia.hasHitBlock());
         assertEquals(1, Ollivanders2API.getStationarySpells().getStationarySpellsAtLocation(location1).size(), "harmonia created a stationary spell when there was already a spell present");
 
         // clean spells for next tests
@@ -92,21 +92,21 @@ public class HarmoniaNecterePassusTest extends O2SpellTestSuper {
         location1.getBlock().setType(Material.DANDELION);
         harmonia = (HARMONIA_NECTERE_PASSUS) castSpell(caster, castLocation, location1);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(harmonia.hasHitTarget());
+        assertTrue(harmonia.hasHitBlock());
         assertFalse(Ollivanders2API.getStationarySpells().checkLocationForStationarySpell(location1, O2StationarySpellType.HARMONIA_NECTERE_PASSUS), "harmonia stationary spell was created when there was no sign");
 
         // spell fails if there is a sign, but it does not have the to location
         location1.getBlock().setType(Material.ACACIA_SIGN);
         harmonia = (HARMONIA_NECTERE_PASSUS) castSpell(caster, castLocation, location1);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(harmonia.hasHitTarget());
+        assertTrue(harmonia.hasHitBlock());
         assertFalse(Ollivanders2API.getStationarySpells().checkLocationForStationarySpell(location1, O2StationarySpellType.HARMONIA_NECTERE_PASSUS), "harmonia stationary spell was created when the sign had no text");
 
         // spell fails in the to and from location are the same
         net.pottercraft.ollivanders2.test.stationaryspell.HarmoniaNecterePassusTest.createCabinet(location1, location1);
         harmonia = (HARMONIA_NECTERE_PASSUS) castSpell(caster, castLocation, location1);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(harmonia.hasHitTarget());
+        assertTrue(harmonia.hasHitBlock());
         assertFalse(Ollivanders2API.getStationarySpells().checkLocationForStationarySpell(location1, O2StationarySpellType.HARMONIA_NECTERE_PASSUS), "harmonia stationary spell was created when to and from locations were the same");
     }
 

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/HerbiforsTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/HerbiforsTest.java
@@ -1,0 +1,18 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Tests for {@link net.pottercraft.ollivanders2.spell.HERBIFORS}. Inherits all test logic from
+ * {@link GaleatiTest}; only provides the spell type.
+ *
+ * @author Azami7
+ */
+public class HerbiforsTest extends GaleatiTest {
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.HERBIFORS;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/ImmobilizePlayerTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/ImmobilizePlayerTest.java
@@ -62,7 +62,7 @@ abstract public class ImmobilizePlayerTest extends O2SpellTestSuper {
         ImmobilizePlayer immobilize = (ImmobilizePlayer) castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
 
-        assertTrue(immobilize.hasHitTarget(), "did not hit target player");
+        assertTrue(immobilize.hasHitBlock(), "did not hit target player");
         if (immobilize.isFullImmobilize())
             assertTrue(Ollivanders2API.getPlayers().playerEffects.hasEffect(target.getUniqueId(), O2EffectType.FULL_IMMOBILIZE), "target does not have the full immobilize effect");
         else
@@ -90,7 +90,7 @@ abstract public class ImmobilizePlayerTest extends O2SpellTestSuper {
         ImmobilizePlayer immobilize = (ImmobilizePlayer) castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
 
-        assertTrue(immobilize.hasHitTarget());
+        assertTrue(immobilize.hasHitBlock());
         assertTrue(immobilize.getEffectDuration() <= immobilize.getMaxEffectDuration(), "effect duration is > max duration");
         assertTrue(immobilize.getEffectDuration() >= immobilize.getMinEffectDuration(), "effect duration is < min duration");
     }
@@ -169,7 +169,7 @@ abstract public class ImmobilizePlayerTest extends O2SpellTestSuper {
 
         ImmobilizePlayer immobilizePlayer = (ImmobilizePlayer) castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(immobilizePlayer.hasHitTarget());
+        assertTrue(immobilizePlayer.hasHitBlock());
 
         if (immobilizePlayer.doesImprison()) {
             Material prisonMaterial = immobilizePlayer.getImprisonMaterial();

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/IncendioBaseTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/IncendioBaseTest.java
@@ -364,7 +364,7 @@ abstract public class IncendioBaseTest extends O2SpellTestSuper {
         IncendioBase incendioBase = (IncendioBase) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel);
         mockServer.getScheduler().performTicks(20);
 
-        assertTrue(incendioBase.hasHitTarget());
+        assertTrue(incendioBase.hasHitBlock());
         assertEquals(Material.FIRE, above.getType());
         assertTrue(Ollivanders2API.getBlocks().isTemporarilyChangedBlock(above), "above block not added to temporarily changed block tracking");
         assertFalse(Ollivanders2API.getBlocks().isTemporarilyChangedBlock(target), "target block was added to temporarily changed block tracking");

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/MeloforsTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/MeloforsTest.java
@@ -1,0 +1,18 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Tests for {@link net.pottercraft.ollivanders2.spell.MELOFORS}. Inherits all test logic from
+ * {@link GaleatiTest}; only provides the spell type.
+ *
+ * @author Azami7
+ */
+public class MeloforsTest extends GaleatiTest {
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.MELOFORS;
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/MulticorforsTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/MulticorforsTest.java
@@ -1,0 +1,125 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.spell.MULTICORFORS;
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Color;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.ArmorStand;
+import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link MULTICORFORS}, the Multicorfors color-changing spell.
+ *
+ * <p>Tests cover the entity-scanning projectile model and the leather-armor recoloring behavior:
+ * <ul>
+ * <li><strong>No target:</strong> Spell hits a block with no entities nearby — killed, no failure message</li>
+ * <li><strong>Non-leather entity:</strong> Entity without leather armor (cow) — killed, failure message sent</li>
+ * <li><strong>Empty armor stand:</strong> Armor stand with no equipment — killed, failure message sent</li>
+ * <li><strong>Iron armor:</strong> Non-leather armor is not modified, failure message sent</li>
+ * <li><strong>Single leather piece:</strong> Leather chestplate is recolored to the spell's random color</li>
+ * <li><strong>Multiple leather pieces:</strong> All leather pieces receive the same random color</li>
+ * </ul>
+ *
+ * @author Azami7
+ */
+public class MulticorforsTest extends O2SpellTestSuper {
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.MULTICORFORS;
+    }
+
+    /**
+     * Tests the full progression of Multicorfors targeting scenarios against various entity
+     * and equipment configurations.
+     *
+     * <p>Sub-tests are ordered so that entities from earlier scenarios remain in the world,
+     * verifying the spell's iteration logic correctly skips entities without leather armor
+     * and continues searching. Each sub-test clears the caster's message queue after
+     * assertions to avoid stale messages leaking into the next sub-test.
+     */
+    @Override
+    @Test
+    void doCheckEffectTest() {
+        World testWorld = mockServer.addSimpleWorld(getSpellType().getSpellName());
+        Location location = getNextLocation(testWorld);
+        Location targetLocation = new Location(testWorld, location.getX() + 3, location.getY(), location.getZ());
+        PlayerMock caster = mockServer.addPlayer();
+
+        TestCommon.createBlockBase(new Location(targetLocation.getWorld(), targetLocation.getX(), targetLocation.getY() - 1, targetLocation.getZ()), 5);
+        MULTICORFORS multicorfors = (MULTICORFORS) castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(multicorfors.isKilled(), "spell not killed when it hit a block");
+        String message = caster.nextMessage();
+        assertNull(message, "caster received failure message when spell did not hit an entity and fail to change armor color");
+        TestCommon.clearMessageQueue(caster);
+
+        testWorld.spawnEntity(targetLocation, EntityType.COW);
+        multicorfors = (MULTICORFORS) castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(multicorfors.isKilled(), "spell not killed when it hit an entity");
+        message = caster.nextMessage();
+        assertNotNull(message, "caster did not receive failure message when armor stand has no equipment");
+        TestCommon.clearMessageQueue(caster);
+
+        ArmorStand armorStand = (ArmorStand) testWorld.spawnEntity(targetLocation, EntityType.ARMOR_STAND);
+        castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        message = caster.nextMessage();
+        assertNotNull(message, "caster did not receive failure message when armor stand has no armor");
+        TestCommon.clearMessageQueue(caster);
+
+        armorStand.getEquipment().setChestplate(new ItemStack(Material.IRON_CHESTPLATE));
+        multicorfors = (MULTICORFORS) castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(multicorfors.isKilled(), "spell not killed when it hit an entity");
+        assertEquals(Material.IRON_CHESTPLATE, armorStand.getEquipment().getChestplate().getType(), "armor stand equipment unexpectedly changed");
+        message = caster.nextMessage();
+        assertNotNull(message, "caster did not receive failure message");
+        TestCommon.clearMessageQueue(caster);
+
+        armorStand.getEquipment().setChestplate(new ItemStack(Material.LEATHER_CHESTPLATE));
+        multicorfors = (MULTICORFORS) castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        Color color = multicorfors.getColor();
+        ItemStack newChestplate = armorStand.getEquipment().getChestplate();
+        assertNotNull(newChestplate, "armor stand chestplate removed");
+        assertEquals(Material.LEATHER_CHESTPLATE, newChestplate.getType(), "armor stand chestplate unexpected type");
+        LeatherArmorMeta newChestplateMeta = (LeatherArmorMeta) newChestplate.getItemMeta();
+        assertEquals(color, newChestplateMeta.getColor(), "armor stand chestplate color unexpected");
+
+        armorStand.getEquipment().setChestplate(new ItemStack(Material.LEATHER_CHESTPLATE));
+        armorStand.getEquipment().setBoots(new ItemStack(Material.LEATHER_BOOTS));
+        multicorfors = (MULTICORFORS) castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        color = multicorfors.getColor();
+        newChestplate = armorStand.getEquipment().getChestplate();
+        ItemStack newBoots = armorStand.getEquipment().getBoots();
+        newChestplateMeta = (LeatherArmorMeta) newChestplate.getItemMeta();
+        assertEquals(color, newChestplateMeta.getColor(), "armor stand chestplate color unexpected");
+        LeatherArmorMeta newBootMeta = (LeatherArmorMeta) newBoots.getItemMeta();
+        assertEquals(newChestplateMeta.getColor(), newBootMeta.getColor(), "boots and chestplate are not the same color");
+    }
+
+    /**
+     * No-op revert test — MULTICORFORS has no revert actions to undo.
+     */
+    @Override
+    @Test
+    void revertTest() {
+        // no revert actions
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/O2SpellTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/O2SpellTest.java
@@ -230,14 +230,14 @@ public class O2SpellTest {
             melofors.checkEffect();
         }
         assertTrue(melofors.isKilled(), "melofors did not age out");
-        assertFalse(melofors.hasHitTarget(), "melofors set has hit target when spell aged out");
+        assertFalse(melofors.hasHitBlock(), "melofors set has hit target when spell aged out");
 
         // hitting a target stops the projectile
         melofors = new MELOFORS(testPlugin, caster, O2PlayerCommon.rightWand);
         testWorld.getBlockAt(targetLocation).setType(Material.DIRT);
         Ollivanders2API.getSpells().addSpell(caster, melofors);
         mockServer.getScheduler().performTicks(20);
-        assertTrue(melofors.hasHitTarget(), "melofors did not hit target");
+        assertTrue(melofors.hasHitBlock(), "melofors did not hit target");
         assertTrue(melofors.isKilled(), "melofors projectile not killed when target hit");
     }
 
@@ -408,7 +408,7 @@ public class O2SpellTest {
         accio.move();
         assertTrue(accio.isAtMaxDistance());
         assertTrue(accio.isKilled(), "Accio not killed when hitting max projectile distance.");
-        assertFalse(accio.hasHitTarget(), "Accio has hit target set when projectile hit max distance");
+        assertFalse(accio.hasHitBlock(), "Accio has hit target set when projectile hit max distance");
 
         // a move event is fire when projectiles move
         assertThat(mockServer.getPluginManager(), hasFiredEventInstance(OllivandersSpellProjectileMoveEvent.class));

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/PackTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/PackTest.java
@@ -1,0 +1,295 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import net.pottercraft.ollivanders2.spell.PACK;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.Chest;
+import org.bukkit.block.ShulkerBox;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Item;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import java.util.function.BiFunction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link PACK}, the Packing Charm.
+ *
+ * <p>Provides test coverage for the spell's container-packing mechanics including:
+ * <ul>
+ * <li><strong>Target validation:</strong> Verifies the spell only fires on chest-family blocks</li>
+ * <li><strong>Item collection:</strong> Tests that nearby item entities are scooped into the target container</li>
+ * <li><strong>Container routing:</strong> Validates correct destination for chests, ender chests, and shulker boxes</li>
+ * <li><strong>Overflow handling:</strong> Confirms items that exceed container capacity remain in the world with the leftover stack</li>
+ * <li><strong>Non-item entities:</strong> Verifies non-item entities within radius are not affected</li>
+ * </ul>
+ *
+ * @author Azami7
+ */
+public class PackTest extends O2SpellTestSuper {
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.PACK;
+    }
+
+    /**
+     * Tests packing behavior against a regular chest.
+     *
+     * <p>Verifies that:
+     * <ul>
+     * <li>The spell is killed when it strikes a non-chest block (oak door)</li>
+     * <li>The spell is killed when it strikes a chest with no nearby items, and the chest stays empty</li>
+     * <li>Nearby blocks of other types are not modified by the spell</li>
+     * <li>Non-item entities (boat) within radius are not affected</li>
+     * <li>A single nearby item is moved into the chest and removed from the world</li>
+     * <li>Multiple nearby items are all moved into the chest in a single cast</li>
+     * <li>Adding items does not remove items already in the chest</li>
+     * <li>Items that exceed the chest's remaining capacity remain in the world with the leftover stack amount</li>
+     * </ul>
+     */
+    @Override
+    @Test
+    void doCheckEffectTest() {
+        World testWorld = mockServer.addSimpleWorld(getSpellType().getSpellName());
+        Location location = getNextLocation(testWorld);
+        Location targetLocation = new Location(testWorld, location.getX() + 3, location.getY(), location.getZ());
+        PlayerMock caster = mockServer.addPlayer();
+
+        TestCommon.createBlockBase(new Location(targetLocation.getWorld(), targetLocation.getX(), targetLocation.getY() - 1, targetLocation.getZ()), 5);
+        targetLocation.getBlock().setType(Material.OAK_DOOR);
+
+        PACK pack = (PACK)castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(pack.isKilled(), "spell not killed when hit non pass through block");
+
+        Block chestBlock = targetLocation.getBlock();
+        chestBlock.setType(Material.CHEST);
+
+        // spell only targets blocks that are chest materials
+        Chest chest = (Chest)chestBlock.getState();
+        assertTrue(chest.getInventory().isEmpty());
+        pack = (PACK)castSpell(caster, location, targetLocation);
+        chest = (Chest)chestBlock.getState(); // get the state fresh every time since mockbukkit likes to cache it
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(pack.isKilled(), "spell not killed when it hit a chest block");
+        assertTrue(chest.getInventory().isEmpty());
+
+        // nearby blocks are not affected
+        Block nearbyBlock = chestBlock.getRelative(BlockFace.EAST);
+        nearbyBlock.setType(Material.OAK_PLANKS);
+        castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        assertEquals(Material.OAK_PLANKS, nearbyBlock.getType(), "nearby block type changed unexpectedly");
+        chest = (Chest)chestBlock.getState();
+        assertTrue(chest.getInventory().isEmpty());
+
+        // entities that are not items are not affected
+        Entity nearbyEntity = testWorld.spawnEntity(chestBlock.getRelative(BlockFace.WEST).getLocation(), EntityType.OAK_BOAT);
+        castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(nearbyEntity.isDead(), "nearby entity removed unexpectedly");
+        chest = (Chest)chestBlock.getState();
+        assertTrue(chest.getBlockInventory().isEmpty());
+
+        // add 1 item
+        Item nearbyItem = testWorld.dropItem(chestBlock.getRelative(BlockFace.SOUTH).getLocation(), new ItemStack(Material.COMPASS, 1));
+        castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        chest = (Chest)chestBlock.getState();
+        assertFalse(chest.getBlockInventory().isEmpty(), "Chest is empty when pack should have added 1 item");
+        assertEquals(1, getChestItemCount(chest), "unexpected count of items in chest");
+        assertTrue(nearbyItem.isDead(), "nearby item not removed when added to chest");
+        chest.getInventory().clear();
+
+        // add multiple items
+        nearbyItem = testWorld.dropItem(chestBlock.getRelative(BlockFace.SOUTH).getLocation(), new ItemStack(Material.COMPASS, 1));
+        Item nearbyItem2 = testWorld.dropItem(chestBlock.getRelative(BlockFace.NORTH).getLocation(), new ItemStack(Material.BOWL, 1));
+        castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        chest = (Chest)chestBlock.getState();
+        assertFalse(chest.getBlockInventory().isEmpty());
+        assertEquals(2, getChestItemCount(chest), "unexpected count of items in chest");
+        assertTrue(nearbyItem.isDead(), "nearby item not removed when added to chest");
+        assertTrue(nearbyItem2.isDead(), "nearby item not removed when added to chest");
+
+        // adding an item does not remove items already in the chest
+        nearbyItem = testWorld.dropItem(chestBlock.getRelative(BlockFace.SOUTH).getLocation(), new ItemStack(Material.BOOK, 1));
+        castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        chest = (Chest)chestBlock.getState();
+        assertFalse(chest.getBlockInventory().isEmpty());
+        assertEquals(3, getChestItemCount(chest), "unexpected count of items in chest");
+        assertTrue(nearbyItem.isDead(), "nearby item not removed when added to chest");
+
+        // adding more items that can fit results in overflow items outside the chest
+        int maxChestCapacity = 1728; // 27 slots x 64 item stack depth - https://minecraft.fandom.com/wiki/Chest
+        nearbyItem = testWorld.dropItem(chestBlock.getRelative(BlockFace.SOUTH).getLocation(), new ItemStack(Material.OXEYE_DAISY, maxChestCapacity));
+        castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        chest = (Chest)chestBlock.getState();
+        assertFalse(chest.getBlockInventory().isEmpty());
+        assertFalse(nearbyItem.isDead(), "item removed when there should be overflow inventory");
+        // remainder will be 1728 - 3 stacks of 64 because there are 3 item slots in use in the chest already = 192
+        assertEquals(192, nearbyItem.getItemStack().getAmount(), "unexpected overflow amount");
+    }
+
+    /**
+     * Tests packing behavior against an ender chest.
+     *
+     * <p>Verifies that items go into the caster's personal ender chest inventory rather than into
+     * the targeted block. Covers the same three phases as {@link #doCheckEffectTest()}:
+     * <ul>
+     * <li>Adding a single item</li>
+     * <li>Adding multiple items in one cast</li>
+     * <li>Overflow handling when items exceed the ender chest's capacity</li>
+     * </ul>
+     */
+    @Test
+    void enderChestTest() {
+        runContainerPackTest(
+                "PackEnderChest",
+                Material.ENDER_CHEST,
+                (block, caster) -> caster.getEnderChest(),
+                "ender chest"
+        );
+    }
+
+    /**
+     * Tests packing behavior against a shulker box.
+     *
+     * <p>Verifies that items are added to the shulker box's block inventory. Covers the same three
+     * phases as {@link #doCheckEffectTest()}:
+     * <ul>
+     * <li>Adding a single item</li>
+     * <li>Adding multiple items in one cast</li>
+     * <li>Overflow handling when items exceed the shulker box's capacity</li>
+     * </ul>
+     */
+    @Test
+    void shulkerBoxTest() {
+        runContainerPackTest(
+                "PackShulkerBox",
+                Material.SHULKER_BOX,
+                (block, caster) -> ((ShulkerBox)block.getState()).getInventory(),
+                "shulker box"
+        );
+    }
+
+    /**
+     * Shared three-phase pack test against an arbitrary container type.
+     *
+     * <p>Phases run in order against the same container, caster, and world:
+     * <ul>
+     * <li>Add a single item — verifies it lands in the container and the entity is removed.</li>
+     * <li>Add multiple items in one cast — verifies all items land and all entities are removed.</li>
+     * <li>Overflow — drops more items than the container can hold and verifies the leftover stack
+     *     remains in the world with the correct overflow amount.</li>
+     * </ul>
+     *
+     * <p>The container inventory is cleared between phases.
+     *
+     * @param worldName          name passed to {@link org.mockbukkit.mockbukkit.ServerMock#addSimpleWorld(String)}
+     * @param containerMaterial  the container block type to spawn at the target location
+     * @param inventoryAccessor  function returning the container's inventory given the block and caster;
+     *                           called fresh on every access to avoid stale MockBukkit state
+     * @param containerLabel     human-readable container name used in assertion failure messages
+     */
+    private void runContainerPackTest(
+            String worldName,
+            Material containerMaterial,
+            BiFunction<Block, PlayerMock, Inventory> inventoryAccessor,
+            String containerLabel
+    ) {
+        World testWorld = mockServer.addSimpleWorld(worldName);
+        Location location = getNextLocation(testWorld);
+        Location targetLocation = new Location(testWorld, location.getX() + 3, location.getY(), location.getZ());
+        PlayerMock caster = mockServer.addPlayer();
+
+        TestCommon.createBlockBase(new Location(targetLocation.getWorld(), targetLocation.getX(), targetLocation.getY() - 1, targetLocation.getZ()), 5);
+        Block containerBlock = targetLocation.getBlock();
+        containerBlock.setType(containerMaterial);
+
+        // sanity check: container is empty to start
+        assertTrue(inventoryAccessor.apply(containerBlock, caster).isEmpty());
+
+        // add 1 item
+        Item nearbyItem = testWorld.dropItem(containerBlock.getRelative(BlockFace.SOUTH).getLocation(), new ItemStack(Material.COMPASS, 1));
+        castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(inventoryAccessor.apply(containerBlock, caster).isEmpty(), containerLabel + " is empty when pack should have added 1 item");
+        assertEquals(1, getInventoryItemCount(inventoryAccessor.apply(containerBlock, caster)), "unexpected count of items in " + containerLabel);
+        assertTrue(nearbyItem.isDead(), "nearby item not removed when added to " + containerLabel);
+        inventoryAccessor.apply(containerBlock, caster).clear();
+
+        // add multiple items
+        nearbyItem = testWorld.dropItem(containerBlock.getRelative(BlockFace.SOUTH).getLocation(), new ItemStack(Material.COMPASS, 1));
+        Item nearbyItem2 = testWorld.dropItem(containerBlock.getRelative(BlockFace.NORTH).getLocation(), new ItemStack(Material.BOWL, 1));
+        castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(inventoryAccessor.apply(containerBlock, caster).isEmpty());
+        assertEquals(2, getInventoryItemCount(inventoryAccessor.apply(containerBlock, caster)), "unexpected count of items in " + containerLabel);
+        assertTrue(nearbyItem.isDead(), "nearby item not removed when added to " + containerLabel);
+        assertTrue(nearbyItem2.isDead(), "nearby item not removed when added to " + containerLabel);
+        inventoryAccessor.apply(containerBlock, caster).clear();
+
+        // adding more items than can fit results in overflow items outside the container
+        int maxCapacity = 1728; // 27 slots x 64 item stack depth - https://minecraft.fandom.com/wiki/Chest
+        nearbyItem = testWorld.dropItem(containerBlock.getRelative(BlockFace.SOUTH).getLocation(), new ItemStack(Material.OXEYE_DAISY, maxCapacity + 3));
+        castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(inventoryAccessor.apply(containerBlock, caster).isEmpty());
+        assertFalse(nearbyItem.isDead(), "item removed when there should be overflow inventory");
+        // remainder will be (1728 + 3) - 1728 = 3
+        assertEquals(3, nearbyItem.getItemStack().getAmount(), "unexpected overflow amount");
+    }
+
+    /**
+     * Counts the number of non-empty item slots in a chest's block inventory.
+     *
+     * @param chest the chest whose contents to count
+     * @return the number of slots containing items
+     */
+    private int getChestItemCount(Chest chest) {
+        return getInventoryItemCount(chest.getBlockInventory());
+    }
+
+    /**
+     * Counts the number of non-empty item slots in an inventory.
+     *
+     * @param inventory the inventory whose contents to count
+     * @return the number of slots containing items
+     */
+    private int getInventoryItemCount(Inventory inventory) {
+        int count = 0;
+
+        for (ItemStack itemStack : inventory.getContents()) {
+            if (itemStack != null && itemStack.getAmount() > 0)
+                count = count + 1;
+        }
+
+        return count;
+    }
+
+    /**
+     * No-op revert test — PACK has no revert actions to undo.
+     */
+    @Override
+    @Test
+    void revertTest() {
+        // no revert actions
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/PackTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/PackTest.java
@@ -72,7 +72,7 @@ public class PackTest extends O2SpellTestSuper {
         TestCommon.createBlockBase(new Location(targetLocation.getWorld(), targetLocation.getX(), targetLocation.getY() - 1, targetLocation.getZ()), 5);
         targetLocation.getBlock().setType(Material.OAK_DOOR);
 
-        PACK pack = (PACK)castSpell(caster, location, targetLocation);
+        PACK pack = (PACK) castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
         assertTrue(pack.isKilled(), "spell not killed when hit non pass through block");
 
@@ -80,10 +80,10 @@ public class PackTest extends O2SpellTestSuper {
         chestBlock.setType(Material.CHEST);
 
         // spell only targets blocks that are chest materials
-        Chest chest = (Chest)chestBlock.getState();
+        Chest chest = (Chest) chestBlock.getState();
         assertTrue(chest.getInventory().isEmpty());
-        pack = (PACK)castSpell(caster, location, targetLocation);
-        chest = (Chest)chestBlock.getState(); // get the state fresh every time since mockbukkit likes to cache it
+        pack = (PACK) castSpell(caster, location, targetLocation);
+        chest = (Chest) chestBlock.getState(); // get the state fresh every time since mockbukkit likes to cache it
         mockServer.getScheduler().performTicks(20);
         assertTrue(pack.isKilled(), "spell not killed when it hit a chest block");
         assertTrue(chest.getInventory().isEmpty());
@@ -94,7 +94,7 @@ public class PackTest extends O2SpellTestSuper {
         castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
         assertEquals(Material.OAK_PLANKS, nearbyBlock.getType(), "nearby block type changed unexpectedly");
-        chest = (Chest)chestBlock.getState();
+        chest = (Chest) chestBlock.getState();
         assertTrue(chest.getInventory().isEmpty());
 
         // entities that are not items are not affected
@@ -102,14 +102,14 @@ public class PackTest extends O2SpellTestSuper {
         castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
         assertFalse(nearbyEntity.isDead(), "nearby entity removed unexpectedly");
-        chest = (Chest)chestBlock.getState();
+        chest = (Chest) chestBlock.getState();
         assertTrue(chest.getBlockInventory().isEmpty());
 
         // add 1 item
         Item nearbyItem = testWorld.dropItem(chestBlock.getRelative(BlockFace.SOUTH).getLocation(), new ItemStack(Material.COMPASS, 1));
         castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
-        chest = (Chest)chestBlock.getState();
+        chest = (Chest) chestBlock.getState();
         assertFalse(chest.getBlockInventory().isEmpty(), "Chest is empty when pack should have added 1 item");
         assertEquals(1, getChestItemCount(chest), "unexpected count of items in chest");
         assertTrue(nearbyItem.isDead(), "nearby item not removed when added to chest");
@@ -120,7 +120,7 @@ public class PackTest extends O2SpellTestSuper {
         Item nearbyItem2 = testWorld.dropItem(chestBlock.getRelative(BlockFace.NORTH).getLocation(), new ItemStack(Material.BOWL, 1));
         castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
-        chest = (Chest)chestBlock.getState();
+        chest = (Chest) chestBlock.getState();
         assertFalse(chest.getBlockInventory().isEmpty());
         assertEquals(2, getChestItemCount(chest), "unexpected count of items in chest");
         assertTrue(nearbyItem.isDead(), "nearby item not removed when added to chest");
@@ -130,7 +130,7 @@ public class PackTest extends O2SpellTestSuper {
         nearbyItem = testWorld.dropItem(chestBlock.getRelative(BlockFace.SOUTH).getLocation(), new ItemStack(Material.BOOK, 1));
         castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
-        chest = (Chest)chestBlock.getState();
+        chest = (Chest) chestBlock.getState();
         assertFalse(chest.getBlockInventory().isEmpty());
         assertEquals(3, getChestItemCount(chest), "unexpected count of items in chest");
         assertTrue(nearbyItem.isDead(), "nearby item not removed when added to chest");
@@ -140,7 +140,7 @@ public class PackTest extends O2SpellTestSuper {
         nearbyItem = testWorld.dropItem(chestBlock.getRelative(BlockFace.SOUTH).getLocation(), new ItemStack(Material.OXEYE_DAISY, maxChestCapacity));
         castSpell(caster, location, targetLocation);
         mockServer.getScheduler().performTicks(20);
-        chest = (Chest)chestBlock.getState();
+        chest = (Chest) chestBlock.getState();
         assertFalse(chest.getBlockInventory().isEmpty());
         assertFalse(nearbyItem.isDead(), "item removed when there should be overflow inventory");
         // remainder will be 1728 - 3 stacks of 64 because there are 3 item slots in use in the chest already = 192
@@ -184,7 +184,7 @@ public class PackTest extends O2SpellTestSuper {
         runContainerPackTest(
                 "PackShulkerBox",
                 Material.SHULKER_BOX,
-                (block, caster) -> ((ShulkerBox)block.getState()).getInventory(),
+                (block, caster) -> ((ShulkerBox) block.getState()).getInventory(),
                 "shulker box"
         );
     }
@@ -202,18 +202,13 @@ public class PackTest extends O2SpellTestSuper {
      *
      * <p>The container inventory is cleared between phases.
      *
-     * @param worldName          name passed to {@link org.mockbukkit.mockbukkit.ServerMock#addSimpleWorld(String)}
-     * @param containerMaterial  the container block type to spawn at the target location
-     * @param inventoryAccessor  function returning the container's inventory given the block and caster;
-     *                           called fresh on every access to avoid stale MockBukkit state
-     * @param containerLabel     human-readable container name used in assertion failure messages
+     * @param worldName         name passed to {@link org.mockbukkit.mockbukkit.ServerMock#addSimpleWorld(String)}
+     * @param containerMaterial the container block type to spawn at the target location
+     * @param inventoryAccessor function returning the container's inventory given the block and caster;
+     *                          called fresh on every access to avoid stale MockBukkit state
+     * @param containerLabel    human-readable container name used in assertion failure messages
      */
-    private void runContainerPackTest(
-            String worldName,
-            Material containerMaterial,
-            BiFunction<Block, PlayerMock, Inventory> inventoryAccessor,
-            String containerLabel
-    ) {
+    private void runContainerPackTest(String worldName, Material containerMaterial, BiFunction<Block, PlayerMock, Inventory> inventoryAccessor, String containerLabel) {
         World testWorld = mockServer.addSimpleWorld(worldName);
         Location location = getNextLocation(testWorld);
         Location targetLocation = new Location(testWorld, location.getX() + 3, location.getY(), location.getZ());

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/ReparifargeTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/ReparifargeTest.java
@@ -1,12 +1,50 @@
 package net.pottercraft.ollivanders2.test.spell;
 
+import net.pottercraft.ollivanders2.player.O2PlayerCommon;
+import net.pottercraft.ollivanders2.spell.AGUAMENTI;
+import net.pottercraft.ollivanders2.spell.FATUUS_AURUM;
+import net.pottercraft.ollivanders2.spell.LAPIFORS;
+import net.pottercraft.ollivanders2.spell.MORTUOS_SUSCITATE;
+import net.pottercraft.ollivanders2.spell.O2Spell;
 import net.pottercraft.ollivanders2.spell.O2SpellType;
+import net.pottercraft.ollivanders2.spell.REPARIFARGE;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Item;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link REPARIFARGE}, the untransfiguration counter-spell.
+ *
+ * <p>Tests cover both block and entity untransfiguration paths, the magic-level gating, and
+ * the success-rate clamping:
+ * <ul>
+ * <li><strong>Non-transfigured block:</strong> Spell hits a normal block — failure message sent</li>
+ * <li><strong>Block revert (within level):</strong> Reverts an OWL-level block transfiguration
+ *     ({@link FATUUS_AURUM}) from a BEGINNER-level counter-spell (1 level higher, within the +1 tolerance)</li>
+ * <li><strong>Block revert blocked (too high):</strong> Cannot revert a NEWT-level block
+ *     transfiguration ({@link AGUAMENTI}) — 2 levels above BEGINNER exceeds the +1 tolerance</li>
+ * <li><strong>Entity revert (within level):</strong> Reverts an OWL-level entity transfiguration
+ *     ({@link LAPIFORS}) via the entity-scanning projectile path</li>
+ * <li><strong>Entity revert blocked (too high):</strong> Cannot revert a NEWT-level entity
+ *     transfiguration ({@link MORTUOS_SUSCITATE})</li>
+ * <li><strong>Success rate clamping:</strong> Verifies {@link REPARIFARGE#getSuccessRate()} is
+ *     clamped to [{@link REPARIFARGE#minSuccessRate}, {@link REPARIFARGE#maxSuccessRate}]</li>
+ * </ul>
+ *
+ * @author Azami7
+ */
 public class ReparifargeTest extends O2SpellTestSuper {
     @Override
     @NotNull
@@ -14,6 +52,14 @@ public class ReparifargeTest extends O2SpellTestSuper {
         return O2SpellType.REPARIFARGE;
     }
 
+    /**
+     * Tests the untransfiguration behavior across block and entity targets at different
+     * magic levels.
+     *
+     * <p>All casts use {@link O2Spell#spellMasteryLevel} experience to guarantee 100% success
+     * rate, isolating the level-check logic from the random success check. Sub-tests clean up
+     * active transfigurations and message queues between scenarios to prevent state leakage.
+     */
     @Override
     @Test
     void doCheckEffectTest() {
@@ -22,11 +68,101 @@ public class ReparifargeTest extends O2SpellTestSuper {
         Location targetLocation = new Location(testWorld, location.getX() + 3, location.getY(), location.getZ());
         PlayerMock caster = mockServer.addPlayer();
 
+        TestCommon.createBlockBase(new Location(targetLocation.getWorld(), targetLocation.getX(), targetLocation.getY() - 1, targetLocation.getZ()), 5);
+
+        Block targetBlock = targetLocation.getBlock();
+        targetBlock.setType(Material.STONE);
+        REPARIFARGE reparifarge = (REPARIFARGE) castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(reparifarge.isKilled(), "spell not killed when it hit a block");
+        String message = caster.nextMessage();
+        assertNotNull(message, "caster did not receive failure message when spell hit non-transfigured block");
+        TestCommon.clearMessageQueue(caster);
+
+        // can revert a block transfiguration up to 1 level higher
+        FATUUS_AURUM fatuusAurum = (FATUUS_AURUM) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel, O2SpellType.FATUUS_AURUM);
+        mockServer.getScheduler().performTicks(5);
+        assertTrue(fatuusAurum.isTransfigured());
+        reparifarge = (REPARIFARGE) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(reparifarge.isKilled());
+        assertTrue(fatuusAurum.isKilled(), "Fatuus Aurum spell not removed by reparifarge");
+        message = caster.nextMessage();
+        assertNotNull(message, "caster did not receive success message when spell hit transfigured block");
+        TestCommon.clearMessageQueue(caster);
+
+        // cannot revert a block transfiguration 2 levels higher
+        targetBlock.setType(Material.AIR);
+        AGUAMENTI aguamenti = (AGUAMENTI) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel, O2SpellType.AGUAMENTI);
+        mockServer.getScheduler().performTicks(5);
+        assertTrue(aguamenti.isTransfigured());
+        Block waterBlock = aguamenti.getTargetBlock();
+        assertNotNull(waterBlock);
+        reparifarge = (REPARIFARGE) castSpell(caster, location, waterBlock.getLocation(), O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(reparifarge.isKilled());
+        assertFalse(aguamenti.isKilled(), "aguamenti spell removed when it should not be");
+        aguamenti.kill();
+        mockServer.getScheduler().performTicks(5);
+
+        // can revert an entity transfiguration up to 1 level higher
+        targetBlock.setType(Material.AIR);
+        Item droppedItem = testWorld.dropItem(targetLocation, new ItemStack(Material.IRON_HOE));
+        LAPIFORS lapifors = (LAPIFORS) castSpell(caster, location, droppedItem.getLocation(), O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel, O2SpellType.LAPIFORS);
+        mockServer.getScheduler().performTicks(5);
+        assertTrue(lapifors.isTransfigured());
+        reparifarge = (REPARIFARGE) castSpell(caster, location, lapifors.getLocation(), O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(reparifarge.isKilled());
+        assertTrue(lapifors.isKilled(), "lapifors was not removed by reparifarge");
+        message = caster.nextMessage();
+        assertNotNull(message, "caster did not receive success message when spell hit transfigured entity");
+        TestCommon.clearMessageQueue(caster);
+
+        // cannot revert an entity transfiguration 2 or more levels higher
+        droppedItem = testWorld.dropItem(targetLocation, new ItemStack(Material.ROTTEN_FLESH));
+        MORTUOS_SUSCITATE mortuosSuscitate = (MORTUOS_SUSCITATE) castSpell(caster, location, droppedItem.getLocation(), O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel, O2SpellType.MORTUOS_SUSCITATE);
+        mockServer.getScheduler().performTicks(5);
+        assertTrue(mortuosSuscitate.isTransfigured());
+        reparifarge = (REPARIFARGE) castSpell(caster, location, mortuosSuscitate.getLocation(), O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(reparifarge.isKilled());
+        assertFalse(mortuosSuscitate.isKilled(), "MORTUOS_SUSCITATE removed by reparifarge");
     }
 
+    /**
+     * Tests that the success rate is clamped to the configured min/max bounds.
+     *
+     * <p>Verifies that:
+     * <ul>
+     * <li>Experience 0 produces a success rate at or above {@link REPARIFARGE#minSuccessRate}</li>
+     * <li>Experience 50 produces exactly 50 (mid-range, no clamping)</li>
+     * <li>Experience 150 produces a success rate at or below {@link REPARIFARGE#maxSuccessRate}</li>
+     * </ul>
+     */
+    @Test
+    void successRateTest() {
+        World testWorld = mockServer.addSimpleWorld(getSpellType().getSpellName());
+        Location location = getNextLocation(testWorld);
+        Location targetLocation = new Location(testWorld, location.getX() + 3, location.getY(), location.getZ());
+        PlayerMock caster = mockServer.addPlayer();
+
+        REPARIFARGE reparifarge = (REPARIFARGE) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, 0);
+        assertTrue(reparifarge.getSuccessRate() >= REPARIFARGE.minSuccessRate);
+
+        reparifarge = (REPARIFARGE) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, 50);
+        assertEquals(50, reparifarge.getSuccessRate());
+
+        reparifarge = (REPARIFARGE) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, 150);
+        assertTrue(reparifarge.getSuccessRate() <= REPARIFARGE.maxSuccessRate);
+    }
+
+    /**
+     * No-op revert test — REPARIFARGE has no revert actions to undo.
+     */
     @Override
     @Test
     void revertTest() {
-
+        // no revert actions
     }
 }

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/ReparifargeTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/ReparifargeTest.java
@@ -1,0 +1,32 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+public class ReparifargeTest extends O2SpellTestSuper {
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.REPARIFARGE;
+    }
+
+    @Override
+    @Test
+    void doCheckEffectTest() {
+        World testWorld = mockServer.addSimpleWorld(getSpellType().getSpellName());
+        Location location = getNextLocation(testWorld);
+        Location targetLocation = new Location(testWorld, location.getX() + 3, location.getY(), location.getZ());
+        PlayerMock caster = mockServer.addPlayer();
+
+    }
+
+    @Override
+    @Test
+    void revertTest() {
+
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/RepariforsTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/RepariforsTest.java
@@ -1,12 +1,52 @@
 package net.pottercraft.ollivanders2.test.spell;
 
+import net.pottercraft.ollivanders2.Ollivanders2API;
+import net.pottercraft.ollivanders2.effect.IMMOBILIZE;
+import net.pottercraft.ollivanders2.effect.O2Effect;
+import net.pottercraft.ollivanders2.effect.O2EffectType;
+import net.pottercraft.ollivanders2.effect.SUSPENSION;
+import net.pottercraft.ollivanders2.player.O2PlayerCommon;
 import net.pottercraft.ollivanders2.spell.O2SpellType;
+import net.pottercraft.ollivanders2.spell.REPARIFORS;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityPotionEffectEvent;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link REPARIFORS}, the healing spell.
+ *
+ * <p>Tests cover the spell's three-stage priority healing cascade:
+ * <ul>
+ * <li><strong>No target:</strong> Spell hits a block with no nearby players and is killed</li>
+ * <li><strong>Minor heal:</strong> Player without ailments receives {@link PotionEffectType#INSTANT_HEALTH}.
+ *     Because {@code INSTANT_HEALTH} is an instant effect (it fires once and is never stored in
+ *     the active effects list), the test observes it via an {@link EntityPotionEffectEvent} listener
+ *     rather than {@code hasPotionEffect}.</li>
+ * <li><strong>Immobilize aging:</strong> Player with {@link O2EffectType#IMMOBILIZE} has the effect's
+ *     duration reduced by an experience-scaled percentage</li>
+ * <li><strong>Suspension blocks immobilize healing:</strong> Player with both
+ *     {@link O2EffectType#IMMOBILIZE} and {@link O2EffectType#SUSPENSION} is not treated for
+ *     immobilize (to prevent falling while suspended)</li>
+ * <li><strong>Poison halving:</strong> Player with {@link PotionEffectType#POISON} has the poison
+ *     duration halved, preserving the original amplifier</li>
+ * </ul>
+ *
+ * @author Azami7
+ */
 public class RepariforsTest extends O2SpellTestSuper {
     @Override
     @NotNull
@@ -14,19 +54,89 @@ public class RepariforsTest extends O2SpellTestSuper {
         return O2SpellType.REPARIFORS;
     }
 
+    /**
+     * Tests the full progression of Reparifors healing scenarios.
+     *
+     * <p>Sub-tests run in order against the same world and target player. Effect state is
+     * cleaned up between sub-tests via explicit effect removal. The target is placed 10 blocks
+     * from the caster (rather than the usual 3) to give more ticks of projectile travel,
+     * making the natural-aging arithmetic in the duration assertions more predictable.
+     */
     @Override
     @Test
     void doCheckEffectTest() {
         World testWorld = mockServer.addSimpleWorld(getSpellType().getSpellName());
         Location location = getNextLocation(testWorld);
-        Location targetLocation = new Location(testWorld, location.getX() + 3, location.getY(), location.getZ());
+        Location targetLocation = new Location(testWorld, location.getX() + 10, location.getY(), location.getZ());
         PlayerMock caster = mockServer.addPlayer();
 
+        TestCommon.createBlockBase(new Location(targetLocation.getWorld(), targetLocation.getX(), targetLocation.getY() - 1, targetLocation.getZ()), 5);
+        REPARIFORS reparifors = (REPARIFORS) castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(reparifors.isKilled(), "spell was not killed when it hit a block");
+
+        // player without poison or immobilize is healed
+        PlayerMock target = mockServer.addPlayer();
+        target.setLocation(targetLocation);
+        // we cannot check the player health level because MockBukkit does not apply the effects of Effects
+        // we also cannot use Player.hasPotionEffect because INSTANT_HEALTH is instant, it doesn't stay on the player to check
+        AtomicBoolean effectApplied = new AtomicBoolean(false);
+        mockServer.getPluginManager().registerEvents(new Listener() {
+            @EventHandler
+            public void onEffect(EntityPotionEffectEvent event) {
+                if (event.getEntity().equals(target)
+                        && event.getNewEffect() != null
+                        && event.getNewEffect().getType().equals(PotionEffectType.INSTANT_HEALTH)) {
+                    effectApplied.set(true);
+                }
+            }
+        }, testPlugin);
+        reparifors = (REPARIFORS) castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(reparifors.isKilled(), "spell was not killed when it hit an entity");
+        assertTrue(effectApplied.get());
+
+        // ages immobilize
+        Ollivanders2API.getPlayers().playerEffects.addEffect(new IMMOBILIZE(testPlugin, 1000, false, target.getUniqueId()));
+        assertTrue(Ollivanders2API.getPlayers().playerEffects.hasEffect(target.getUniqueId(), O2EffectType.IMMOBILIZE));
+        castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, 100);
+        mockServer.getScheduler().performTicks(11);
+        O2Effect immobilize = Ollivanders2API.getPlayers().playerEffects.getEffect(target.getUniqueId(), O2EffectType.IMMOBILIZE);
+        assertNotNull(immobilize);
+        // experience 100 will result in a 55% reduction on the 1000 tick duration, also subtract 12 ticks that will have passed since the effect was added
+        assertEquals(443, immobilize.duration, "Immobilize duration not reduced by expected amount");
+        Ollivanders2API.getPlayers().playerEffects.removeEffect(target.getUniqueId(), O2EffectType.IMMOBILIZE);
+
+        // does not change immobilize when player is also suspended
+        Ollivanders2API.getPlayers().playerEffects.addEffect(new IMMOBILIZE(testPlugin, 1000, false, target.getUniqueId()));
+        assertTrue(Ollivanders2API.getPlayers().playerEffects.hasEffect(target.getUniqueId(), O2EffectType.IMMOBILIZE));
+        Ollivanders2API.getPlayers().playerEffects.addEffect(new SUSPENSION(testPlugin, 1000, false, target.getUniqueId()));
+        assertTrue(Ollivanders2API.getPlayers().playerEffects.hasEffect(target.getUniqueId(), O2EffectType.SUSPENSION));
+        castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, 100);
+        mockServer.getScheduler().performTicks(11);
+        immobilize = Ollivanders2API.getPlayers().playerEffects.getEffect(target.getUniqueId(), O2EffectType.IMMOBILIZE);
+        assertNotNull(immobilize);
+        assertEquals(989, immobilize.duration, "immobilize duration reduced when player also has suspension");
+        Ollivanders2API.getPlayers().playerEffects.removeEffect(target.getUniqueId(), O2EffectType.IMMOBILIZE);
+        Ollivanders2API.getPlayers().playerEffects.removeEffect(target.getUniqueId(), O2EffectType.SUSPENSION);
+
+        // reduce poison duration
+        int duration = 1000;
+        target.addPotionEffect(new PotionEffect(PotionEffectType.POISON, 1000, 1));
+        castSpell(caster, location, targetLocation);
+        mockServer.getScheduler().performTicks(11);
+        PotionEffect potionEffect = target.getPotionEffect(PotionEffectType.POISON);
+        assertNotNull(potionEffect);
+        // reduce the duration by half
+        assertEquals(493, potionEffect.getDuration(), "poison duration not reduced to expected amount");
     }
 
+    /**
+     * No-op revert test — REPARIFORS has no revert actions to undo.
+     */
     @Override
     @Test
     void revertTest() {
-
+        // no revert actions
     }
 }

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/RepariforsTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/RepariforsTest.java
@@ -1,0 +1,32 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+public class RepariforsTest extends O2SpellTestSuper {
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.REPARIFORS;
+    }
+
+    @Override
+    @Test
+    void doCheckEffectTest() {
+        World testWorld = mockServer.addSimpleWorld(getSpellType().getSpellName());
+        Location location = getNextLocation(testWorld);
+        Location targetLocation = new Location(testWorld, location.getX() + 3, location.getY(), location.getZ());
+        PlayerMock caster = mockServer.addPlayer();
+
+    }
+
+    @Override
+    @Test
+    void revertTest() {
+
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/SpellZoneTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/SpellZoneTest.java
@@ -1,0 +1,238 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.Ollivanders2;
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import net.pottercraft.ollivanders2.spell.SpellZone;
+import net.pottercraft.ollivanders2.spell.SpellZone.SpellZoneType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link SpellZone}.
+ *
+ * <p>SpellZone is a value-object configuration class with no game-state side effects, so each
+ * scenario is independent and lives in its own {@code @Test} method. Tests cover:
+ * <ul>
+ * <li><strong>Construction:</strong> Each zone type stores name, world, type, and spell lists correctly</li>
+ * <li><strong>Cuboid wiring:</strong> CUBOID zones receive a working cuboid built from the area array</li>
+ * <li><strong>Defensive copies:</strong> Caller-supplied lists cannot be mutated through the SpellZone</li>
+ * <li><strong>Empty lists:</strong> Zones constructed with empty allow/disallow lists work without error</li>
+ * </ul>
+ *
+ * @author Azami7
+ */
+public class SpellZoneTest {
+    /**
+     * Name of the shared test world. Passed to {@link SpellZone}'s {@code world} parameter and to
+     * {@link org.mockbukkit.mockbukkit.ServerMock#addSimpleWorld(String)}.
+     */
+    static final String worldName = "SpellZone";
+
+    /**
+     * The shared MockBukkit world used by tests that need a {@link Location} for cuboid
+     * containment checks.
+     */
+    static World testWorld;
+
+    /**
+     * Shared mock Bukkit server instance for all tests.
+     *
+     * <p>Static field initialized once before all tests in this class. Reused across test instances
+     * to avoid expensive server setup/teardown for each test method.</p>
+     */
+    static ServerMock mockServer;
+
+    /**
+     * The plugin instance being tested.
+     *
+     * <p>Loaded before all test methods with the default configuration. Provides access to
+     * logger, scheduler, and other plugin API methods during tests.</p>
+     */
+    static Ollivanders2 testPlugin;
+
+    /**
+     * Initialize the mock Bukkit server, plugin, and shared test world before all tests.
+     *
+     * <p>Static setup method called once before all tests in this class. Creates the shared
+     * MockBukkit server, loads the Ollivanders2 plugin with the default test config, adds the
+     * shared {@link #testWorld}, and advances the scheduler past the plugin's startup delay.
+     * The same server, plugin, and world instances are reused across all test methods to
+     * avoid expensive setup/teardown per method.</p>
+     */
+    @BeforeAll
+    static void globalSetUp() {
+        Ollivanders2.testMode = true;
+
+        mockServer = MockBukkit.mock();
+        testPlugin = MockBukkit.loadWithConfig(Ollivanders2.class, new File("Ollivanders/test/resources/default_config.yml"));
+        testWorld = mockServer.addSimpleWorld(worldName);
+
+        // advance the server by 20 ticks to let the scheduler start (it has an initial delay of 20 ticks)
+        mockServer.getScheduler().performTicks(TestCommon.startupTicks);
+    }
+
+    /**
+     * Tests construction of a CUBOID zone.
+     *
+     * <p>Verifies that:
+     * <ul>
+     * <li>Name, type, world name, allowed list, and disallowed list are stored as provided</li>
+     * <li>The backing {@link net.pottercraft.ollivanders2.common.Cuboid} reports points inside
+     *     the supplied area as inside</li>
+     * <li>The backing cuboid reports points outside the supplied area as outside</li>
+     * </ul>
+     */
+    @Test
+    void cuboidZoneConstructorTest() {
+        int[] area = {0, 0, 0, 100, 100, 100};
+        ArrayList<O2SpellType> allowed = new ArrayList<>();
+        allowed.add(O2SpellType.PACK);
+        ArrayList<O2SpellType> disallowed = new ArrayList<>();
+        disallowed.add(O2SpellType.BOMBARDA);
+
+        SpellZone zone = new SpellZone("testCuboid", worldName, SpellZoneType.CUBOID, area, allowed, disallowed);
+
+        assertEquals("testCuboid", zone.getZoneName(), "zone name not stored correctly");
+        assertEquals(SpellZoneType.CUBOID, zone.getZoneType(), "zone type not stored correctly");
+        assertEquals(worldName, zone.getZoneWorldName(), "zone world name not stored correctly");
+        assertEquals(allowed, zone.getAllowedSpells(), "allowed spells not stored correctly");
+        assertEquals(disallowed, zone.getDisallowedSpells(), "disallowed spells not stored correctly");
+
+        assertNotNull(zone.getCuboid(), "cuboid not constructed for CUBOID zone");
+        assertTrue(zone.getCuboid().isInside(new Location(testWorld, 50, 50, 50)),
+                "cuboid should contain a point inside the supplied area");
+        assertFalse(zone.getCuboid().isInside(new Location(testWorld, 200, 200, 200)),
+                "cuboid should not contain a point outside the supplied area");
+    }
+
+    /**
+     * Tests construction of a WORLD zone.
+     *
+     * <p>Verifies that name, type, world name, and spell lists are stored as provided. The cuboid
+     * field is constructed as a stub for non-CUBOID zones (current implementation detail) but is
+     * not queried — the consumer filters by {@link SpellZoneType} before touching it.
+     */
+    @Test
+    void worldZoneConstructorTest() {
+        ArrayList<O2SpellType> allowed = new ArrayList<>();
+        allowed.add(O2SpellType.PACK);
+        allowed.add(O2SpellType.BOMBARDA);
+        ArrayList<O2SpellType> disallowed = new ArrayList<>();
+
+        // area is unused for WORLD zones; an empty stub is passed in production
+        int[] area = {0, 0, 0, 0, 0, 0};
+        SpellZone zone = new SpellZone("testWorld", worldName, SpellZoneType.WORLD, area, allowed, disallowed);
+
+        assertEquals("testWorld", zone.getZoneName(), "zone name not stored correctly");
+        assertEquals(SpellZoneType.WORLD, zone.getZoneType(), "zone type not stored correctly");
+        assertEquals(worldName, zone.getZoneWorldName(), "zone world name not stored correctly");
+        assertEquals(allowed, zone.getAllowedSpells(), "allowed spells not stored correctly");
+        assertEquals(disallowed, zone.getDisallowedSpells(), "disallowed spells not stored correctly");
+    }
+
+    /**
+     * Tests construction of a WORLD_GUARD zone.
+     *
+     * <p>Verifies that name, type, world name, and spell lists are stored as provided. As with
+     * WORLD zones, the cuboid field is a stub and is not queried.
+     */
+    @Test
+    void worldGuardZoneConstructorTest() {
+        ArrayList<O2SpellType> allowed = new ArrayList<>();
+        ArrayList<O2SpellType> disallowed = new ArrayList<>();
+        disallowed.add(O2SpellType.PACK);
+
+        int[] area = {0, 0, 0, 0, 0, 0};
+        SpellZone zone = new SpellZone("testRegion", worldName, SpellZoneType.WORLD_GUARD, area, allowed, disallowed);
+
+        assertEquals("testRegion", zone.getZoneName(), "zone name not stored correctly");
+        assertEquals(SpellZoneType.WORLD_GUARD, zone.getZoneType(), "zone type not stored correctly");
+        assertEquals(worldName, zone.getZoneWorldName(), "zone world name not stored correctly");
+        assertEquals(allowed, zone.getAllowedSpells(), "allowed spells not stored correctly");
+        assertEquals(disallowed, zone.getDisallowedSpells(), "disallowed spells not stored correctly");
+    }
+
+    /**
+     * Tests that the constructor makes defensive copies of the allowed and disallowed lists.
+     *
+     * <p>Verifies that:
+     * <ul>
+     * <li>Mutating the caller's allowed list after construction does not affect the zone's stored list</li>
+     * <li>Mutating the caller's disallowed list after construction does not affect the zone's stored list</li>
+     * <li>The getters also return copies — mutating a returned list does not affect the next call</li>
+     * </ul>
+     *
+     * <p>Without defensive copies, a caller (or a buggy test) could silently corrupt zone state
+     * after construction.
+     */
+    @Test
+    void defensiveCopyTest() {
+        ArrayList<O2SpellType> allowed = new ArrayList<>();
+        allowed.add(O2SpellType.PACK);
+        ArrayList<O2SpellType> disallowed = new ArrayList<>();
+        disallowed.add(O2SpellType.BOMBARDA);
+
+        int[] area = {0, 0, 0, 0, 0, 0};
+        SpellZone zone = new SpellZone("defensiveCopy", worldName, SpellZoneType.WORLD, area, allowed, disallowed);
+
+        // mutate the caller's lists after construction — must not affect the zone's stored copies
+        allowed.clear();
+        disallowed.clear();
+
+        assertEquals(1, zone.getAllowedSpells().size(), "zone's allowed list was aliased to caller list");
+        assertEquals(O2SpellType.PACK, zone.getAllowedSpells().getFirst(), "zone's allowed list was mutated by caller");
+        assertEquals(1, zone.getDisallowedSpells().size(), "zone's disallowed list was aliased to caller list");
+        assertEquals(O2SpellType.BOMBARDA, zone.getDisallowedSpells().getFirst(), "zone's disallowed list was mutated by caller");
+
+        // mutate the getter result — must not affect the next getter call
+        List<O2SpellType> firstAllowed = zone.getAllowedSpells();
+        firstAllowed.clear();
+        assertEquals(1, zone.getAllowedSpells().size(), "getAllowedSpells() returned a live reference instead of a copy");
+        assertNotSame(firstAllowed, zone.getAllowedSpells(), "getAllowedSpells() returned the same list reference twice");
+    }
+
+    /**
+     * Tests construction with empty allow and disallow lists.
+     *
+     * <p>Verifies that a zone can be constructed with no spell restrictions and the getters
+     * return empty (not null) lists.
+     */
+    @Test
+    void emptySpellListsTest() {
+        int[] area = {0, 0, 0, 0, 0, 0};
+        SpellZone zone = new SpellZone("empty", worldName, SpellZoneType.WORLD, area, new ArrayList<>(), new ArrayList<>());
+
+        assertNotNull(zone.getAllowedSpells(), "allowed spells getter returned null");
+        assertNotNull(zone.getDisallowedSpells(), "disallowed spells getter returned null");
+        assertTrue(zone.getAllowedSpells().isEmpty(), "allowed spells should be empty");
+        assertTrue(zone.getDisallowedSpells().isEmpty(), "disallowed spells should be empty");
+    }
+
+    /**
+     * Tear down the mock Bukkit server after all tests complete.
+     *
+     * <p>Static teardown method called once after all tests in this class have finished.
+     * Releases the MockBukkit server resources to prevent memory leaks and allow clean
+     * test execution in subsequent test classes.</p>
+     */
+    @AfterAll
+    static void globalTearDown() {
+        MockBukkit.unmock();
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/StationarySpellTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/StationarySpellTest.java
@@ -80,7 +80,7 @@ abstract public class StationarySpellTest extends O2SpellTestSuper {
         // spell is killed after hitting target if it is not noProjectile
         mockServer.getScheduler().performTicks(20);
         if (!stationarySpell.isNoProjectile()) {
-            assertTrue(stationarySpell.hasHitTarget());
+            assertTrue(stationarySpell.hasHitBlock());
             assertTrue(stationarySpell.isKilled(), "Spell not killed after hitting target");
         }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,10 +75,28 @@ tasks.withType<JavaCompile> {
 tasks.test {
     useJUnitPlatform()
     jvmArgs("-XX:+EnableDynamicAgentLoading")
-    // Make sure MockBukkit is completely cleaned up
-    finalizedBy("cleanTestPluginsDir")
+    // Make sure MockBukkit is completely cleaned up, and overlay dark CSS on the HTML report
+    finalizedBy("cleanTestPluginsDir", "applyDarkTestReportCss")
 }
 
 tasks.register<Delete>("cleanTestPluginsDir") {
     delete("plugins")
+}
+
+tasks.register<Copy>("applyDarkTestReportCss") {
+    from("gradle/test-report-css")
+    into(layout.buildDirectory.dir("reports/tests/test/css"))
+    // Gradle regenerates the default CSS on every test run, so always re-apply
+    outputs.upToDateWhen { false }
+}
+
+tasks.jacocoTestReport {
+    finalizedBy("applyDarkJacocoReportCss")
+}
+
+tasks.register<Copy>("applyDarkJacocoReportCss") {
+    from("gradle/jacoco-report-css")
+    into(layout.buildDirectory.dir("reports/jacoco/test/html/jacoco-resources"))
+    // JaCoCo regenerates its CSS on every report run, so always re-apply
+    outputs.upToDateWhen { false }
 }

--- a/gradle/jacoco-report-css/prettify.css
+++ b/gradle/jacoco-report-css/prettify.css
@@ -1,0 +1,13 @@
+/* Pretty printing styles. Used with prettify.js. Dark theme — VSCode Dark+ inspired. */
+
+.str { color: #ce9178; }
+.kwd { color: #569cd6; font-weight:bold; }
+.com { color: #6a9955; font-style:italic; }
+.typ { color: #4ec9b0; }
+.lit { color: #b5cea8; }
+.pun { color: #d4d4d4; }
+.pln { color: #d4d4d4; }
+.tag { color: #569cd6; }
+.atn { color: #9cdcfe; }
+.atv { color: #ce9178; }
+.dec { color: #569cd6; }

--- a/gradle/jacoco-report-css/report.css
+++ b/gradle/jacoco-report-css/report.css
@@ -1,0 +1,259 @@
+body, td {
+  font-family:sans-serif;
+  font-size:10pt;
+}
+
+body {
+  background-color:#1e1e1e;
+  color:#e0e0e0;
+}
+
+a, a:visited {
+  color:#6cb6ff;
+}
+
+h1 {
+  font-weight:bold;
+  font-size:18pt;
+}
+
+.breadcrumb {
+  border:#444 1px solid;
+  padding:2px 4px 2px 4px;
+}
+
+.breadcrumb .info {
+  float:right;
+}
+
+.breadcrumb .info a {
+  margin-left:8px;
+}
+
+.el_report {
+  padding-left:18px;
+  background-image:url(report.gif);
+  background-position:left center;
+  background-repeat:no-repeat;
+}
+
+.el_group {
+  padding-left:18px;
+  background-image:url(group.gif);
+  background-position:left center;
+  background-repeat:no-repeat;
+}
+
+.el_bundle {
+  padding-left:18px;
+  background-image:url(bundle.gif);
+  background-position:left center;
+  background-repeat:no-repeat;
+}
+
+.el_package {
+  padding-left:18px;
+  background-image:url(package.gif);
+  background-position:left center;
+  background-repeat:no-repeat;
+}
+
+.el_class {
+  padding-left:18px;
+  background-image:url(class.gif);
+  background-position:left center;
+  background-repeat:no-repeat;
+}
+
+.el_source {
+  padding-left:18px;
+  background-image:url(source.gif);
+  background-position:left center;
+  background-repeat:no-repeat;
+}
+
+.el_method {
+  padding-left:18px;
+  background-image:url(method.gif);
+  background-position:left center;
+  background-repeat:no-repeat;
+}
+
+.el_session {
+  padding-left:18px;
+  background-image:url(session.gif);
+  background-position:left center;
+  background-repeat:no-repeat;
+}
+
+pre.source {
+  border:#444 1px solid;
+  font-family:monospace;
+  background-color:#161616;
+  color:#d4d4d4;
+}
+
+pre.source ol {
+  margin-bottom: 0px;
+  margin-top: 0px;
+}
+
+pre.source li {
+  border-left: 1px solid #444;
+  color: #707070;
+  padding-left: 0px;
+}
+
+pre.source span.fc {
+  background-color:#1e3a1e;
+}
+
+pre.source span.nc {
+  background-color:#3a1e1e;
+}
+
+pre.source span.pc {
+  background-color:#3a3a1e;
+}
+
+pre.source span.bfc {
+  background-image: url(branchfc.gif);
+  background-repeat: no-repeat;
+  background-position: 2px center;
+}
+
+pre.source span.bfc:hover {
+  background-color:#2e5a2e;
+}
+
+pre.source span.bnc {
+  background-image: url(branchnc.gif);
+  background-repeat: no-repeat;
+  background-position: 2px center;
+}
+
+pre.source span.bnc:hover {
+  background-color:#5a2e2e;
+}
+
+pre.source span.bpc {
+  background-image: url(branchpc.gif);
+  background-repeat: no-repeat;
+  background-position: 2px center;
+}
+
+pre.source span.bpc:hover {
+  background-color:#5a5a2e;
+}
+
+table.coverage {
+  empty-cells:show;
+  border-collapse:collapse;
+}
+
+table.coverage thead {
+  background-color:#707070;
+  color:#f5f5f5;
+}
+
+table.coverage thead td {
+  white-space:nowrap;
+  padding:2px 14px 0px 6px;
+  border-bottom:#555 1px solid;
+}
+
+table.coverage thead td.bar {
+  border-left:#888 1px solid;
+}
+
+table.coverage thead td.ctr1 {
+  text-align:right;
+  border-left:#888 1px solid;
+}
+
+table.coverage thead td.ctr2 {
+  text-align:right;
+  padding-left:2px;
+}
+
+table.coverage thead td.sortable {
+  cursor:pointer;
+  background-image:url(sort.gif);
+  background-position:right center;
+  background-repeat:no-repeat;
+}
+
+table.coverage thead td.up {
+  background-image:url(up.gif);
+}
+
+table.coverage thead td.down {
+  background-image:url(down.gif);
+}
+
+table.coverage tbody td {
+  white-space:nowrap;
+  padding:2px 6px 2px 6px;
+  border-bottom:#333 1px solid;
+}
+
+table.coverage tbody tr:hover {
+  background: #283038 !important;
+}
+
+table.coverage tbody td.bar {
+  border-left:#333 1px solid;
+}
+
+td.bar img {
+  opacity: 0.55;
+}
+
+table.coverage tbody td.ctr1 {
+  text-align:right;
+  padding-right:14px;
+  border-left:#333 1px solid;
+}
+
+table.coverage tbody td.ctr2 {
+  text-align:right;
+  padding-right:14px;
+  padding-left:2px;
+}
+
+table.coverage tfoot td {
+  white-space:nowrap;
+  padding:2px 6px 2px 6px;
+}
+
+table.coverage tfoot td.bar {
+  border-left:#333 1px solid;
+}
+
+table.coverage tfoot td.ctr1 {
+  text-align:right;
+  padding-right:14px;
+  border-left:#333 1px solid;
+}
+
+table.coverage tfoot td.ctr2 {
+  text-align:right;
+  padding-right:14px;
+  padding-left:2px;
+}
+
+.footer {
+  margin-top:20px;
+  border-top:#444 1px solid;
+  padding-top:2px;
+  font-size:8pt;
+  color:#707070;
+}
+
+.footer a {
+  color:#707070;
+}
+
+.right {
+  float:right;
+}

--- a/gradle/test-report-css/base-style.css
+++ b/gradle/test-report-css/base-style.css
@@ -1,0 +1,177 @@
+
+body {
+    margin: 0;
+    padding: 0;
+    font-family: sans-serif;
+    font-size: 12pt;
+    background-color: #1e1e1e;
+    color: #e0e0e0;
+}
+
+a, a:visited {
+    color: #6cb6ff;
+}
+
+#content {
+    padding: 30px 50px;
+}
+
+#content h1 {
+    font-size: 160%;
+    margin-bottom: 10px;
+}
+
+#footer {
+    margin-top: 100px;
+    font-size: 80%;
+    white-space: nowrap;
+}
+
+#footer, #footer a {
+    color: #707070;
+}
+
+#line-wrapping-toggle {
+    vertical-align: middle;
+}
+
+#label-for-line-wrapping-toggle {
+    vertical-align: middle;
+}
+
+ul {
+    margin-left: 0;
+}
+
+h1, h2, h3 {
+    white-space: nowrap;
+}
+
+h2 {
+    font-size: 120%;
+}
+
+.tab-container .tab-container {
+    margin-left: 8px;
+}
+
+ul.tabLinks {
+    padding: 0;
+    margin-bottom: 0;
+    overflow: auto;
+    min-width: 800px;
+    width: auto;
+    border-bottom: solid 1px #555;
+}
+
+ul.tabLinks li {
+    float: left;
+    height: 100%;
+    list-style: none;
+    padding: 5px 10px;
+    border-radius: 7px 7px 0 0;
+    border: solid 1px transparent;
+    border-bottom: none;
+    margin-right: 6px;
+    background-color: #2a2a2a;
+}
+
+ul.tabLinks li.deselected > a {
+    color: #888;
+}
+
+ul.tabLinks li:hover {
+    background-color: #383838;
+}
+
+ul.tabLinks li.selected {
+    background-color: #1f3a44;
+    border-color: #555;
+}
+
+ul.tabLinks a {
+    font-size: 120%;
+    display: block;
+    outline: none;
+    text-decoration: none;
+    margin: 0;
+    padding: 0;
+}
+
+ul.tabLinks li h2 {
+    margin: 0;
+    padding: 0;
+}
+
+div.tab {
+}
+
+div.selected {
+    display: block;
+}
+
+div.deselected {
+    display: none;
+}
+
+div.tab table {
+    min-width: 350px;
+    width: auto;
+    border-collapse: collapse;
+}
+
+div.tab th, div.tab table {
+    border-bottom: solid 1px #444;
+}
+
+div.tab th {
+    text-align: left;
+    white-space: nowrap;
+    padding-left: 6em;
+}
+
+div.tab th:first-child {
+    padding-left: 0;
+}
+
+div.tab td {
+    white-space: nowrap;
+    padding-left: 6em;
+    padding-top: 5px;
+    padding-bottom: 5px;
+}
+
+div.tab td:first-child {
+    padding-left: 0;
+}
+
+div.tab td.numeric, div.tab th.numeric {
+    text-align: right;
+}
+
+span.code {
+    display: inline-block;
+    margin-top: 0;
+    margin-bottom: 1em;
+}
+
+span.code pre {
+    font-size: 11pt;
+    padding: 10px;
+    margin: 0;
+    background-color: #161616;
+    color: #d4d4d4;
+    border: solid 1px #444;
+    min-width: 700px;
+    width: auto;
+}
+
+span.wrapped pre {
+    word-wrap: break-word;
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+
+label.hidden {
+    display: none;
+}

--- a/gradle/test-report-css/style.css
+++ b/gradle/test-report-css/style.css
@@ -1,0 +1,84 @@
+
+#summary {
+    margin-top: 30px;
+    margin-bottom: 40px;
+}
+
+#summary table {
+    border-collapse: collapse;
+}
+
+#summary td {
+    vertical-align: top;
+}
+
+.breadcrumbs, .breadcrumbs a {
+    color: #9a9a9a;
+}
+
+.infoBox {
+    width: 110px;
+    padding-top: 15px;
+    padding-bottom: 15px;
+    text-align: center;
+}
+
+.infoBox p {
+    margin: 0;
+}
+
+.counter, .percent {
+    font-size: 120%;
+    font-weight: bold;
+    margin-bottom: 8px;
+}
+
+#duration {
+    width: 125px;
+}
+
+#successRate, .summaryGroup {
+    border: solid 2px #444;
+    -moz-border-radius: 10px;
+    border-radius: 10px;
+}
+
+#successRate {
+    width: 140px;
+    margin-left: 35px;
+}
+
+#successRate .percent {
+    font-size: 180%;
+}
+
+.success, .success a {
+    color: #6abf69;
+}
+
+div.success, #successRate.success {
+    background-color: #1f3a1f;
+    border-color: #2e7d32;
+}
+
+.failures, .failures a {
+    color: #ff6b6b;
+}
+
+.skipped, .skipped a {
+    color: #e0c068;
+}
+
+div.failures, #successRate.failures {
+    background-color: #3a1f1f;
+    border-color: #b60808;
+}
+
+ul.linkList {
+    padding-left: 0;
+}
+
+ul.linkList li {
+    list-style: none;
+    margin-bottom: 5px;
+}


### PR DESCRIPTION
* updated PACK logic to handle regular chests too,
* added a test code writer skill for Claude
* added use of Tag for material lists like chestBlocks
* added dark mode to gradle for Jupiter test results and Jacoco coverage reports because they were killing my eyes
* fixed isInside bug in Cuboid
* updated O2Spell.hasHitTarget to OSpell.hasHitBlock for clarity
* fixed level-check bug in reparifarge
* added many tests