### PR TITLE
Tests for LivingEntityToItemTransfiguration and RemovePotionEffect spells

### DIFF
--- a/.claude/skills/test-code-writer/SKILL.md
+++ b/.claude/skills/test-code-writer/SKILL.md
@@ -149,3 +149,4 @@ For MockBukkit-specific behavior, the published javadocs are at:
 6. Write the test, grouping state-dependent scenarios into single methods.
 7. Run only the affected test class first (`./gradlew test --tests <FQCN>`) to get fast feedback.
 8. Run the full test suite once everything passes locally.
+9. `git add` any newly created files so they're staged and visible in `git status` — new test files are easy to forget because they're untracked, and a missing file won't show up in a diff review.

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/AddPotionEffect.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/AddPotionEffect.java
@@ -95,7 +95,7 @@ public abstract class AddPotionEffect extends O2Spell {
     /**
      * The potion effect. Set to luck by default.
      */
-    List<PotionEffectType> effectTypes = new ArrayList<>();
+    List<PotionEffectType> potionEffectTypes = new ArrayList<>();
 
     /**
      * Default constructor for use in generating spell text.  Do not use to cast the spell.
@@ -204,7 +204,7 @@ public abstract class AddPotionEffect extends O2Spell {
 
         calculateAmplifier();
 
-        for (PotionEffectType effectType : effectTypes) {
+        for (PotionEffectType effectType : potionEffectTypes) {
             org.bukkit.potion.PotionEffect effect = new org.bukkit.potion.PotionEffect(effectType, durationInTicks, amplifier);
             target.addPotionEffect(effect);
 
@@ -249,11 +249,10 @@ public abstract class AddPotionEffect extends O2Spell {
      * @return a list of the potion effect types
      */
     @NotNull
-    public List<PotionEffectType> getEffectTypes() {
-        ArrayList<PotionEffectType> types = new ArrayList<>();
-        types.addAll(effectTypes);
-
-        return types;
+    public List<PotionEffectType> getPotionEffectTypes() {
+        return new ArrayList<>() {{
+            addAll(potionEffectTypes);
+        }};
     }
 
     public int getMinDurationInSeconds() {

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/ConfundoBase.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/ConfundoBase.java
@@ -28,6 +28,6 @@ public abstract class ConfundoBase extends AddPotionEffect {
     ConfundoBase(@NotNull Ollivanders2 plugin, @NotNull Player player, @NotNull Double rightWand) {
         super(plugin, player, rightWand);
 
-        effectTypes.add(PotionEffectType.NAUSEA);
+        potionEffectTypes.add(PotionEffectType.NAUSEA);
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/EPISKEY.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/EPISKEY.java
@@ -63,7 +63,7 @@ public final class EPISKEY extends AddPotionEffect {
         maxDurationInSeconds = maxDurationInSecondsConfig;
         durationModifier = 0.5; // 50%
 
-        effectTypes.add(PotionEffectType.REGENERATION);
+        potionEffectTypes.add(PotionEffectType.REGENERATION);
 
         initSpell();
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/EntityTransfiguration.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/EntityTransfiguration.java
@@ -355,9 +355,6 @@ public abstract class EntityTransfiguration extends Transfiguration {
      */
     @Override
     public boolean isTransfigured(@NotNull Entity entity) {
-        if (permanent)
-            return false;
-
         if (transfiguredEntity == null)
             return false;
 

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/IMMOBULUS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/IMMOBULUS.java
@@ -66,8 +66,8 @@ public final class IMMOBULUS extends AddPotionEffect {
         maxDurationInSeconds = maxDurationInSecondsConfig;
         durationModifier = 0.5; // 50%
 
-        effectTypes.add(PotionEffectType.SLOWNESS);
-        effectTypes.add(PotionEffectType.SLOW_FALLING);
+        potionEffectTypes.add(PotionEffectType.SLOWNESS);
+        potionEffectTypes.add(PotionEffectType.SLOW_FALLING);
 
         initSpell();
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/IMPEDIMENTA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/IMPEDIMENTA.java
@@ -66,7 +66,7 @@ public final class IMPEDIMENTA extends AddPotionEffect {
         maxDurationInSeconds = maxDurationInSecondsConfig;
         durationModifier = 0.5; // 50%
 
-        effectTypes.add(PotionEffectType.SLOWNESS);
+        potionEffectTypes.add(PotionEffectType.SLOWNESS);
 
         initSpell();
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/LEPUS_SACCULUM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/LEPUS_SACCULUM.java
@@ -1,6 +1,5 @@
 package net.pottercraft.ollivanders2.spell;
 
-import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
@@ -10,15 +9,39 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 
 /**
- * Mice to snuffboxes for minecraft we are using rabbits and bundles
+ * Permanently transfigures a rabbit into a white bundle.
+ * <p>
+ * Lepus Sacculum is the Minecraft adaptation of "Mice to Snuffboxes," a third-year Hogwarts
+ * Transfiguration lesson. Vanilla Minecraft has no mice, so the spell targets rabbits, and
+ * snuffboxes are represented as {@link Material#WHITE_BUNDLE white bundles}.
+ * </p>
+ * <p>
+ * Unlike most other transfiguration spells, Lepus Sacculum has a {@link #minSuccessRate 25%
+ * minimum success rate} regardless of caster skill, reflecting the spell's relative ease in canon.
+ * The transfiguration is permanent: the original rabbit is consumed and replaced with the bundle.
+ * </p>
  *
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/Mice_to_Snuffboxes">https://harrypotter.fandom.com/wiki/Mice_to_Snuffboxes</a>
- * @since 2.21
+ * @see <a href="https://harrypotter.fandom.com/wiki/Mice_to_Snuffboxes">Harry Potter Wiki - Mice to Snuffboxes</a>
  */
 public class LEPUS_SACCULUM extends LivingEntityToItemTransfiguration {
     /**
+     * Minimum per-tick success rate (as a percentage) for this spell, regardless of caster skill.
+     * <p>
+     * Lepus Sacculum is intentionally easy to cast: even a caster with zero experience has at
+     * least a 25% chance per tick to successfully transfigure the targeted rabbit. Used in
+     * {@link #doInitSpell()} as the floor when {@code usesModifier} is at or below this value.
+     * </p>
+     */
+    public static int minSuccessRate = 25;
+
+    /**
      * Default constructor for use in generating spell text. Do not use to cast the spell.
+     * <p>
+     * Populates {@link #flavorText} with the canon "Mice to Snuffboxes" excerpt and sets the
+     * descriptive {@link #text}. Does not initialize the {@link #transfigurationMap} or any
+     * cast-time state — the casting constructor handles that.
+     * </p>
      *
      * @param plugin the Ollivanders2 plugin
      */
@@ -26,7 +49,6 @@ public class LEPUS_SACCULUM extends LivingEntityToItemTransfiguration {
         super(plugin);
 
         spellType = O2SpellType.LEPUS_SACCULUM;
-        branch = O2MagicBranch.TRANSFIGURATION;
 
         flavorText = new ArrayList<>() {{
             add("\"Professor McGonagall watched them turn a mouse into a snuffbox - points were given for how pretty the snuffbox was, but taken away if it had whiskers.\"");
@@ -36,7 +58,12 @@ public class LEPUS_SACCULUM extends LivingEntityToItemTransfiguration {
     }
 
     /**
-     * Constructor.
+     * Constructor for casting Lepus Sacculum.
+     * <p>
+     * Configures the rabbit→white bundle entry in the {@link #transfigurationMap}, sets the
+     * projectile {@link #radius} and success message, then invokes {@link #initSpell()} which
+     * triggers {@link #doInitSpell()} to compute the success rate based on caster skill.
+     * </p>
      *
      * @param plugin    a callback to the MC plugin
      * @param player    the player who cast this spell
@@ -46,7 +73,6 @@ public class LEPUS_SACCULUM extends LivingEntityToItemTransfiguration {
         super(plugin, player, rightWand);
 
         spellType = O2SpellType.LEPUS_SACCULUM;
-        branch = O2MagicBranch.TRANSFIGURATION;
 
         transfigurationMap.put(EntityType.RABBIT, Material.WHITE_BUNDLE);
         radius = 1.5;
@@ -56,13 +82,18 @@ public class LEPUS_SACCULUM extends LivingEntityToItemTransfiguration {
     }
 
     /**
-     * Determine success rate based on caster's skill
+     * Calculate the per-tick success rate from the caster's skill, with a {@link #minSuccessRate} floor.
+     * <p>
+     * If {@code usesModifier} is at or below {@link #minSuccessRate}, the success rate is clamped
+     * to that floor; otherwise it equals {@code usesModifier} directly. Higher skill therefore
+     * produces a proportionally higher per-tick chance to transfigure the rabbit while the spell
+     * projectile is active.
+     * </p>
      */
     @Override
     void doInitSpell() {
-        // chance is no less than 25%
-        if (usesModifier <= 25)
-            successRate = 25;
+        if (usesModifier <= minSuccessRate)
+            successRate = minSuccessRate;
         else
             successRate = (int) (usesModifier);
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/LUMOS.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/LUMOS.java
@@ -19,8 +19,8 @@ import java.util.ArrayList;
  * @see <a href="https://harrypotter.fandom.com/wiki/Wand-Lighting_Charm">Wand-Lighting Charm</a>
  */
 public class LUMOS extends AddPotionEffectInRadius {
-    final static int minEffectRadiusConfig = 5;
-    final static int maxEffectRadiusConfig = 20;
+    public final static int minEffectRadiusConfig = 5;
+    public final static int maxEffectRadiusConfig = 20;
     private final static int minDurationInSecondsConfig = 30;
 
     /**
@@ -62,7 +62,7 @@ public class LUMOS extends AddPotionEffectInRadius {
         spellType = O2SpellType.LUMOS;
         branch = O2MagicBranch.CHARMS;
 
-        effectTypes.add(PotionEffectType.NIGHT_VISION);
+        potionEffectTypes.add(PotionEffectType.NIGHT_VISION);
         amplifier = 0; // Night Vision I
 
         minDurationInSeconds = minDurationInSecondsConfig;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/LUMOS_MAXIMA.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/LUMOS_MAXIMA.java
@@ -56,7 +56,7 @@ public final class LUMOS_MAXIMA extends AddPotionEffectInRadius {
         spellType = O2SpellType.LUMOS_MAXIMA;
         branch = O2MagicBranch.CHARMS;
 
-        effectTypes.add(PotionEffectType.BLINDNESS);
+        potionEffectTypes.add(PotionEffectType.BLINDNESS);
         amplifier = 1;
 
         minDurationInSeconds = minDurationInSecondsConfig;

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/LivingEntityToItemTransfiguration.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/LivingEntityToItemTransfiguration.java
@@ -52,6 +52,7 @@ public abstract class LivingEntityToItemTransfiguration extends EntityTransfigur
     public LivingEntityToItemTransfiguration(@NotNull Ollivanders2 plugin, @NotNull Player player, @NotNull Double rightWand) {
         super(plugin, player, rightWand);
 
+        branch = O2MagicBranch.TRANSFIGURATION;
         permanent = true;
         targetType = EntityType.ITEM;
 
@@ -83,17 +84,13 @@ public abstract class LivingEntityToItemTransfiguration extends EntityTransfigur
             return null;
         }
 
-        // spawn the new entity
-        Entity newEntity = entity.getWorld().spawnEntity(entity.getLocation(), targetType);
-        if (!(newEntity instanceof Item)) {
-            newEntity.remove();
-        }
-        ((Item) newEntity).setItemStack(new ItemStack(targetMaterial));
+        // spawn the new item entity
+        Item item = entity.getWorld().dropItem(entity.getLocation(), new ItemStack(targetMaterial));
 
         // remove the original entity
         entity.remove();
 
-        return newEntity;
+        return item;
     }
 
     /**
@@ -127,5 +124,9 @@ public abstract class LivingEntityToItemTransfiguration extends EntityTransfigur
         }
 
         return true;
+    }
+
+    public Material getTargetMaterial() {
+        return targetMaterial;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/MORSMORDRE.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/MORSMORDRE.java
@@ -89,7 +89,7 @@ public final class MORSMORDRE extends AddPotionEffectInRadius {
         maxDurationInSeconds = 600; // 10 mins
         targetSelf = false;
 
-        effectTypes.add(PotionEffectType.BAD_OMEN);
+        potionEffectTypes.add(PotionEffectType.BAD_OMEN);
 
         initSpell();
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/NOX.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/NOX.java
@@ -10,11 +10,16 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 
 /**
- * Cancels the effect of the LUMOS spell or removes the effect of a Night Vision potion.
+ * The Wand-Extinguishing Charm — cancels the effect of {@link LUMOS} or removes a Night Vision potion effect.
+ *
+ * <p>NOX removes Night Vision from the caster and all nearby entities within a radius that scales
+ * with the caster's experience. The radius uses the same bounds as {@link LUMOS} so that a NOX cast
+ * at the same skill level can fully counter a LUMOS. Success is guaranteed regardless of experience
+ * level ({@code successModifier = 0.01f}).</p>
  *
  * @author Azami7
- * @version Ollivanders2
- * @see <a href="https://harrypotter.fandom.com/wiki/Wand-Extinguishing_Charm">https://harrypotter.fandom.com/wiki/Wand-Extinguishing_Charm</a>
+ * @see LUMOS
+ * @see <a href="https://harrypotter.fandom.com/wiki/Wand-Extinguishing_Charm">Harry Potter Wiki - Wand-Extinguishing Charm</a>
  */
 public final class NOX extends RemovePotionEffectInRadius {
     /**
@@ -51,19 +56,23 @@ public final class NOX extends RemovePotionEffectInRadius {
         targetSelf = true;
 
         potionEffectTypes.add(PotionEffectType.NIGHT_VISION);
+        successModifier = 0.01f; // this will make casting NOX 100% successful
 
         initSpell();
-        successModifier = 0.01f; // this will make casting NOX 100% successful
     }
 
+    /**
+     * Calculate the effect radius based on the caster's experience with this spell.
+     *
+     * <p>Uses the same minimum and maximum radius as {@link LUMOS} so that NOX can fully
+     * counter a LUMOS cast at the same skill level.</p>
+     */
     @Override
     void doInitSpell() {
-        // use the same min and max radius and Lumos
-
-        radius = ((int) usesModifier) / 10;
-        if (radius < LUMOS.minEffectRadiusConfig)
-            radius = LUMOS.minEffectRadiusConfig;
-        else if (radius > LUMOS.maxEffectRadiusConfig)
-            radius = LUMOS.maxEffectRadiusConfig;
+        effectRadius = usesModifier / 10;
+        if (effectRadius < LUMOS.minEffectRadiusConfig)
+            effectRadius = LUMOS.minEffectRadiusConfig;
+        else if (effectRadius > LUMOS.maxEffectRadiusConfig)
+            effectRadius = LUMOS.maxEffectRadiusConfig;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/OBSCURO.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/OBSCURO.java
@@ -63,7 +63,7 @@ public final class OBSCURO extends AddPotionEffect {
         durationModifier = 1.0;
         affectSingleTarget = false;
 
-        effectTypes.add(PotionEffectType.BLINDNESS);
+        potionEffectTypes.add(PotionEffectType.BLINDNESS);
 
         initSpell();
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/RANACULUS_AMPHORAM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/RANACULUS_AMPHORAM.java
@@ -1,24 +1,44 @@
 package net.pottercraft.ollivanders2.spell;
 
-import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-
 /**
- * Snail to teapot for mincraft using tadpole as one of the smallest mobs
+ * Permanently transfigures a tadpole into a decorated pot.
+ * <p>
+ * Ranaculus Amphoram is the Minecraft adaptation of "Snail to Teapot," a Hogwarts Transfiguration
+ * exercise. Vanilla Minecraft has no snails, so the spell targets tadpoles (one of the smallest
+ * mobs available), and teapots are represented as {@link Material#DECORATED_POT decorated pots}.
+ * </p>
+ * <p>
+ * Like {@link LEPUS_SACCULUM}, Ranaculus Amphoram has a {@link #minSuccessRate 25% minimum success
+ * rate} regardless of caster skill, reflecting the spell's relative ease in canon. The
+ * transfiguration is permanent: the original tadpole is consumed and replaced with the pot.
+ * </p>
  *
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/Snail_to_Teapot">https://harrypotter.fandom.com/wiki/Snail_to_Teapot</a>
- * @since 2.21
+ * @see <a href="https://harrypotter.fandom.com/wiki/Snail_to_Teapot">Harry Potter Wiki - Snail to Teapot</a>
  */
 public class RANACULUS_AMPHORAM extends LivingEntityToItemTransfiguration {
     /**
+     * Minimum per-tick success rate (as a percentage) for this spell, regardless of caster skill.
+     * <p>
+     * Ranaculus Amphoram is intentionally easy to cast: even a caster with zero experience has at
+     * least a 25% chance per tick to successfully transfigure the targeted tadpole. Used in
+     * {@link #doInitSpell()} as the floor when {@code usesModifier} is at or below this value.
+     * </p>
+     */
+    public static int minSuccessRate = 25;
+
+    /**
      * Default constructor for use in generating spell text. Do not use to cast the spell.
+     * <p>
+     * Sets the descriptive {@link #text} for the spell info display. Does not initialize the
+     * {@link #transfigurationMap} or any cast-time state — the casting constructor handles that.
+     * </p>
      *
      * @param plugin the Ollivanders2 plugin
      */
@@ -26,13 +46,17 @@ public class RANACULUS_AMPHORAM extends LivingEntityToItemTransfiguration {
         super(plugin);
 
         spellType = O2SpellType.RANACULUS_AMPHORAM;
-        branch = O2MagicBranch.TRANSFIGURATION;
 
         text = "The transfiguration spell Ranaculus Amphoram will transfigure a tadpole into a decorated pot.";
     }
 
     /**
-     * Constructor.
+     * Constructor for casting Ranaculus Amphoram.
+     * <p>
+     * Configures the tadpole→decorated pot entry in the {@link #transfigurationMap}, sets the
+     * projectile {@link #radius} and success message, then invokes {@link #initSpell()} which
+     * triggers {@link #doInitSpell()} to compute the success rate based on caster skill.
+     * </p>
      *
      * @param plugin    a callback to the MC plugin
      * @param player    the player who cast this spell
@@ -42,7 +66,6 @@ public class RANACULUS_AMPHORAM extends LivingEntityToItemTransfiguration {
         super(plugin, player, rightWand);
 
         spellType = O2SpellType.RANACULUS_AMPHORAM;
-        branch = O2MagicBranch.TRANSFIGURATION;
 
         transfigurationMap.put(EntityType.TADPOLE, Material.DECORATED_POT);
         radius = 1.5;
@@ -52,13 +75,18 @@ public class RANACULUS_AMPHORAM extends LivingEntityToItemTransfiguration {
     }
 
     /**
-     * Determine success rate based on caster's skill
+     * Calculate the per-tick success rate from the caster's skill, with a {@link #minSuccessRate} floor.
+     * <p>
+     * If {@code usesModifier} is at or below {@link #minSuccessRate}, the success rate is clamped
+     * to that floor; otherwise it equals {@code usesModifier} directly. Higher skill therefore
+     * produces a proportionally higher per-tick chance to transfigure the tadpole while the spell
+     * projectile is active.
+     * </p>
      */
     @Override
     void doInitSpell() {
-        // chance is no less than 25%
-        if (usesModifier <= 25)
-            successRate = 25;
+        if (usesModifier <= minSuccessRate)
+            successRate = minSuccessRate;
         else
             successRate = (int) (usesModifier);
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/RemovePotionEffect.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/RemovePotionEffect.java
@@ -12,18 +12,35 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Remove potion effects from a target.
+ * Base class for spells that remove potion effects from targets.
+ *
+ * <p>Provides functionality for removing one or more potion effects from living entities within
+ * a configurable radius. Each effect removal is subject to a success check based on the caster's
+ * spell experience level. Subclasses configure which effect types to remove, the effect radius,
+ * number of targets, and whether to target the caster or nearby entities.</p>
+ *
+ * <p>Configuration:</p>
+ *
+ * <ul>
+ * <li>Success rate: calculated from usesModifier / successModifier, clamped to [1, 100]</li>
+ * <li>Does this spell affect multiple targets, set by {@link #affectsMultiple}</li>
+ * <li>Target filtering: excludes caster unless {@link #targetSelf} is true</li>
+ * <li>Visual flair: optional particle effect at spell location (controlled by {@link #doFlair})</li>
+ * <li>Effect radius: configurable via {@link #effectRadius}, defaults to {@link O2Spell#defaultRadius}</li>
+ * </ul>
+ *
+ * @see AddPotionEffect
  */
 public abstract class RemovePotionEffect extends O2Spell {
     /**
-     * The potion effect. Set to luck by default.
+     * The potion effects to remove
      */
     List<PotionEffectType> potionEffectTypes = new ArrayList<>();
 
     /**
-     * Number of targets that can be affected
+     * Does this spell affect multiple targets
      */
-    int numberOfTargets = 1;
+    boolean affectsMultiple = false;
 
     /**
      * Whether the spell targets the caster
@@ -34,6 +51,16 @@ public abstract class RemovePotionEffect extends O2Spell {
      * The modifier for success rate on this spell
      */
     float successModifier = 1.0f;
+
+    /**
+     * Does this spell do a flair?
+     */
+    boolean doFlair = false;
+
+    /**
+     * The radius of effect for this spell
+     */
+    double effectRadius = defaultRadius;
 
     /**
      * Default constructor for use in generating spell text.  Do not use to cast the spell.
@@ -60,62 +87,68 @@ public abstract class RemovePotionEffect extends O2Spell {
     }
 
     /**
-     * If a target player is within the radius of the projectile, add the potion effect to the player.
+     * Remove potion effects from nearby targets within the effect radius.
+     *
+     * <p>If the spell has hit a block, it is killed. Otherwise, processes targets within the effect
+     * radius — starting with the caster if {@link #targetSelf} is true, then iterating through
+     * nearby living entities if {@link #affectsMultiple}. Kills the spell once at least one
+     * target has been processed.</p>
      */
     @Override
     protected void doCheckEffect() {
         if (hasHitBlock())
             kill();
 
-        affectRadius(defaultRadius, false);
-    }
+        if (doFlair)
+            Ollivanders2Common.flair(location, (int) effectRadius, 10);
 
-    /**
-     * Affect targets within the radius.
-     *
-     * @param radius the radius of the spell
-     * @param flair  whether or not to show a visual flair
-     */
-    void affectRadius(double radius, boolean flair) {
-        if (flair)
-            Ollivanders2Common.flair(location, (int) radius, 10);
+        boolean foundTargets = false;
 
-        if (targetSelf) {
+        if (targetSelf) { // ensure the caster gets the effect removal first
             removePotionEffects(caster);
-            numberOfTargets = numberOfTargets - 1;
+            foundTargets = true;
         }
 
-        for (LivingEntity livingEntity : getNearbyLivingEntities(radius)) {
-            // stop when the limit of targets is reached
-            if (numberOfTargets <= 0) {
-                kill();
-                return;
-            }
+        for (LivingEntity livingEntity : getNearbyLivingEntities(effectRadius)) {
+            // stop if limit of targets is reached
+            if (foundTargets && !affectsMultiple)
+                break;
 
             if (livingEntity.getUniqueId().equals(caster.getUniqueId())) // already handled self above
                 continue;
 
             removePotionEffects(livingEntity);
-            numberOfTargets = numberOfTargets - 1;
+            foundTargets = true;
         }
+
+        if (foundTargets)
+            kill();
     }
 
     /**
-     * Remove potion effects from the target player
+     * Remove potion effects from the target entity.
      *
-     * @param target the player to remove effects from
+     * <p>Iterates through all configured {@link #potionEffectTypes} and attempts to remove each one.
+     * Each removal is subject to a {@link #checkSuccess()} roll — only effects that pass the check
+     * are removed.</p>
+     *
+     * @param target the living entity to remove effects from
      */
     void removePotionEffects(@NotNull LivingEntity target) {
-        for (PotionEffectType effectType : potionEffectTypes) {
+        for (PotionEffectType potionEffectType : potionEffectTypes) {
             if (checkSuccess()) {
-                common.printDebugMessage("Removing " + effectType.getName() + " from " + target.getName(), null, null, false);
-                target.removePotionEffect(effectType);
+                common.printDebugMessage("Removing " + potionEffectType.getName() + " from " + target.getName(), null, null, false);
+                target.removePotionEffect(potionEffectType);
             }
         }
     }
 
     /**
-     * Determine if this spell is successful based on player skill and level of the effect relative to the level of this spell.
+     * Determine if this spell successfully removes an effect based on the caster's experience.
+     *
+     * <p>Calculates a success rate from {@code usesModifier / successModifier}, clamped to [1, 100],
+     * then rolls against it. A lower {@link #successModifier} makes success easier (e.g., 0.01 yields
+     * near-certain success).</p>
      *
      * @return true if the effect can be removed, false otherwise
      */
@@ -126,6 +159,18 @@ public abstract class RemovePotionEffect extends O2Spell {
         else if (successRate > 100)
             successRate = 100;
 
-        return Math.abs(Ollivanders2Common.random.nextInt() % 100) < successRate;
+        return Ollivanders2Common.random.nextInt(100) < successRate;
+    }
+
+    public boolean doesTargetSelf() {
+        return targetSelf;
+    }
+
+    public boolean doesAffectMultiple() {
+        return affectsMultiple;
+    }
+
+    public double getEffectRadius() {
+        return effectRadius;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/RemovePotionEffectInRadius.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/RemovePotionEffectInRadius.java
@@ -5,14 +5,15 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Remove a potion effect for all entities in a radius of the caster
+ * Base class for instant-radius potion effect removal spells.
+ *
+ * <p>These spells remove potion effects from all targets within a radius of the caster without
+ * using a projectile. The spell fires immediately with a visual flair and affects multiple
+ * targets based on the configured radius.</p>
+ *
+ * @see AddPotionEffectInRadius
  */
 public class RemovePotionEffectInRadius extends RemovePotionEffect {
-    /**
-     * Radius of the spell from the caster.
-     */
-    int radius = 5;
-
     /**
      * Default constructor for use in generating spell text.  Do not use to cast the spell.
      *
@@ -23,7 +24,10 @@ public class RemovePotionEffectInRadius extends RemovePotionEffect {
     }
 
     /**
-     * Constructor.
+     * Constructor for casting the spell.
+     *
+     * <p>Configures the spell as an instant radius effect with no projectile and visual flair.
+     * All eligible targets within the configured radius are affected.</p>
      *
      * @param plugin    a callback to the MC plugin
      * @param player    the player who cast this spell
@@ -31,20 +35,10 @@ public class RemovePotionEffectInRadius extends RemovePotionEffect {
      */
     public RemovePotionEffectInRadius(@NotNull Ollivanders2 plugin, @NotNull Player player, @NotNull Double rightWand) {
         super(plugin, player, rightWand);
-    }
 
-    /**
-     * Remove the potion effect from the caster.
-     */
-    @Override
-    public void checkEffect() {
-        if (!isSpellAllowed()) {
-            kill();
-            return;
-        }
-
-        affectRadius(radius, true);
-
-        kill();
+        doFlair = true;
+        noProjectile = true;
+        effectRadius = 5;
+        affectsMultiple = true;
     }
 }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/SCARABAEUS_FIBULUM.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/SCARABAEUS_FIBULUM.java
@@ -1,6 +1,5 @@
 package net.pottercraft.ollivanders2.spell;
 
-import net.pottercraft.ollivanders2.O2MagicBranch;
 import net.pottercraft.ollivanders2.Ollivanders2;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
@@ -10,15 +9,40 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 
 /**
- * Beetle to button for minecraft we are using endermites to button
+ * Permanently transfigures an endermite into a polished blackstone button.
+ * <p>
+ * Scarabaeus Fibulum is the Minecraft adaptation of "Beetle into Button," a Hogwarts Transfiguration
+ * exercise. Vanilla Minecraft has no beetles, so the spell targets endermites, and buttons are
+ * represented as {@link Material#POLISHED_BLACKSTONE_BUTTON polished blackstone buttons}.
+ * </p>
+ * <p>
+ * Like {@link LEPUS_SACCULUM} and {@link RANACULUS_AMPHORAM}, Scarabaeus Fibulum has a
+ * {@link #minSuccessRate 25% minimum success rate} regardless of caster skill, reflecting the
+ * spell's relative ease in canon. The transfiguration is permanent: the original endermite is
+ * consumed and replaced with the button.
+ * </p>
  *
  * @author Azami7
- * @see <a href = "https://harrypotter.fandom.com/wiki/Beetle_into_Button">https://harrypotter.fandom.com/wiki/Beetle_into_Button</a>
- * @since 2.21
+ * @see <a href="https://harrypotter.fandom.com/wiki/Beetle_into_Button">Harry Potter Wiki - Beetle into Button</a>
  */
 public class SCARABAEUS_FIBULUM extends LivingEntityToItemTransfiguration {
     /**
+     * Minimum per-tick success rate (as a percentage) for this spell, regardless of caster skill.
+     * <p>
+     * Scarabaeus Fibulum is intentionally easy to cast: even a caster with zero experience has at
+     * least a 25% chance per tick to successfully transfigure the targeted endermite. Used in
+     * {@link #doInitSpell()} as the floor when {@code usesModifier} is at or below this value.
+     * </p>
+     */
+    public static int minSuccessRate = 25;
+
+    /**
      * Default constructor for use in generating spell text. Do not use to cast the spell.
+     * <p>
+     * Populates {@link #flavorText} with the canon "Beetle into Button" excerpt and sets the
+     * descriptive {@link #text}. Does not initialize the {@link #transfigurationMap} or any
+     * cast-time state — the casting constructor handles that.
+     * </p>
      *
      * @param plugin the Ollivanders2 plugin
      */
@@ -26,7 +50,6 @@ public class SCARABAEUS_FIBULUM extends LivingEntityToItemTransfiguration {
         super(plugin);
 
         spellType = O2SpellType.SCARABAEUS_FIBULUM;
-        branch = O2MagicBranch.TRANSFIGURATION;
 
         flavorText = new ArrayList<>() {{
             add("\"He was supposed to be turning a beetle into a button, but all he managed to do was give his beetle a lot of exercise as it scuttled over the desk top avoiding his wand.\"");
@@ -36,7 +59,12 @@ public class SCARABAEUS_FIBULUM extends LivingEntityToItemTransfiguration {
     }
 
     /**
-     * Constructor.
+     * Constructor for casting Scarabaeus Fibulum.
+     * <p>
+     * Configures the endermite→polished blackstone button entry in the {@link #transfigurationMap},
+     * sets the projectile {@link #radius} and success message, then invokes {@link #initSpell()}
+     * which triggers {@link #doInitSpell()} to compute the success rate based on caster skill.
+     * </p>
      *
      * @param plugin    a callback to the MC plugin
      * @param player    the player who cast this spell
@@ -46,7 +74,6 @@ public class SCARABAEUS_FIBULUM extends LivingEntityToItemTransfiguration {
         super(plugin, player, rightWand);
 
         spellType = O2SpellType.SCARABAEUS_FIBULUM;
-        branch = O2MagicBranch.TRANSFIGURATION;
 
         transfigurationMap.put(EntityType.ENDERMITE, Material.POLISHED_BLACKSTONE_BUTTON);
         radius = 1.5;
@@ -56,13 +83,18 @@ public class SCARABAEUS_FIBULUM extends LivingEntityToItemTransfiguration {
     }
 
     /**
-     * Determine success rate based on caster's skill
+     * Calculate the per-tick success rate from the caster's skill, with a {@link #minSuccessRate} floor.
+     * <p>
+     * If {@code usesModifier} is at or below {@link #minSuccessRate}, the success rate is clamped
+     * to that floor; otherwise it equals {@code usesModifier} directly. Higher skill therefore
+     * produces a proportionally higher per-tick chance to transfigure the endermite while the spell
+     * projectile is active.
+     * </p>
      */
     @Override
     void doInitSpell() {
-        // chance is no less than 25%
-        if (usesModifier <= 25)
-            successRate = 25;
+        if (usesModifier <= minSuccessRate)
+            successRate = minSuccessRate;
         else
             successRate = (int) (usesModifier);
     }

--- a/Ollivanders/src/net/pottercraft/ollivanders2/spell/STUPEFY.java
+++ b/Ollivanders/src/net/pottercraft/ollivanders2/spell/STUPEFY.java
@@ -65,8 +65,8 @@ public final class STUPEFY extends AddPotionEffect {
         minDurationInSeconds = minDurationInSecondsConfig;
         maxDurationInSeconds = maxDurationInSecondsConfig;
 
-        effectTypes.add(PotionEffectType.BLINDNESS);
-        effectTypes.add(PotionEffectType.SLOWNESS);
+        potionEffectTypes.add(PotionEffectType.BLINDNESS);
+        potionEffectTypes.add(PotionEffectType.SLOWNESS);
 
         initSpell();
     }

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/AddPotionEffectTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/AddPotionEffectTest.java
@@ -42,7 +42,7 @@ abstract class AddPotionEffectTest extends O2SpellTestSuper {
         player.setLocation(targetLocation);
 
         AddPotionEffect addPotionEffect = (AddPotionEffect) castSpell(caster, location, targetLocation);
-        List<PotionEffectType> effectTypes = addPotionEffect.getEffectTypes();
+        List<PotionEffectType> effectTypes = addPotionEffect.getPotionEffectTypes();
         assertFalse(effectTypes.isEmpty(), "effect types list empty");
 
         mockServer.getScheduler().performTicks(20);
@@ -77,7 +77,7 @@ abstract class AddPotionEffectTest extends O2SpellTestSuper {
             mockServer.getScheduler().performTicks(2);
             assertTrue(addPotionEffect.isKilled());
 
-            for (PotionEffectType potionEffectType : addPotionEffect.getEffectTypes()) {
+            for (PotionEffectType potionEffectType : addPotionEffect.getPotionEffectTypes()) {
                 if (addPotionEffect.targetsSelf())
                     assertTrue(caster.hasPotionEffect(potionEffectType), "caster does not have effect");
                 assertFalse(player.hasPotionEffect(potionEffectType), "player outside radius has effect");
@@ -197,7 +197,7 @@ abstract class AddPotionEffectTest extends O2SpellTestSuper {
 
             mockServer.getScheduler().performTicks(5);
 
-            for (PotionEffectType potionEffectType : addPotionEffect.getEffectTypes()) {
+            for (PotionEffectType potionEffectType : addPotionEffect.getPotionEffectTypes()) {
                 if (addPotionEffect.targetsSelf()) {
                     assertTrue(caster.hasPotionEffect(potionEffectType), "caster does not have effect");
                     assertFalse(player.hasPotionEffect(potionEffectType), "player has effect when caster already targeted");

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/EntityTransfigurationTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/EntityTransfigurationTest.java
@@ -153,17 +153,18 @@ abstract public class EntityTransfigurationTest extends O2SpellTestSuper {
         TestCommon.createBlockBase(new Location(targetLocation.getWorld(), targetLocation.getX(), targetLocation.getY() - 1, targetLocation.getZ()), 5); // create a base that is just past the target so that we know the projectile will eventually stop
         spawnEntityAtLocation(targetLocation, getValidEntityType(), getValidMaterialType());
 
+        effectSuccessRateTestZeroExp(caster, location, targetLocation);
+
+        EntityTransfiguration entityTransfiguration = (EntityTransfiguration) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel * 2);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(entityTransfiguration.isTransfigured(), "transfiguration failed when skill is mastery and success rate < 100%");
+    }
+
+    void effectSuccessRateTestZeroExp(PlayerMock caster, Location location, Location targetLocation) {
         EntityTransfiguration entityTransfiguration = (EntityTransfiguration) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, 0);
-
-        if (entityTransfiguration.getSuccessRate() < 100) {
-            mockServer.getScheduler().performTicks(20);
-            assertFalse(entityTransfiguration.isTransfigured(), "transfiguration succeeded when skill is 0 and success rate < 100%");
-
-            entityTransfiguration.kill();
-            entityTransfiguration = (EntityTransfiguration) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel * 2);
-            mockServer.getScheduler().performTicks(20);
-            assertTrue(entityTransfiguration.isTransfigured(), "transfiguration failed when skill is mastery and success rate < 100%");
-        }
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(entityTransfiguration.isTransfigured(), "transfiguration succeeded when skill is 0 and success rate < 100%");
+        entityTransfiguration.kill();
     }
 
     /**
@@ -181,12 +182,10 @@ abstract public class EntityTransfigurationTest extends O2SpellTestSuper {
         Entity entity = spawnEntityAtLocation(targetLocation, getValidEntityType(), getValidMaterialType());
 
         // 0 experience fails success check
-        EntityTransfiguration entityTransfiguration = (EntityTransfiguration) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, 0);
-        assertFalse(entityTransfiguration.canTransfigure(entity), "canTransfigure() returned true for 0 experience");
-        entityTransfiguration.kill();
+        canTransfigureTestZeroExp(caster, location, targetLocation, entity);
 
         // mastery level experience passes success check
-        entityTransfiguration = (EntityTransfiguration) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel * 2);
+        EntityTransfiguration entityTransfiguration = (EntityTransfiguration) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel * 2);
         assertTrue(entityTransfiguration.canTransfigure(entity), "canTransfigure() returned false for double mastery level experience");
 
         // invalid entity cannot be targeted
@@ -202,6 +201,13 @@ abstract public class EntityTransfigurationTest extends O2SpellTestSuper {
             assertFalse(entityTransfiguration.canTransfigure(sameEntity), "canTransfigure() returned true for same entity type");
             sameEntity.remove();
         }
+    }
+
+    void canTransfigureTestZeroExp(PlayerMock caster, Location location, Location targetLocation, Entity target) {
+        // 0 experience fails success check
+        EntityTransfiguration entityTransfiguration = (EntityTransfiguration) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, 0);
+        assertFalse(entityTransfiguration.canTransfigure(target), "canTransfigure() returned true for 0 experience");
+        entityTransfiguration.kill();
     }
 
     /**

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/LepusSacculumTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/LepusSacculumTest.java
@@ -1,0 +1,143 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.common.EntityCommon;
+import net.pottercraft.ollivanders2.player.O2PlayerCommon;
+import net.pottercraft.ollivanders2.spell.LAPIFORS;
+import net.pottercraft.ollivanders2.spell.LEPUS_SACCULUM;
+import net.pottercraft.ollivanders2.spell.O2Spell;
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Item;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test suite for the {@link LEPUS_SACCULUM} spell.
+ * <p>
+ * Verifies LEPUS_SACCULUM's behavior as a permanent rabbit-to-bundle transfiguration. Inherits the
+ * shared transfiguration tests from {@link LivingEntityToItemTransfigurationTest} and overrides
+ * the cases that do not fit LEPUS_SACCULUM's specific design — most notably the
+ * {@link LEPUS_SACCULUM#minSuccessRate 25% minimum success rate} at zero skill, which makes the
+ * parent's deterministic-failure assertions inapplicable.
+ * </p>
+ *
+ * @author Azami7
+ */
+public class LepusSacculumTest extends LivingEntityToItemTransfigurationTest {
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@link O2SpellType#LEPUS_SACCULUM}
+     */
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.LEPUS_SACCULUM;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@link EntityType#RABBIT}, the only entity type LEPUS_SACCULUM transfigures
+     */
+    @NotNull
+    @Override
+    EntityType getValidEntityType() {
+        return EntityType.RABBIT;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@link EntityType#CAT}, an arbitrary entity not in LEPUS_SACCULUM's transfiguration map
+     */
+    @Nullable
+    @Override
+    EntityType getInvalidEntityType() {
+        return EntityType.CAT;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return null because LEPUS_SACCULUM transfigures rabbits into items, so no valid target entity
+     * type is also the spell's output type
+     */
+    @Nullable
+    @Override
+    EntityType getSameEntityType() {
+        return null;
+    }
+
+    /**
+     * Test that LEPUS_SACCULUM cannot target a rabbit that is already under an active transfiguration.
+     * <p>
+     * Because LEPUS_SACCULUM is permanent, the parent's approach of casting the same spell twice on
+     * the same target won't work — the first cast removes the original rabbit. Instead, this test
+     * uses {@link LAPIFORS} (a non-permanent cat-to-rabbit transfiguration) to produce a transfigured
+     * rabbit, then verifies LEPUS_SACCULUM refuses to target it.
+     * </p>
+     */
+    @Override
+    @Test
+    void canTransfigureAlreadyTransfiguredTest() {
+        World testWorld = mockServer.addSimpleWorld(getSpellType().getSpellName());
+        Location location = getNextLocation(testWorld);
+        Location targetLocation = new Location(testWorld, location.getX() + 10, location.getY(), location.getZ());
+        PlayerMock caster = mockServer.addPlayer();
+
+        TestCommon.createBlockBase(new Location(targetLocation.getWorld(), targetLocation.getX(), targetLocation.getY() - 1, targetLocation.getZ()), 5); // create a base that is just past the target so that we know the projectile will eventually stop
+        Item item = testWorld.dropItem(targetLocation, new ItemStack(Material.IRON_HELMET));
+        assertNotNull(item);
+
+        LAPIFORS lapifors = (LAPIFORS) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel, O2SpellType.LAPIFORS);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(lapifors.isTransfigured());
+
+        Entity rabbit = EntityCommon.getLivingEntityAtLocation(targetLocation);
+        assertNotNull(rabbit);
+        LEPUS_SACCULUM lepusSacculum = (LEPUS_SACCULUM) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel * 2);
+        mockServer.getScheduler().performTicks(20);
+        assertFalse(lepusSacculum.isTransfigured(), "transfigured rabbit was targeted by lepus sacculum");
+    }
+
+    /**
+     * Verify the success rate floor at zero experience.
+     * <p>
+     * LEPUS_SACCULUM enforces a {@link LEPUS_SACCULUM#minSuccessRate 25% minimum} regardless of
+     * caster skill. The parent implementation asserts the spell deterministically fails to transfigure
+     * at zero experience, which is not true for LEPUS_SACCULUM (it succeeds ~25% of the time per tick).
+     * Instead, this override asserts the success rate equals the configured minimum.
+     * </p>
+     */
+    @Override
+    void effectSuccessRateTestZeroExp(PlayerMock caster, Location location, Location targetLocation) {
+        LEPUS_SACCULUM lepusSacculum = (LEPUS_SACCULUM) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, 0);
+        assertEquals(LEPUS_SACCULUM.minSuccessRate, lepusSacculum.getSuccessRate(), "success rate not set to minSuccessRate when experience is 0");
+        lepusSacculum.kill();
+    }
+
+    /**
+     * No-op override because LEPUS_SACCULUM cannot deterministically fail
+     * {@link net.pottercraft.ollivanders2.spell.EntityTransfiguration#canTransfigure(Entity)} at zero
+     * experience: the {@link LEPUS_SACCULUM#minSuccessRate 25% floor} means there is always a non-zero
+     * chance the success-rate check passes.
+     */
+    @Override
+    void canTransfigureTestZeroExp(PlayerMock caster, Location location, Location targetLocation, Entity target) {
+        // lepus sacculum always has at least a 25% chance
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/LivingEntityToItemTransfigurationTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/LivingEntityToItemTransfigurationTest.java
@@ -1,0 +1,39 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.common.EntityCommon;
+import net.pottercraft.ollivanders2.player.O2PlayerCommon;
+import net.pottercraft.ollivanders2.spell.LivingEntityToItemTransfiguration;
+import net.pottercraft.ollivanders2.spell.O2Spell;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+abstract public class LivingEntityToItemTransfigurationTest extends EntityTransfigurationTest {
+    @Override
+    @Test
+    void transfigureTest() {
+        World testWorld = mockServer.addSimpleWorld(getSpellType().getSpellName());
+        Location location = getNextLocation(testWorld);
+        Location targetLocation = new Location(testWorld, location.getX() + 10, location.getY(), location.getZ());
+        PlayerMock caster = mockServer.addPlayer();
+
+        TestCommon.createBlockBase(new Location(targetLocation.getWorld(), targetLocation.getX(), targetLocation.getY() - 1, targetLocation.getZ()), 5);
+
+        testWorld.spawnEntity(targetLocation, getValidEntityType());
+        LivingEntityToItemTransfiguration livingEntityToItemTransfiguration = (LivingEntityToItemTransfiguration) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel);
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(livingEntityToItemTransfiguration.isTransfigured(), "failed to hit target");
+        Item item = EntityCommon.getItemAtLocation(targetLocation);
+        assertNotNull(item, "no item found at target location");
+        assertTrue(livingEntityToItemTransfiguration.isTransfigured(item), "transfigured item not found");
+        assertEquals(livingEntityToItemTransfiguration.getTargetMaterial(), item.getItemStack().getType(), "item not expected type");
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/NoxTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/NoxTest.java
@@ -1,0 +1,58 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.player.O2PlayerCommon;
+import net.pottercraft.ollivanders2.spell.LUMOS;
+import net.pottercraft.ollivanders2.spell.NOX;
+import net.pottercraft.ollivanders2.spell.O2Spell;
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the {@link NOX} spell (Wand-Extinguishing Charm).
+ *
+ * <p>Verifies NOX-specific behavior including Night Vision removal and effect radius
+ * clamping to {@link LUMOS} bounds.</p>
+ */
+public class NoxTest extends RemovePotionEffectTest {
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.NOX;
+    }
+
+    @Override
+    PotionEffectType getValidEffectType() {
+        return PotionEffectType.NIGHT_VISION;
+    }
+
+    /**
+     * Test that NOX effect radius is clamped to LUMOS radius bounds.
+     *
+     * <p>Verifies the radius stays within [{@link LUMOS#minEffectRadiusConfig},
+     * {@link LUMOS#maxEffectRadiusConfig}] at low, mid, and mastery experience levels.</p>
+     */
+    @Test
+    void effectRadiusTest() {
+        World testWorld = mockServer.addSimpleWorld(getSpellType().getSpellName());
+        Location location = getNextLocation(testWorld);
+        Location targetLocation = new Location(testWorld, location.getX() + 10, location.getY(), location.getZ());
+        PlayerMock caster = mockServer.addPlayer();
+
+        NOX nox = (NOX) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, 0);
+        assertTrue(nox.getEffectRadius() >= LUMOS.minEffectRadiusConfig, "nox radius < min radius");
+
+        nox = (NOX) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, 50);
+        assertEquals(5, nox.getEffectRadius(), "unexpected radius");
+
+        nox = (NOX) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel * 4);
+        assertTrue(nox.getEffectRadius() <= LUMOS.maxEffectRadiusConfig, "nox radius > max radius");
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/RanaculusAmphoramTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/RanaculusAmphoramTest.java
@@ -1,0 +1,112 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.player.O2PlayerCommon;
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import net.pottercraft.ollivanders2.spell.RANACULUS_AMPHORAM;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test suite for the {@link RANACULUS_AMPHORAM} spell.
+ * <p>
+ * Verifies RANACULUS_AMPHORAM's behavior as a permanent tadpole-to-decorated-pot transfiguration.
+ * Inherits the shared transfiguration tests from {@link LivingEntityToItemTransfigurationTest} and
+ * overrides the cases that do not fit RANACULUS_AMPHORAM's specific design — most notably the
+ * {@link RANACULUS_AMPHORAM#minSuccessRate 25% minimum success rate} at zero skill, which makes the
+ * parent's deterministic-failure assertions inapplicable.
+ * </p>
+ *
+ * @author Azami7
+ */
+public class RanaculusAmphoramTest extends LivingEntityToItemTransfigurationTest {
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@link O2SpellType#RANACULUS_AMPHORAM}
+     */
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.RANACULUS_AMPHORAM;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@link EntityType#TADPOLE}, the only entity type RANACULUS_AMPHORAM transfigures
+     */
+    @NotNull
+    @Override
+    EntityType getValidEntityType() {
+        return EntityType.TADPOLE;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@link EntityType#CAT}, an arbitrary entity not in RANACULUS_AMPHORAM's transfiguration map
+     */
+    @Nullable
+    @Override
+    EntityType getInvalidEntityType() {
+        return EntityType.CAT;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return null because RANACULUS_AMPHORAM transfigures tadpoles into items, so no valid target
+     * entity type is also the spell's output type
+     */
+    @Nullable
+    @Override
+    EntityType getSameEntityType() {
+        return null;
+    }
+
+    /**
+     * No-op override because no transfiguration spell produces an {@link EntityType#TADPOLE}, so
+     * there is no way to stage an "already transfigured" tadpole target. The trick used in
+     * {@code LepusSacculumTest} (cast LAPIFORS to produce a transfigured rabbit before re-targeting)
+     * has no analogue here.
+     */
+    @Override
+    @Test
+    void canTransfigureAlreadyTransfiguredTest() {
+        // not currently testable since no transfiguration results in an EntityType.TADPOLE
+    }
+
+    /**
+     * Verify the success rate floor at zero experience.
+     * <p>
+     * RANACULUS_AMPHORAM enforces a {@link RANACULUS_AMPHORAM#minSuccessRate 25% minimum} regardless of
+     * caster skill. The parent implementation asserts the spell deterministically fails to transfigure
+     * at zero experience, which is not true for RANACULUS_AMPHORAM (it succeeds ~25% of the time per tick).
+     * Instead, this override asserts the success rate equals the configured minimum.
+     * </p>
+     */
+    @Override
+    void effectSuccessRateTestZeroExp(PlayerMock caster, Location location, Location targetLocation) {
+        RANACULUS_AMPHORAM ranaculusAmphoram = (RANACULUS_AMPHORAM) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, 0);
+        assertEquals(RANACULUS_AMPHORAM.minSuccessRate, ranaculusAmphoram.getSuccessRate(), "success rate not set to minSuccessRate when experience is 0");
+        ranaculusAmphoram.kill();
+    }
+
+    /**
+     * No-op override because RANACULUS_AMPHORAM cannot deterministically fail
+     * {@link net.pottercraft.ollivanders2.spell.EntityTransfiguration#canTransfigure(Entity)} at zero
+     * experience: the {@link RANACULUS_AMPHORAM#minSuccessRate 25% floor} means there is always a
+     * non-zero chance the success-rate check passes.
+     */
+    @Override
+    void canTransfigureTestZeroExp(PlayerMock caster, Location location, Location targetLocation, Entity target) {
+        // ranaculus amphoram always has at least a 25% chance
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/RemovePotionEffectTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/RemovePotionEffectTest.java
@@ -1,0 +1,123 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.player.O2PlayerCommon;
+import net.pottercraft.ollivanders2.spell.O2Spell;
+import net.pottercraft.ollivanders2.spell.RemovePotionEffect;
+import net.pottercraft.ollivanders2.test.testcommon.TestCommon;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.BlockFace;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Base test class for spells that remove potion effects from targets.
+ *
+ * <p>Tests the core functionality of potion effect removal spells, including self-targeting,
+ * non-self-targeting projectile behavior, and multi-target radius behavior. Subclasses provide
+ * the spell type and the potion effect type to verify.</p>
+ */
+abstract public class RemovePotionEffectTest extends O2SpellTestSuper {
+    /**
+     * Get the potion effect type that the spell under test removes.
+     *
+     * @return the potion effect type to verify removal of
+     */
+    abstract PotionEffectType getValidEffectType();
+
+    /**
+     * Test that the spell correctly removes potion effects from targets.
+     *
+     * <p>Verifies three behaviors based on spell configuration:</p>
+     *
+     * <ul>
+     * <li>Self-targeting: if targetsSelf, caster's effect is removed and spell must be noProjectile</li>
+     * <li>Non-self-targeting: effect is removed from a target entity but not from the caster</li>
+     * <li>Multi-target: if affectsMultiple, effects are removed from all entities within the
+     *     effect radius but not from entities outside it</li>
+     * </ul>
+     */
+    @Override
+    @Test
+    void doCheckEffectTest() {
+        World testWorld = mockServer.addSimpleWorld(getSpellType().getSpellName());
+        Location location = getNextLocation(testWorld);
+        Location targetLocation = new Location(testWorld, location.getX() + 10, location.getY(), location.getZ());
+        PlayerMock caster = mockServer.addPlayer();
+
+        TestCommon.createBlockBase(new Location(targetLocation.getWorld(), targetLocation.getX(), targetLocation.getY() - 1, targetLocation.getZ()), 5);
+
+        caster.addPotionEffect(new PotionEffect(getValidEffectType(), 1000, 1));
+        assertTrue(caster.hasPotionEffect(getValidEffectType()));
+
+        RemovePotionEffect removePotionEffect = (RemovePotionEffect) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel);
+        // make sure the effect is targetsSelf it is also noProjectile
+        if (removePotionEffect.doesTargetSelf())
+            assertTrue(removePotionEffect.isNoProjectile(), "spell is targets self but also does a projectile, this is an invalid combination");
+        mockServer.getScheduler().performTicks(20);
+        assertTrue(removePotionEffect.isKilled(), "spell not killed");
+        if (removePotionEffect.doesTargetSelf())
+            assertFalse(caster.hasPotionEffect(getValidEffectType()), getValidEffectType().toString() + " not removed from caster when spell targets self");
+        else
+            assertTrue(caster.hasPotionEffect(getValidEffectType()), getValidEffectType().toString() + " removed from caster when spell does not target self");
+
+        if (!removePotionEffect.doesTargetSelf()) {
+            PlayerMock target = mockServer.addPlayer();
+            target.setLocation(targetLocation);
+            target.addPotionEffect(new PotionEffect(getValidEffectType(), 1000, 1));
+            assertTrue(target.hasPotionEffect(getValidEffectType()));
+
+            mockServer.getScheduler().performTicks(20);
+            assertTrue(removePotionEffect.isKilled(), "spell not killed when target hit");
+            assertFalse(target.hasPotionEffect(getValidEffectType()), getValidEffectType().toString() + " not removed from target");
+        }
+
+        if (removePotionEffect.doesAffectMultiple()) {
+            removePotionEffect = (RemovePotionEffect) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, O2Spell.spellMasteryLevel);
+
+            PlayerMock player1 = mockServer.addPlayer();
+            PlayerMock player2 = mockServer.addPlayer();
+            PlayerMock player3 = mockServer.addPlayer();
+
+            Location baseLocation;
+            if (removePotionEffect.isNoProjectile())
+                baseLocation = location;
+            else
+                baseLocation = targetLocation;
+
+            player1.setLocation(baseLocation.getBlock().getRelative(BlockFace.EAST).getLocation());
+            player2.setLocation(baseLocation.getBlock().getRelative(BlockFace.WEST).getLocation());
+            // set player 3 outside the effect radius
+            player3.setLocation(new Location(testWorld, baseLocation.getX() + removePotionEffect.getEffectRadius() + 3, baseLocation.getY(), baseLocation.getZ()));
+
+            player1.addPotionEffect(new PotionEffect(getValidEffectType(), 1000, 1));
+            assertTrue(player1.hasPotionEffect(getValidEffectType()));
+            player2.addPotionEffect(new PotionEffect(getValidEffectType(), 1000, 1));
+            assertTrue(player2.hasPotionEffect(getValidEffectType()));
+            player3.addPotionEffect(new PotionEffect(getValidEffectType(), 1000, 1));
+            assertTrue(player3.hasPotionEffect(getValidEffectType()));
+
+            mockServer.getScheduler().performTicks(20);
+            assertTrue(removePotionEffect.isKilled());
+            assertFalse(player1.hasPotionEffect(getValidEffectType()), getValidEffectType().toString() + " not removed from player1");
+            assertFalse(player2.hasPotionEffect(getValidEffectType()), getValidEffectType().toString() + " not removed from player2");
+            assertTrue(player3.hasPotionEffect(getValidEffectType()), getValidEffectType().toString() + " removed from player3");
+        }
+    }
+
+    /**
+     * Revert test (empty for potion effect removal spells).
+     *
+     * <p>Potion effect removal spells do not have revert actions.</p>
+     */
+    @Override
+    @Test
+    void revertTest() {
+        // no revert actions
+    }
+}

--- a/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/ScarabaeusFibulumTest.java
+++ b/Ollivanders/test/java/net/pottercraft/ollivanders2/test/spell/ScarabaeusFibulumTest.java
@@ -1,0 +1,113 @@
+package net.pottercraft.ollivanders2.test.spell;
+
+import net.pottercraft.ollivanders2.player.O2PlayerCommon;
+import net.pottercraft.ollivanders2.spell.O2SpellType;
+import net.pottercraft.ollivanders2.spell.SCARABAEUS_FIBULUM;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test suite for the {@link SCARABAEUS_FIBULUM} spell.
+ * <p>
+ * Verifies SCARABAEUS_FIBULUM's behavior as a permanent endermite-to-polished-blackstone-button
+ * transfiguration. Inherits the shared transfiguration tests from
+ * {@link LivingEntityToItemTransfigurationTest} and overrides the cases that do not fit
+ * SCARABAEUS_FIBULUM's specific design — most notably the
+ * {@link SCARABAEUS_FIBULUM#minSuccessRate 25% minimum success rate} at zero skill, which makes
+ * the parent's deterministic-failure assertions inapplicable.
+ * </p>
+ *
+ * @author Azami7
+ */
+public class ScarabaeusFibulumTest extends LivingEntityToItemTransfigurationTest {
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@link O2SpellType#SCARABAEUS_FIBULUM}
+     */
+    @Override
+    @NotNull
+    O2SpellType getSpellType() {
+        return O2SpellType.SCARABAEUS_FIBULUM;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@link EntityType#ENDERMITE}, the only entity type SCARABAEUS_FIBULUM transfigures
+     */
+    @NotNull
+    @Override
+    EntityType getValidEntityType() {
+        return EntityType.ENDERMITE;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return {@link EntityType#CAT}, an arbitrary entity not in SCARABAEUS_FIBULUM's transfiguration map
+     */
+    @Nullable
+    @Override
+    EntityType getInvalidEntityType() {
+        return EntityType.CAT;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return null because SCARABAEUS_FIBULUM transfigures endermites into items, so no valid target
+     * entity type is also the spell's output type
+     */
+    @Nullable
+    @Override
+    EntityType getSameEntityType() {
+        return null;
+    }
+
+    /**
+     * No-op override because no transfiguration spell produces an {@link EntityType#ENDERMITE}, so
+     * there is no way to stage an "already transfigured" endermite target. The trick used in
+     * {@code LepusSacculumTest} (cast LAPIFORS to produce a transfigured rabbit before re-targeting)
+     * has no analogue here.
+     */
+    @Override
+    @Test
+    void canTransfigureAlreadyTransfiguredTest() {
+        // not currently testable since no transfiguration results in an EntityType.ENDERMITE
+    }
+
+    /**
+     * Verify the success rate floor at zero experience.
+     * <p>
+     * SCARABAEUS_FIBULUM enforces a {@link SCARABAEUS_FIBULUM#minSuccessRate 25% minimum} regardless of
+     * caster skill. The parent implementation asserts the spell deterministically fails to transfigure
+     * at zero experience, which is not true for SCARABAEUS_FIBULUM (it succeeds ~25% of the time per tick).
+     * Instead, this override asserts the success rate equals the configured minimum.
+     * </p>
+     */
+    @Override
+    void effectSuccessRateTestZeroExp(PlayerMock caster, Location location, Location targetLocation) {
+        SCARABAEUS_FIBULUM scarabaeusFibulum = (SCARABAEUS_FIBULUM) castSpell(caster, location, targetLocation, O2PlayerCommon.rightWand, 0);
+        assertEquals(SCARABAEUS_FIBULUM.minSuccessRate, scarabaeusFibulum.getSuccessRate(), "success rate not set to minSuccessRate when experience is 0");
+        scarabaeusFibulum.kill();
+    }
+
+    /**
+     * No-op override because SCARABAEUS_FIBULUM cannot deterministically fail
+     * {@link net.pottercraft.ollivanders2.spell.EntityTransfiguration#canTransfigure(Entity)} at zero
+     * experience: the {@link SCARABAEUS_FIBULUM#minSuccessRate 25% floor} means there is always a
+     * non-zero chance the success-rate check passes.
+     */
+    @Override
+    void canTransfigureTestZeroExp(PlayerMock caster, Location location, Location targetLocation, Entity target) {
+        // SCARABAEUS_FIBULUM always has at least a 25% chance
+    }
+}


### PR DESCRIPTION
* added tests for LivingEntityToItemTransfiguration spells
* fixed bug in LivingEntityToItemTransfiguration where it was using World.spawnEntity instead of World.dropItem to spawn an item, this simplified several lines as well
* renamed effectTypes to potionEffectTypes in AddPotionEffect
* renamed radius to effectRadius in RemovePotionEffectInRadius
* added tests for RemovePotionEffect spells
* totally refactored doCheckEffect for RemovePotionEffect, this also allowed me to remove checkEffect() from RemovePotionEffectInRadius
* added a test code writer claude skill